### PR TITLE
01/04 — Add controllog library

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Each experiment lives in its own directory under [`projects/`](./projects/). Bro
 | [`agentic-sql-mini`](./projects/agentic-sql-mini/) | Minimal A/B harness for the catalog-context-for-agents experiment — can descriptive column names alone replace prose docs as an agent's information source? |
 | [`bird-bench`](./projects/bird-bench/) | Text-to-SQL evaluation framework using the BIRD Mini-Dev benchmark with MotherDuck as the execution backend. |
 | [`connections-eval-mini`](./projects/connections-eval-mini/) | Evaluate AI models on NYT Connections puzzles. Built for the Seattle Startup Summit evals workshop. |
+| [`controllog`](./projects/controllog/) | Controllable logging library for AI/agentic systems — events + balanced postings, JSONL transport, optional MotherDuck upload. Shared dep of `bird-bench` and `connections-eval-mini`. |
 | [`metadata_generator`](./projects/metadata_generator/) | Generate rich metadata for MotherDuck databases — profile statistics, LLM-generated descriptions, and SQL `COMMENT` statements. Used as a dep by `bird-bench`. |
 <!-- END PROJECT LIST -->
 

--- a/projects/controllog/README.md
+++ b/projects/controllog/README.md
@@ -55,10 +55,7 @@ controllog.model_completion(
 )
 ```
 
-Writes append-only JSONL to `logs/controllog/{events,postings}.jsonl` (the
-default flat layout). Pass `partition_by_date=True` to `init()` for
-`logs/controllog/YYYY-MM-DD/{events,postings}.jsonl` instead. The uploader
-handles both layouts.
+Writes append-only JSONL to `logs/controllog/{events,postings}.jsonl` (spec § 3.2).
 
 ## Upload to MotherDuck
 
@@ -77,7 +74,7 @@ Creates `controllog.events` and `controllog.postings` tables and appends new row
 
 ```python
 # Core
-controllog.init(project_id, log_dir, default_dims=None, partition_by_date=False)
+controllog.init(project_id, log_dir, default_dims=None)
 controllog.event(*, kind, actor=None, run_id=None, payload=None, postings=None, ...)
 controllog.post(account_type, account_id, unit, delta, dims=None)
 controllog.new_id()              # UUIDv7

--- a/projects/controllog/README.md
+++ b/projects/controllog/README.md
@@ -88,7 +88,6 @@ exchange_id = controllog.model_prompt(...)          # returns exchange_id
 controllog.model_completion(exchange_id=..., ...)   # pass the paired id
 controllog.state_move(task_id, from_, to, ...)
 controllog.utility(task_id, project_id, metric, value, ...)
-controllog.agent_run(task_id, agent_id, run_id=None)  # contextmanager
 
 # Optional, requires controllog[duckdb]
 from controllog import motherduck

--- a/projects/controllog/README.md
+++ b/projects/controllog/README.md
@@ -27,9 +27,9 @@ import controllog
 
 controllog.init(project_id="my-eval", log_dir=Path("logs"))
 
-exchange_id = controllog.new_id()
-
-controllog.model_prompt(
+# model_prompt returns the exchange_id; pass it to the paired completion.
+# Spec § 5/§ 8.3 require both events to share one exchange_id.
+exchange_id = controllog.model_prompt(
     task_id="q42",
     agent_id="solver",
     run_id="run-2026-05-26",
@@ -38,10 +38,10 @@ controllog.model_prompt(
     model="gpt-5",
     prompt_tokens=812,
     request_text="What is the capital of France?",
-    exchange_id=exchange_id,
 )
 
 controllog.model_completion(
+    exchange_id=exchange_id,
     task_id="q42",
     agent_id="solver",
     run_id="run-2026-05-26",
@@ -52,11 +52,13 @@ controllog.model_completion(
     wall_ms=1380,
     response_text="Paris.",
     cost_money=0.0024,
-    exchange_id=exchange_id,
 )
 ```
 
-Writes append-only JSONL to `logs/controllog/YYYY-MM-DD/{events,postings}.jsonl`.
+Writes append-only JSONL to `logs/controllog/{events,postings}.jsonl` (the
+default flat layout). Pass `partition_by_date=True` to `init()` for
+`logs/controllog/YYYY-MM-DD/{events,postings}.jsonl` instead. The uploader
+handles both layouts.
 
 ## Upload to MotherDuck
 
@@ -75,15 +77,15 @@ Creates `controllog.events` and `controllog.postings` tables and appends new row
 
 ```python
 # Core
-controllog.init(project_id, log_dir, default_dims=None)
+controllog.init(project_id, log_dir, default_dims=None, partition_by_date=False)
 controllog.event(*, kind, actor=None, run_id=None, payload=None, postings=None, ...)
 controllog.post(account_type, account_id, unit, delta, dims=None)
-controllog.new_id()  # UUIDv7
+controllog.new_id()              # UUIDv7
+controllog.is_initialized()
 
 # Generic builders (preferred over raw event/post)
-controllog.model_prompt(...)
-controllog.model_completion(...)
-controllog.model_response(...)       # single-event variant
+exchange_id = controllog.model_prompt(...)          # returns exchange_id
+controllog.model_completion(exchange_id=..., ...)   # pass the paired id
 controllog.state_move(task_id, from_, to, ...)
 controllog.utility(task_id, project_id, metric, value, ...)
 controllog.agent_run(task_id, agent_id, run_id=None)  # contextmanager

--- a/projects/controllog/README.md
+++ b/projects/controllog/README.md
@@ -1,0 +1,106 @@
+# controllog
+
+Controllable logging for AI/agentic systems. A drop-in replacement for `logger.info(...)` built on two primitives:
+
+- **Events** — immutable facts ("what happened")
+- **Postings** — balanced deltas applied to accounts ("what changed")
+
+The core invariant is conservation: postings must net to zero across defined surfaces (time, money, state, utility). This gives you a deterministic audit trail in fundamentally non-deterministic systems.
+
+The full design is in [`docs/spec-v1.1.md`](./docs/spec-v1.1.md).
+
+## Install
+
+```bash
+# Core (zero deps)
+pip install "controllog @ git+https://github.com/motherduckdb/labs#subdirectory=projects/controllog"
+
+# With MotherDuck upload support
+pip install "controllog[duckdb] @ git+https://github.com/motherduckdb/labs#subdirectory=projects/controllog"
+```
+
+## Quick start
+
+```python
+from pathlib import Path
+import controllog
+
+controllog.init(project_id="my-eval", log_dir=Path("logs"))
+
+exchange_id = controllog.new_id()
+
+controllog.model_prompt(
+    task_id="q42",
+    agent_id="solver",
+    run_id="run-2026-05-26",
+    project_id="my-eval",
+    provider="openai",
+    model="gpt-5",
+    prompt_tokens=812,
+    request_text="What is the capital of France?",
+    exchange_id=exchange_id,
+)
+
+controllog.model_completion(
+    task_id="q42",
+    agent_id="solver",
+    run_id="run-2026-05-26",
+    project_id="my-eval",
+    provider="openai",
+    model="gpt-5",
+    completion_tokens=4,
+    wall_ms=1380,
+    response_text="Paris.",
+    cost_money=0.0024,
+    exchange_id=exchange_id,
+)
+```
+
+Writes append-only JSONL to `logs/controllog/YYYY-MM-DD/{events,postings}.jsonl`.
+
+## Upload to MotherDuck
+
+```python
+from controllog import motherduck
+
+motherduck.upload(
+    motherduck_db="my_eval",
+    log_dir=Path("logs"),
+)
+```
+
+Creates `controllog.events` and `controllog.postings` tables and appends new rows (idempotent by `event_id` / `posting_id`).
+
+## Public API
+
+```python
+# Core
+controllog.init(project_id, log_dir, default_dims=None)
+controllog.event(*, kind, actor=None, run_id=None, payload=None, postings=None, ...)
+controllog.post(account_type, account_id, unit, delta, dims=None)
+controllog.new_id()  # UUIDv7
+
+# Generic builders (preferred over raw event/post)
+controllog.model_prompt(...)
+controllog.model_completion(...)
+controllog.model_response(...)       # single-event variant
+controllog.state_move(task_id, from_, to, ...)
+controllog.utility(task_id, project_id, metric, value, ...)
+controllog.agent_run(task_id, agent_id, run_id=None)  # contextmanager
+
+# Optional, requires controllog[duckdb]
+from controllog import motherduck
+motherduck.upload(...)
+motherduck.cleanup_local(...)
+motherduck.verify(...)
+```
+
+## Why not just use a logger?
+
+Standard loggers observe. Controllog enforces. Because postings must balance per event and across slices, you can detect missing, duplicated, or inconsistent work without after-the-fact reconciliation — useful when the work is being done by a non-deterministic model.
+
+See the [spec](./docs/spec-v1.1.md) for the full motivation.
+
+## Status
+
+Alpha. The on-disk JSONL schema and MotherDuck tables follow v1.1 of the spec and are considered stable. Builder signatures may evolve.

--- a/projects/controllog/README.md
+++ b/projects/controllog/README.md
@@ -33,7 +33,6 @@ exchange_id = controllog.model_prompt(
     task_id="q42",
     agent_id="solver",
     run_id="run-2026-05-26",
-    project_id="my-eval",
     provider="openai",
     model="gpt-5",
     prompt_tokens=812,
@@ -45,7 +44,6 @@ controllog.model_completion(
     task_id="q42",
     agent_id="solver",
     run_id="run-2026-05-26",
-    project_id="my-eval",
     provider="openai",
     model="gpt-5",
     completion_tokens=4,
@@ -80,11 +78,12 @@ controllog.post(account_type, account_id, unit, delta, dims=None)
 controllog.new_id()              # UUIDv7
 controllog.is_initialized()
 
-# Generic builders (preferred over raw event/post)
-exchange_id = controllog.model_prompt(...)          # returns exchange_id
-controllog.model_completion(exchange_id=..., ...)   # pass the paired id
-controllog.state_move(task_id, from_, to, ...)
-controllog.utility(task_id, project_id, metric, value, ...)
+# Generic builders (preferred over raw event/post) — all keyword-only.
+# project_id is taken from init(); not a per-call argument.
+exchange_id = controllog.model_prompt(*, task_id, agent_id, provider, model, prompt_tokens, ...)
+controllog.model_completion(*, exchange_id, task_id, agent_id, provider, model, completion_tokens, wall_ms, ...)
+controllog.state_move(*, task_id, from_, to, ...)
+controllog.utility(*, task_id, metric, value, ...)
 
 # Optional, requires controllog[duckdb]
 from controllog import motherduck

--- a/projects/controllog/docs/spec-v1.1.md
+++ b/projects/controllog/docs/spec-v1.1.md
@@ -358,7 +358,7 @@ The learn command emits three event kinds tracking the knowledge extraction life
 | `learn_complete` | End of a learn run | total_questions, total_fragments, total_comments, total_schema_comments, guide_updates, view_candidates, errors, total_cost_usd, duration_ms |
 
 Postings:
-- `learn_question`: optional `resource.money` (vendor:openrouter <-> project) when cost_usd is present
+- `learn_question`: optional `truth.money` (vendor:openrouter <-> project) when cost_usd is present
 - `learn_start` / `learn_complete`: no postings (lifecycle markers)
 
 Idempotency keys:
@@ -377,7 +377,7 @@ The maintain command emits three event kinds tracking the maintenance pipeline l
 | `maintain_complete` | End of a maintain run | plan_summary, applied, errors, llm_calls, estimated_cost_usd, transaction_id, duration_ms |
 
 Postings:
-- `maintain_complete`: optional `resource.money` (vendor:openrouter <-> project) when estimated_cost_usd > 0
+- `maintain_complete`: optional `truth.money` (vendor:openrouter <-> project) when estimated_cost_usd > 0
 - `maintain_start` / `maintain_action`: no postings (lifecycle markers)
 
 Idempotency keys:

--- a/projects/controllog/docs/spec-v1.1.md
+++ b/projects/controllog/docs/spec-v1.1.md
@@ -71,7 +71,7 @@ Logical fields:
 - posting_id
 - event_id (FK)
 - account_type (e.g. truth.money)
-- account_id (e.g. project, provider, task:<id>)
+- account_id, namespaced by role (e.g. `project:<project_id>`, `provider:<name>`, `vendor:<name>`, `agent:<agent_id>`, `task:<task_id>`)
 - unit (e.g. usd, ms, task_status)
 - delta_numeric (signed)
 - dims_json (dimensions)
@@ -260,8 +260,8 @@ Example:
 
 ```sql
 cost = -SUM(delta_numeric)
-WHERE account_type='truth.money'
-AND account_id='project'
+WHERE account_type = 'truth.money'
+  AND account_id LIKE 'project:%'
 ```
 
 ### 9.2 Ops Latency

--- a/projects/controllog/docs/spec-v1.1.md
+++ b/projects/controllog/docs/spec-v1.1.md
@@ -1,0 +1,380 @@
+# Controllog v1.1
+## Telemetry Is Not Enough for Non-Deterministic Systems
+
+A drop-in replacement for traditional logging in AI / agentic systems, based on
+accounting and cybernetic control primitives.
+
+This spec reflects real-world implementation learnings from
+`based-eval/shared/controllog` and is intended to be reused across projects.
+
+---
+
+## 0. What This Is
+
+Controllog is a controllable logging system built around two primitives:
+
+- Events: immutable facts ("what happened")
+- Postings: balanced deltas applied to accounts ("what changed")
+
+The core invariant is conservation: postings must net to zero across defined
+surfaces (time, money, state, utility). This enables deterministic auditability
+in fundamentally non-deterministic systems.
+
+---
+
+## 1. Goals / Non-Goals
+
+### Goals
+- Drop-in replacement for `logger.info(...)`
+- Deterministic audit trail for AI agents
+- Early detection of missing, duplicated, or inconsistent work
+- Cheap to operate (append-only JSONL → MotherDuck)
+
+### Non-Goals
+- Not a tracing/APM system
+- Not metrics-first (metrics are derived)
+- Not a scheduler, router, or evaluator
+
+---
+
+## 2. Core Primitives
+
+### 2.1 Event
+
+An event is an immutable fact.
+
+Required fields (logical schema):
+- event_id (unique)
+- event_time (UTC)
+- kind (string enum)
+- project_id
+- source (e.g. runtime)
+- idempotency_key
+- payload_json (freeform)
+
+Optional but recommended:
+- run_id
+- actor_agent_id
+- actor_task_id
+
+Events are written to:
+
+controllog.events
+
+---
+
+### 2.2 Posting
+
+A posting applies a signed delta to an account.
+
+Logical fields:
+- posting_id
+- event_id (FK)
+- account_type (e.g. truth.money)
+- account_id (e.g. project, provider, task:<id>)
+- unit (e.g. usd, ms, task_status)
+- delta_numeric (signed)
+- dims_json (dimensions)
+
+Postings are written to:
+
+controllog.postings
+
+---
+
+## 3. Transport: JSONL (Append-Only)
+
+### 3.1 Initialization
+
+```python
+controllog.init(
+  project_id: str,
+  log_dir: Path,
+  default_dims: dict | None
+)
+```
+
+* Writes JSONL locally
+* Uploads asynchronously (optional)
+* Raw payloads preserved by default
+
+### 3.2 File Layout
+
+```
+<log_dir>/
+  controllog/
+    events.jsonl
+    postings.jsonl
+```
+
+Each line is one JSON object.
+
+---
+
+## 4. API Surface
+
+### 4.1 Core Emit
+
+```python
+controllog.event(
+  kind: str,
+  actor: dict | None,
+  run_id: str | None,
+  payload: dict | None,
+  postings: list[dict],
+  idempotency_key: str,
+  source: str = "runtime"
+)
+```
+
+Rules:
+
+* Events with postings must balance
+* idempotency_key is required for retriable work
+
+---
+
+## 5. Model Calls: Two-Phase Pattern (Required)
+
+### 5.1 Phases
+
+Every model call is represented as two events:
+
+1. model_prompt
+2. model_completion
+
+Both share a common exchange_id.
+
+Each has its own idempotency key:
+
+* `<exchange_id>:prompt`
+* `<exchange_id>:completion`
+
+### 5.2 Why This Matters
+
+* Prompt is logged even if completion fails
+* Clean reconciliation with provider data
+* Phase-specific latency and cost attribution
+
+---
+
+## 6. Task Lifecycle: truth.state
+
+Required lifecycle per task:
+
+1. NEW → WIP (exactly once)
+2. One terminal transition:
+
+   * WIP → DONE
+   * WIP → FAILED
+
+Rules:
+
+* Terminal transitions are unique
+* Retries do not leave WIP
+* State transitions must be balanced postings
+
+---
+
+## 7. Accounts (Minimum Set)
+
+### 7.1 truth.money
+
+Tracks cost.
+
+Convention:
+
+* \* provider
+* \* project
+
+### 7.2 truth.time
+
+Tracks latency/time.
+
+* Completion events carry agent-side wall time
+
+### 7.3 truth.state
+
+Tracks lifecycle transitions (conserved)
+
+### 7.4 truth.utility (optional)
+
+Tracks reward/score
+
+---
+
+## 8. Invariants
+
+### 8.1 Double-Entry (Per Event)
+
+For each (account_type, unit):
+
+SUM(delta_numeric) == 0
+
+### 8.2 Trial Balance (Any Slice)
+
+For any filtered slice of data:
+
+SUM(delta_numeric) == 0
+
+### 8.3 Exchange Completeness
+
+For each exchange_id:
+
+* exactly one prompt
+* exactly one completion (even on failure)
+
+---
+
+## 9. Reporting (Derived)
+
+### 9.1 Why Flows Sum to Zero
+
+Because postings conserve value.
+
+Rule:
+Compute flows from one side only (e.g. project).
+
+Example:
+
+```sql
+cost = -SUM(delta_numeric)
+WHERE account_type='truth.money'
+AND account_id='project'
+```
+
+### 9.2 Ops Latency
+
+* Use completion events only
+* Use agent-side time postings
+* Ignore prompt/queue phases
+
+---
+
+## 10. MotherDuck Integration
+
+### 10.1 Schema
+
+Use a dedicated schema:
+
+controllog.events
+controllog.postings
+
+Avoid search_path ambiguity.
+
+### 10.2 Column Stability
+
+Do not rename core columns.
+Extend via new columns only.
+
+---
+
+## 11. Idempotency & Correlation
+
+Two identifiers:
+
+* exchange_id: groups logical work
+* idempotency_key: dedupes emission
+
+Recommended default:
+
+exchange_id = UUIDv7
+idempotency_key = f"{exchange_id}:{phase}"
+
+Deterministic keys may hash stable inputs if needed.
+
+---
+
+## 12. Privacy Mode
+
+Optional fields for strict environments:
+
+* request_hash
+* response_hash
+
+Allows lineage without raw text.
+
+---
+
+## 13. Backpressure Rule
+
+When saturated:
+
+* Must persist postings
+* May drop payload_json
+
+Never lie about postings.
+
+---
+
+## 14. Recommended Dims Baseline
+
+Whitelist:
+
+* model
+* provider
+* phase (prompt, completion)
+* optional domain dims (e.g. agent_role)
+
+Dims should be:
+
+* small
+* enumerable
+* safe to group by
+
+---
+
+## 15. Learn & Maintain Events
+
+### 15.1 Learn Events
+
+The learn command emits three event kinds tracking the knowledge extraction lifecycle:
+
+| Kind | When | Key Payload Fields |
+|------|------|--------------------|
+| `learn_start` | Beginning of a learn run | benchmark, database, model, total_questions, mode, max_concurrent |
+| `learn_question` | After each question is processed | question_id, surface_routed, fragments_written, comments_written, schema_comments_written, guide_updated, view_candidates_logged, duration_ms, cost_usd, error |
+| `learn_complete` | End of a learn run | total_questions, total_fragments, total_comments, total_schema_comments, guide_updates, view_candidates, errors, total_cost_usd, duration_ms |
+
+Postings:
+- `learn_question`: optional `resource.money` (vendor:openrouter <-> project) when cost_usd is present
+- `learn_start` / `learn_complete`: no postings (lifecycle markers)
+
+Idempotency keys:
+- `learn_start`: `{run_id}:learn_start`
+- `learn_question`: `{run_id}:learn_question:{question_id}`
+- `learn_complete`: `{run_id}:learn_complete`
+
+### 15.2 Maintain Events
+
+The maintain command emits three event kinds tracking the maintenance pipeline lifecycle:
+
+| Kind | When | Key Payload Fields |
+|------|------|--------------------|
+| `maintain_start` | Beginning of a maintain run | benchmark, database, model, operations, dry_run |
+| `maintain_action` | After each plan action executes | operation, action_type, fragment_id, success, error |
+| `maintain_complete` | End of a maintain run | plan_summary, applied, errors, llm_calls, estimated_cost_usd, transaction_id, duration_ms |
+
+Postings:
+- `maintain_complete`: optional `resource.money` (vendor:openrouter <-> project) when estimated_cost_usd > 0
+- `maintain_start` / `maintain_action`: no postings (lifecycle markers)
+
+Idempotency keys:
+- `maintain_start`: `{run_id}:maintain_start`
+- `maintain_action`: auto-generated event_id (actions are not retriable)
+- `maintain_complete`: `{run_id}:maintain_complete`
+
+---
+
+## 16. Summary
+
+Controllog replaces passive telemetry with active control:
+
+* Events give memory
+* Postings enforce invariants
+* Trial balance detects drift
+* Reports become trustworthy
+* Non-determinism becomes manageable
+
+Telemetry observes.
+Controllog controls.

--- a/projects/controllog/docs/spec-v1.1.md
+++ b/projects/controllog/docs/spec-v1.1.md
@@ -201,6 +201,27 @@ Tracks lifecycle transitions (conserved)
 
 Tracks reward/score
 
+### 7.5 Extension namespaces
+
+Implementations MAY add account types outside the `truth.*` namespace. The
+convention is:
+
+* `truth.*` — accounts whose unit is comparable across models, runs, and
+  vendors (USD, wall-clock ms, lifecycle state, normalized utility).
+  Always meaningful to sum, average, or compare cross-run.
+* `resource.*` — accounts whose unit is system-specific and **not**
+  comparable across implementations. Tokens are the canonical example:
+  1000 GPT tokens ≠ 1000 Claude tokens ≠ 1000 Gemini tokens because
+  tokenizers differ.
+
+Extension accounts MUST still balance per event (§ 8.1) and across slices
+(§ 8.2). The invariant checker treats `truth.*` and `resource.*` identically;
+the distinction is semantic, not enforcement.
+
+Reference implementation uses `resource.tokens` (unit `+tokens`) to track
+prompt and completion token flow between `provider:{name}` and
+`project:{id}`.
+
 ---
 
 ## 8. Invariants

--- a/projects/controllog/pyproject.toml
+++ b/projects/controllog/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = []
 
 [project.optional-dependencies]
 duckdb = ["duckdb>=1.0.0"]
+dev = ["pytest>=7.0", "duckdb>=1.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/motherduckdb/labs/tree/main/projects/controllog"

--- a/projects/controllog/pyproject.toml
+++ b/projects/controllog/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "controllog"
+version = "0.1.0"
+description = "Controllable logging for AI/agentic systems — events + balanced postings, JSONL transport, optional MotherDuck upload."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "MotherDuck Labs" },
+]
+keywords = ["logging", "observability", "agents", "evals", "double-entry", "motherduck", "duckdb"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+]
+dependencies = []
+
+[project.optional-dependencies]
+duckdb = ["duckdb>=1.0.0"]
+
+[project.urls]
+Homepage = "https://github.com/motherduckdb/labs/tree/main/projects/controllog"
+Spec = "https://github.com/motherduckdb/labs/blob/main/projects/controllog/docs/spec-v1.1.md"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/controllog"]

--- a/projects/controllog/src/controllog/__init__.py
+++ b/projects/controllog/src/controllog/__init__.py
@@ -6,7 +6,6 @@ See docs/spec-v1.1.md for the full design.
 
 from .sdk import event, init, is_initialized, new_id, post
 from .builders import (
-    agent_run,
     model_completion,
     model_prompt,
     state_move,
@@ -19,7 +18,6 @@ __all__ = [
     "event",
     "post",
     "new_id",
-    "agent_run",
     "model_prompt",
     "model_completion",
     "state_move",

--- a/projects/controllog/src/controllog/__init__.py
+++ b/projects/controllog/src/controllog/__init__.py
@@ -23,5 +23,3 @@ __all__ = [
     "state_move",
     "utility",
 ]
-
-__version__ = "0.1.0"

--- a/projects/controllog/src/controllog/__init__.py
+++ b/projects/controllog/src/controllog/__init__.py
@@ -1,0 +1,31 @@
+"""controllog — controllable logging for AI/agentic systems.
+
+Events + balanced postings, JSONL transport, optional MotherDuck upload.
+See docs/spec-v1.1.md for the full design.
+"""
+
+from .sdk import event, init, is_initialized, new_id, post
+from .builders import (
+    agent_run,
+    model_completion,
+    model_prompt,
+    model_response,
+    state_move,
+    utility,
+)
+
+__all__ = [
+    "init",
+    "is_initialized",
+    "event",
+    "post",
+    "new_id",
+    "agent_run",
+    "model_prompt",
+    "model_completion",
+    "model_response",
+    "state_move",
+    "utility",
+]
+
+__version__ = "0.1.0"

--- a/projects/controllog/src/controllog/__init__.py
+++ b/projects/controllog/src/controllog/__init__.py
@@ -9,7 +9,6 @@ from .builders import (
     agent_run,
     model_completion,
     model_prompt,
-    model_response,
     state_move,
     utility,
 )
@@ -23,7 +22,6 @@ __all__ = [
     "agent_run",
     "model_prompt",
     "model_completion",
-    "model_response",
     "state_move",
     "utility",
 ]

--- a/projects/controllog/src/controllog/builders.py
+++ b/projects/controllog/src/controllog/builders.py
@@ -1,0 +1,260 @@
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, Optional
+
+from .sdk import event, post, new_id
+
+
+@contextmanager
+def agent_run(*, task_id: str, agent_id: str, run_id: Optional[str] = None) -> Iterator[Dict[str, Any]]:
+    """Context manager capturing a logical agent run.
+
+    Yields a dict with run metadata and helper methods bound via closures.
+    """
+    run_info = {"task_id": task_id, "agent_id": agent_id, "run_id": run_id}
+    try:
+        yield run_info
+    finally:
+        # Nothing to clean up for JSONL transport
+        ...
+
+
+def model_response(
+    *,
+    task_id: str,
+    agent_id: str,
+    run_id: Optional[str],
+    project_id: Optional[str],
+    provider: str,
+    model: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    wall_ms: int,
+    reward: Optional[float] = None,
+    cost_money: Optional[float] = None,
+    upstream_cost_money: Optional[float] = None,
+    payload: Optional[Dict[str, Any]] = None,
+    state_transition: Optional[Dict[str, str]] = None,
+    request_text: Optional[str] = None,
+    response_text: Optional[str] = None,
+) -> None:
+    """Emit a balanced model_response event with postings.
+
+    Accounts balanced per spec:
+      - resource.tokens: provider ↔ project (tokens unit)
+      - resource.time_ms: agent ↔ project (ms unit)
+      - truth.state: task WIP->DONE (tasks unit)
+      - value.utility: task ↔ project (points unit, optional)
+      - resource.money: vendor ↔ project (money unit, optional)
+    """
+    total_tokens = int(prompt_tokens or 0) + int(completion_tokens or 0)
+    postings = [
+        # tokens conservation
+        post("resource.tokens", f"provider:{provider}", "+tokens", -total_tokens, {"model": model}),
+        post("resource.tokens", f"project:{project_id}", "+tokens", +total_tokens, {"model": model}),
+        # time conservation
+        post("resource.time_ms", f"agent:{agent_id}", "ms", -int(wall_ms or 0), {"kind": "wall"}),
+        post("resource.time_ms", f"project:{project_id}", "ms", +int(wall_ms or 0), {"kind": "wall"}),
+    ]
+
+    if state_transition is not None:
+        frm = state_transition.get("from", "WIP")
+        to = state_transition.get("to", "DONE")
+        postings.extend(
+            [
+                post("truth.state", f"task:{task_id}", "tasks", -1, {"from": frm}),
+                post("truth.state", f"task:{task_id}", "tasks", +1, {"to": to}),
+            ]
+        )
+
+    if reward is not None:
+        postings.extend(
+            [
+                post("value.utility", f"task:{task_id}", "points", +float(reward), {"metric": "reward"}),
+                post("value.utility", f"project:{project_id}", "points", -float(reward), {"metric": "reward"}),
+            ]
+        )
+
+    if cost_money is not None:
+        postings.extend(
+            [
+                post("resource.money", f"vendor:openrouter", "$", -float(cost_money), {"model": model}),
+                post("resource.money", f"project:{project_id}", "$", +float(cost_money), {"model": model}),
+            ]
+        )
+
+    if upstream_cost_money is not None:
+        # optionally track upstream vendor as separate vendor
+        postings.extend(
+            [
+                post("resource.money", f"vendor:upstream", "$", -float(upstream_cost_money), {"model": model}),
+                post("resource.money", f"project:{project_id}", "$", +float(upstream_cost_money), {"model": model}),
+            ]
+        )
+
+    # Merge default payload with any extra payload
+    payload_base: Dict[str, Any] = {
+        "provider": provider,
+        "model": model,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "wall_ms": wall_ms,
+    }
+    if request_text is not None:
+        payload_base["request_text"] = request_text
+    if response_text is not None:
+        payload_base["response_text"] = response_text
+
+    event(
+        kind="model_response",
+        actor={"agent_id": agent_id, "task_id": task_id},
+        run_id=run_id,
+        payload={**payload_base, **(payload or {})},
+        postings=postings,
+        project_id=project_id,
+        source="runtime",
+    )
+
+
+def model_prompt(
+    *,
+    task_id: str,
+    agent_id: str,
+    run_id: Optional[str],
+    project_id: Optional[str],
+    provider: str,
+    model: str,
+    prompt_tokens: int,
+    request_text: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+    exchange_id: Optional[str] = None,
+) -> None:
+    """Emit a model_prompt event with balanced token postings.
+
+    Posts resource.tokens only; no time or money here.
+    """
+    postings = [
+        post("resource.tokens", f"provider:{provider}", "+tokens", -int(prompt_tokens or 0), {"model": model, "phase": "prompt"}),
+        post("resource.tokens", f"project:{project_id}", "+tokens", +int(prompt_tokens or 0), {"model": model, "phase": "prompt"}),
+    ]
+    payload_base: Dict[str, Any] = {
+        "provider": provider,
+        "model": model,
+        "prompt_tokens": prompt_tokens,
+        "phase": "prompt",
+    }
+    if request_text is not None:
+        payload_base["request_text"] = request_text
+
+    if exchange_id is None:
+        exchange_id = new_id()
+
+    event(
+        kind="model_prompt",
+        actor={"agent_id": agent_id, "task_id": task_id},
+        run_id=run_id,
+        payload={**payload_base, **(payload or {}), "exchange_id": exchange_id},
+        postings=postings,
+        project_id=project_id,
+        source="runtime",
+        idempotency_key=f"{exchange_id}:prompt",
+    )
+
+
+def model_completion(
+    *,
+    task_id: str,
+    agent_id: str,
+    run_id: Optional[str],
+    project_id: Optional[str],
+    provider: str,
+    model: str,
+    completion_tokens: int,
+    wall_ms: int,
+    response_text: Optional[str] = None,
+    cost_money: Optional[float] = None,
+    upstream_cost_money: Optional[float] = None,
+    payload: Optional[Dict[str, Any]] = None,
+    exchange_id: Optional[str] = None,
+) -> None:
+    """Emit a model_completion event with completion tokens, time, and optional money.
+
+    Balanced postings for resource.tokens and resource.time_ms; money optional.
+    """
+    postings = [
+        post("resource.tokens", f"provider:{provider}", "+tokens", -int(completion_tokens or 0), {"model": model, "phase": "completion"}),
+        post("resource.tokens", f"project:{project_id}", "+tokens", +int(completion_tokens or 0), {"model": model, "phase": "completion"}),
+        post("resource.time_ms", f"agent:{agent_id}", "ms", -int(wall_ms or 0), {"kind": "wall"}),
+        post("resource.time_ms", f"project:{project_id}", "ms", +int(wall_ms or 0), {"kind": "wall"}),
+    ]
+    if cost_money is not None:
+        postings.extend(
+            [
+                post("resource.money", f"vendor:openrouter", "$", -float(cost_money), {"model": model}),
+                post("resource.money", f"project:{project_id}", "$", +float(cost_money), {"model": model}),
+            ]
+        )
+    if upstream_cost_money is not None:
+        postings.extend(
+            [
+                post("resource.money", f"vendor:upstream", "$", -float(upstream_cost_money), {"model": model}),
+                post("resource.money", f"project:{project_id}", "$", +float(upstream_cost_money), {"model": model}),
+            ]
+        )
+
+    payload_base: Dict[str, Any] = {
+        "provider": provider,
+        "model": model,
+        "completion_tokens": completion_tokens,
+        "wall_ms": wall_ms,
+        "phase": "completion",
+    }
+    if response_text is not None:
+        payload_base["response_text"] = response_text
+
+    if exchange_id is None:
+        exchange_id = new_id()
+
+    event(
+        kind="model_completion",
+        actor={"agent_id": agent_id, "task_id": task_id},
+        run_id=run_id,
+        payload={**payload_base, **(payload or {}), "exchange_id": exchange_id},
+        postings=postings,
+        project_id=project_id,
+        source="runtime",
+        idempotency_key=f"{exchange_id}:completion",
+    )
+
+
+def state_move(*, task_id: str, from_: str, to: str, project_id: Optional[str], agent_id: Optional[str] = None, run_id: Optional[str] = None, payload: Optional[Dict[str, Any]] = None) -> None:
+    postings = [
+        post("truth.state", f"task:{task_id}", "tasks", -1, {"from": from_}),
+        post("truth.state", f"task:{task_id}", "tasks", +1, {"to": to}),
+    ]
+    event(
+        kind="state_move",
+        actor={"agent_id": agent_id, "task_id": task_id} if agent_id else {"task_id": task_id},
+        run_id=run_id,
+        payload=payload or {"reason": None},
+        postings=postings,
+        project_id=project_id,
+        source="runtime",
+    )
+
+
+def utility(*, task_id: str, project_id: str, metric: str, value: float, agent_id: Optional[str] = None, run_id: Optional[str] = None, payload: Optional[Dict[str, Any]] = None) -> None:
+    postings = [
+        post("value.utility", f"task:{task_id}", "points", +float(value), {"metric": metric}),
+        post("value.utility", f"project:{project_id}", "points", -float(value), {"metric": metric}),
+    ]
+    event(
+        kind="utility",
+        actor={"agent_id": agent_id, "task_id": task_id} if agent_id else {"task_id": task_id},
+        run_id=run_id,
+        payload=payload or {"metric": metric, "value": value},
+        postings=postings,
+        project_id=project_id,
+        source="runtime",
+    )
+
+

--- a/projects/controllog/src/controllog/builders.py
+++ b/projects/controllog/src/controllog/builders.py
@@ -1,3 +1,13 @@
+"""Generic balanced-posting builders.
+
+Account names follow ``docs/spec-v1.1.md`` § 7:
+
+  - ``resource.tokens``  (extension, provider ↔ project, unit ``+tokens``)
+  - ``truth.money``      (vendor ↔ project, unit ``$``)
+  - ``truth.time``       (agent ↔ project, unit ``ms``)
+  - ``truth.state``      (task lifecycle, unit ``tasks``)
+  - ``truth.utility``    (task ↔ project, unit ``points``)
+"""
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Optional
 
@@ -6,113 +16,12 @@ from .sdk import event, post, new_id
 
 @contextmanager
 def agent_run(*, task_id: str, agent_id: str, run_id: Optional[str] = None) -> Iterator[Dict[str, Any]]:
-    """Context manager capturing a logical agent run.
-
-    Yields a dict with run metadata and helper methods bound via closures.
-    """
+    """Context manager capturing a logical agent run."""
     run_info = {"task_id": task_id, "agent_id": agent_id, "run_id": run_id}
     try:
         yield run_info
     finally:
-        # Nothing to clean up for JSONL transport
         ...
-
-
-def model_response(
-    *,
-    task_id: str,
-    agent_id: str,
-    run_id: Optional[str],
-    project_id: Optional[str],
-    provider: str,
-    model: str,
-    prompt_tokens: int,
-    completion_tokens: int,
-    wall_ms: int,
-    reward: Optional[float] = None,
-    cost_money: Optional[float] = None,
-    upstream_cost_money: Optional[float] = None,
-    payload: Optional[Dict[str, Any]] = None,
-    state_transition: Optional[Dict[str, str]] = None,
-    request_text: Optional[str] = None,
-    response_text: Optional[str] = None,
-) -> None:
-    """Emit a balanced model_response event with postings.
-
-    Accounts balanced per spec:
-      - resource.tokens: provider ↔ project (tokens unit)
-      - resource.time_ms: agent ↔ project (ms unit)
-      - truth.state: task WIP->DONE (tasks unit)
-      - value.utility: task ↔ project (points unit, optional)
-      - resource.money: vendor ↔ project (money unit, optional)
-    """
-    total_tokens = int(prompt_tokens or 0) + int(completion_tokens or 0)
-    postings = [
-        # tokens conservation
-        post("resource.tokens", f"provider:{provider}", "+tokens", -total_tokens, {"model": model}),
-        post("resource.tokens", f"project:{project_id}", "+tokens", +total_tokens, {"model": model}),
-        # time conservation
-        post("resource.time_ms", f"agent:{agent_id}", "ms", -int(wall_ms or 0), {"kind": "wall"}),
-        post("resource.time_ms", f"project:{project_id}", "ms", +int(wall_ms or 0), {"kind": "wall"}),
-    ]
-
-    if state_transition is not None:
-        frm = state_transition.get("from", "WIP")
-        to = state_transition.get("to", "DONE")
-        postings.extend(
-            [
-                post("truth.state", f"task:{task_id}", "tasks", -1, {"from": frm}),
-                post("truth.state", f"task:{task_id}", "tasks", +1, {"to": to}),
-            ]
-        )
-
-    if reward is not None:
-        postings.extend(
-            [
-                post("value.utility", f"task:{task_id}", "points", +float(reward), {"metric": "reward"}),
-                post("value.utility", f"project:{project_id}", "points", -float(reward), {"metric": "reward"}),
-            ]
-        )
-
-    if cost_money is not None:
-        postings.extend(
-            [
-                post("resource.money", f"vendor:openrouter", "$", -float(cost_money), {"model": model}),
-                post("resource.money", f"project:{project_id}", "$", +float(cost_money), {"model": model}),
-            ]
-        )
-
-    if upstream_cost_money is not None:
-        # optionally track upstream vendor as separate vendor
-        postings.extend(
-            [
-                post("resource.money", f"vendor:upstream", "$", -float(upstream_cost_money), {"model": model}),
-                post("resource.money", f"project:{project_id}", "$", +float(upstream_cost_money), {"model": model}),
-            ]
-        )
-
-    # Merge default payload with any extra payload
-    payload_base: Dict[str, Any] = {
-        "provider": provider,
-        "model": model,
-        "prompt_tokens": prompt_tokens,
-        "completion_tokens": completion_tokens,
-        "wall_ms": wall_ms,
-    }
-    if request_text is not None:
-        payload_base["request_text"] = request_text
-    if response_text is not None:
-        payload_base["response_text"] = response_text
-
-    event(
-        kind="model_response",
-        actor={"agent_id": agent_id, "task_id": task_id},
-        run_id=run_id,
-        payload={**payload_base, **(payload or {})},
-        postings=postings,
-        project_id=project_id,
-        source="runtime",
-    )
 
 
 def model_prompt(
@@ -124,14 +33,20 @@ def model_prompt(
     provider: str,
     model: str,
     prompt_tokens: int,
+    exchange_id: Optional[str] = None,
     request_text: Optional[str] = None,
     payload: Optional[Dict[str, Any]] = None,
-    exchange_id: Optional[str] = None,
-) -> None:
-    """Emit a model_prompt event with balanced token postings.
+) -> str:
+    """Emit a ``model_prompt`` event with balanced token postings.
 
-    Posts resource.tokens only; no time or money here.
+    Per spec § 5, every model call is two events sharing one ``exchange_id``.
+    If ``exchange_id`` is omitted, one is generated here and **returned** so
+    the caller can pass the same value to :func:`model_completion`. Pairing
+    the two is required for the spec's exchange-completeness invariant.
     """
+    if exchange_id is None:
+        exchange_id = new_id()
+
     postings = [
         post("resource.tokens", f"provider:{provider}", "+tokens", -int(prompt_tokens or 0), {"model": model, "phase": "prompt"}),
         post("resource.tokens", f"project:{project_id}", "+tokens", +int(prompt_tokens or 0), {"model": model, "phase": "prompt"}),
@@ -145,9 +60,6 @@ def model_prompt(
     if request_text is not None:
         payload_base["request_text"] = request_text
 
-    if exchange_id is None:
-        exchange_id = new_id()
-
     event(
         kind="model_prompt",
         actor={"agent_id": agent_id, "task_id": task_id},
@@ -158,10 +70,12 @@ def model_prompt(
         source="runtime",
         idempotency_key=f"{exchange_id}:prompt",
     )
+    return exchange_id
 
 
 def model_completion(
     *,
+    exchange_id: str,
     task_id: str,
     agent_id: str,
     run_id: Optional[str],
@@ -174,30 +88,30 @@ def model_completion(
     cost_money: Optional[float] = None,
     upstream_cost_money: Optional[float] = None,
     payload: Optional[Dict[str, Any]] = None,
-    exchange_id: Optional[str] = None,
 ) -> None:
-    """Emit a model_completion event with completion tokens, time, and optional money.
+    """Emit a ``model_completion`` event sharing ``exchange_id`` with its prompt.
 
-    Balanced postings for resource.tokens and resource.time_ms; money optional.
+    ``exchange_id`` is required (per spec § 5.2 / § 8.3 — exchange
+    completeness). Pass the value returned by :func:`model_prompt`.
     """
     postings = [
         post("resource.tokens", f"provider:{provider}", "+tokens", -int(completion_tokens or 0), {"model": model, "phase": "completion"}),
         post("resource.tokens", f"project:{project_id}", "+tokens", +int(completion_tokens or 0), {"model": model, "phase": "completion"}),
-        post("resource.time_ms", f"agent:{agent_id}", "ms", -int(wall_ms or 0), {"kind": "wall"}),
-        post("resource.time_ms", f"project:{project_id}", "ms", +int(wall_ms or 0), {"kind": "wall"}),
+        post("truth.time", f"agent:{agent_id}", "ms", -int(wall_ms or 0), {"kind": "wall"}),
+        post("truth.time", f"project:{project_id}", "ms", +int(wall_ms or 0), {"kind": "wall"}),
     ]
     if cost_money is not None:
         postings.extend(
             [
-                post("resource.money", f"vendor:openrouter", "$", -float(cost_money), {"model": model}),
-                post("resource.money", f"project:{project_id}", "$", +float(cost_money), {"model": model}),
+                post("truth.money", f"vendor:openrouter", "$", -float(cost_money), {"model": model}),
+                post("truth.money", f"project:{project_id}", "$", +float(cost_money), {"model": model}),
             ]
         )
     if upstream_cost_money is not None:
         postings.extend(
             [
-                post("resource.money", f"vendor:upstream", "$", -float(upstream_cost_money), {"model": model}),
-                post("resource.money", f"project:{project_id}", "$", +float(upstream_cost_money), {"model": model}),
+                post("truth.money", f"vendor:upstream", "$", -float(upstream_cost_money), {"model": model}),
+                post("truth.money", f"project:{project_id}", "$", +float(upstream_cost_money), {"model": model}),
             ]
         )
 
@@ -211,9 +125,6 @@ def model_completion(
     if response_text is not None:
         payload_base["response_text"] = response_text
 
-    if exchange_id is None:
-        exchange_id = new_id()
-
     event(
         kind="model_completion",
         actor={"agent_id": agent_id, "task_id": task_id},
@@ -226,7 +137,17 @@ def model_completion(
     )
 
 
-def state_move(*, task_id: str, from_: str, to: str, project_id: Optional[str], agent_id: Optional[str] = None, run_id: Optional[str] = None, payload: Optional[Dict[str, Any]] = None) -> None:
+def state_move(
+    *,
+    task_id: str,
+    from_: str,
+    to: str,
+    project_id: Optional[str],
+    agent_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Emit a balanced ``truth.state`` transition for a task."""
     postings = [
         post("truth.state", f"task:{task_id}", "tasks", -1, {"from": from_}),
         post("truth.state", f"task:{task_id}", "tasks", +1, {"to": to}),
@@ -242,10 +163,20 @@ def state_move(*, task_id: str, from_: str, to: str, project_id: Optional[str], 
     )
 
 
-def utility(*, task_id: str, project_id: str, metric: str, value: float, agent_id: Optional[str] = None, run_id: Optional[str] = None, payload: Optional[Dict[str, Any]] = None) -> None:
+def utility(
+    *,
+    task_id: str,
+    project_id: str,
+    metric: str,
+    value: float,
+    agent_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Emit a balanced ``truth.utility`` posting."""
     postings = [
-        post("value.utility", f"task:{task_id}", "points", +float(value), {"metric": metric}),
-        post("value.utility", f"project:{project_id}", "points", -float(value), {"metric": metric}),
+        post("truth.utility", f"task:{task_id}", "points", +float(value), {"metric": metric}),
+        post("truth.utility", f"project:{project_id}", "points", -float(value), {"metric": metric}),
     ]
     event(
         kind="utility",
@@ -256,5 +187,3 @@ def utility(*, task_id: str, project_id: str, metric: str, value: float, agent_i
         project_id=project_id,
         source="runtime",
     )
-
-

--- a/projects/controllog/src/controllog/builders.py
+++ b/projects/controllog/src/controllog/builders.py
@@ -37,8 +37,8 @@ def model_prompt(
         exchange_id = new_id()
 
     postings = [
-        post("resource.tokens", f"provider:{provider}", "+tokens", -int(prompt_tokens or 0), {"model": model, "phase": "prompt"}),
-        post("resource.tokens", f"project:{project_id}", "+tokens", +int(prompt_tokens or 0), {"model": model, "phase": "prompt"}),
+        post("resource.tokens", f"provider:{provider}", "+tokens", -int(prompt_tokens), {"model": model, "phase": "prompt"}),
+        post("resource.tokens", f"project:{project_id}", "+tokens", +int(prompt_tokens), {"model": model, "phase": "prompt"}),
     ]
     payload_base: Dict[str, Any] = {
         "provider": provider,
@@ -75,7 +75,6 @@ def model_completion(
     run_id: Optional[str] = None,
     response_text: Optional[str] = None,
     cost_money: Optional[float] = None,
-    upstream_cost_money: Optional[float] = None,
     payload: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Emit a ``model_completion`` event sharing ``exchange_id`` with its prompt.
@@ -83,28 +82,21 @@ def model_completion(
     ``exchange_id`` is required (per spec § 5.2 / § 8.3 — exchange
     completeness). Pass the value returned by :func:`model_prompt`.
 
-    ``cost_money`` postings record ``vendor:{provider}``. For aggregator
-    setups where the direct vendor differs from the upstream provider,
-    pass ``upstream_cost_money`` separately — it lands on ``vendor:upstream``.
+    ``cost_money`` postings record ``vendor:{provider}``. Callers needing
+    aggregator-vs-upstream accounting can emit additional ``truth.money``
+    postings via raw :func:`event` / :func:`post`.
     """
     postings = [
-        post("resource.tokens", f"provider:{provider}", "+tokens", -int(completion_tokens or 0), {"model": model, "phase": "completion"}),
-        post("resource.tokens", f"project:{project_id}", "+tokens", +int(completion_tokens or 0), {"model": model, "phase": "completion"}),
-        post("truth.time", f"agent:{agent_id}", "ms", -int(wall_ms or 0), {"kind": "wall"}),
-        post("truth.time", f"project:{project_id}", "ms", +int(wall_ms or 0), {"kind": "wall"}),
+        post("resource.tokens", f"provider:{provider}", "+tokens", -int(completion_tokens), {"model": model, "phase": "completion"}),
+        post("resource.tokens", f"project:{project_id}", "+tokens", +int(completion_tokens), {"model": model, "phase": "completion"}),
+        post("truth.time", f"agent:{agent_id}", "ms", -int(wall_ms), {"kind": "wall"}),
+        post("truth.time", f"project:{project_id}", "ms", +int(wall_ms), {"kind": "wall"}),
     ]
     if cost_money is not None:
         postings.extend(
             [
                 post("truth.money", f"vendor:{provider}", "$", -float(cost_money), {"model": model}),
                 post("truth.money", f"project:{project_id}", "$", +float(cost_money), {"model": model}),
-            ]
-        )
-    if upstream_cost_money is not None:
-        postings.extend(
-            [
-                post("truth.money", f"vendor:upstream", "$", -float(upstream_cost_money), {"model": model}),
-                post("truth.money", f"project:{project_id}", "$", +float(upstream_cost_money), {"model": model}),
             ]
         )
 
@@ -178,7 +170,11 @@ def utility(
     run_id: Optional[str] = None,
     payload: Optional[Dict[str, Any]] = None,
 ) -> None:
-    """Emit a balanced ``truth.utility`` posting."""
+    """Emit a balanced ``truth.utility`` posting.
+
+    ``metric`` and ``value`` are already recorded on the postings' dims_json
+    and delta_numeric; the event payload only carries what the caller passes.
+    """
     postings = [
         post("truth.utility", f"task:{task_id}", "points", +float(value), {"metric": metric}),
         post("truth.utility", f"project:{project_id}", "points", -float(value), {"metric": metric}),
@@ -187,7 +183,7 @@ def utility(
         kind="utility",
         actor={"agent_id": agent_id, "task_id": task_id} if agent_id else {"task_id": task_id},
         run_id=run_id,
-        payload=payload or {"metric": metric, "value": value},
+        payload=payload,
         postings=postings,
         project_id=project_id,
         source="runtime",

--- a/projects/controllog/src/controllog/builders.py
+++ b/projects/controllog/src/controllog/builders.py
@@ -8,20 +8,9 @@ Account names follow ``docs/spec-v1.1.md`` § 7:
   - ``truth.state``      (task lifecycle, unit ``tasks``)
   - ``truth.utility``    (task ↔ project, unit ``points``)
 """
-from contextlib import contextmanager
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Optional
 
 from .sdk import event, post, new_id
-
-
-@contextmanager
-def agent_run(*, task_id: str, agent_id: str, run_id: Optional[str] = None) -> Iterator[Dict[str, Any]]:
-    """Context manager capturing a logical agent run."""
-    run_info = {"task_id": task_id, "agent_id": agent_id, "run_id": run_id}
-    try:
-        yield run_info
-    finally:
-        ...
 
 
 def model_prompt(

--- a/projects/controllog/src/controllog/builders.py
+++ b/projects/controllog/src/controllog/builders.py
@@ -17,11 +17,11 @@ def model_prompt(
     *,
     task_id: str,
     agent_id: str,
-    run_id: Optional[str],
-    project_id: Optional[str],
+    project_id: str,
     provider: str,
     model: str,
     prompt_tokens: int,
+    run_id: Optional[str] = None,
     exchange_id: Optional[str] = None,
     request_text: Optional[str] = None,
     payload: Optional[Dict[str, Any]] = None,
@@ -67,12 +67,12 @@ def model_completion(
     exchange_id: str,
     task_id: str,
     agent_id: str,
-    run_id: Optional[str],
-    project_id: Optional[str],
+    project_id: str,
     provider: str,
     model: str,
     completion_tokens: int,
     wall_ms: int,
+    run_id: Optional[str] = None,
     response_text: Optional[str] = None,
     cost_money: Optional[float] = None,
     upstream_cost_money: Optional[float] = None,
@@ -82,6 +82,10 @@ def model_completion(
 
     ``exchange_id`` is required (per spec § 5.2 / § 8.3 — exchange
     completeness). Pass the value returned by :func:`model_prompt`.
+
+    ``cost_money`` postings record ``vendor:{provider}``. For aggregator
+    setups where the direct vendor differs from the upstream provider,
+    pass ``upstream_cost_money`` separately — it lands on ``vendor:upstream``.
     """
     postings = [
         post("resource.tokens", f"provider:{provider}", "+tokens", -int(completion_tokens or 0), {"model": model, "phase": "completion"}),
@@ -92,7 +96,7 @@ def model_completion(
     if cost_money is not None:
         postings.extend(
             [
-                post("truth.money", f"vendor:openrouter", "$", -float(cost_money), {"model": model}),
+                post("truth.money", f"vendor:{provider}", "$", -float(cost_money), {"model": model}),
                 post("truth.money", f"project:{project_id}", "$", +float(cost_money), {"model": model}),
             ]
         )
@@ -131,7 +135,7 @@ def state_move(
     task_id: str,
     from_: str,
     to: str,
-    project_id: Optional[str],
+    project_id: str,
     agent_id: Optional[str] = None,
     run_id: Optional[str] = None,
     payload: Optional[Dict[str, Any]] = None,
@@ -156,7 +160,7 @@ def state_move(
         kind="state_move",
         actor={"agent_id": agent_id, "task_id": task_id} if agent_id else {"task_id": task_id},
         run_id=run_id,
-        payload=payload or {"reason": None},
+        payload=payload,
         postings=postings,
         project_id=project_id,
         source="runtime",

--- a/projects/controllog/src/controllog/builders.py
+++ b/projects/controllog/src/controllog/builders.py
@@ -146,8 +146,19 @@ def state_move(
     agent_id: Optional[str] = None,
     run_id: Optional[str] = None,
     payload: Optional[Dict[str, Any]] = None,
+    idempotency_key: Optional[str] = None,
 ) -> None:
-    """Emit a balanced ``truth.state`` transition for a task."""
+    """Emit a balanced ``truth.state`` transition for a task.
+
+    Per spec § 6, ``NEW → WIP`` happens exactly once and terminal transitions
+    are unique. Without a deterministic idempotency key, retries would emit
+    duplicate events with fresh ``event_id`` s — each duplicate is locally
+    balanced, so trial balance can't catch the drift.
+
+    Defaults to ``f"{task_id}:{from_}:{to}"``; pass an explicit
+    ``idempotency_key`` if you need a different correlation (e.g., when the
+    same transition is legitimately recorded by multiple actors).
+    """
     postings = [
         post("truth.state", f"task:{task_id}", "tasks", -1, {"from": from_}),
         post("truth.state", f"task:{task_id}", "tasks", +1, {"to": to}),
@@ -160,6 +171,7 @@ def state_move(
         postings=postings,
         project_id=project_id,
         source="runtime",
+        idempotency_key=idempotency_key or f"{task_id}:{from_}:{to}",
     )
 
 

--- a/projects/controllog/src/controllog/builders.py
+++ b/projects/controllog/src/controllog/builders.py
@@ -7,17 +7,19 @@ Account names follow ``docs/spec-v1.1.md`` § 7:
   - ``truth.time``       (agent ↔ project, unit ``ms``)
   - ``truth.state``      (task lifecycle, unit ``tasks``)
   - ``truth.utility``    (task ↔ project, unit ``points``)
+
+``project_id`` is resolved from ``init()``'s config — builders don't accept
+it per call. One configured project per SDK instance per spec § 3.1.
 """
 from typing import Any, Dict, Optional
 
-from .sdk import event, post, new_id
+from .sdk import _require_config, event, new_id, post
 
 
 def model_prompt(
     *,
     task_id: str,
     agent_id: str,
-    project_id: str,
     provider: str,
     model: str,
     prompt_tokens: int,
@@ -32,7 +34,13 @@ def model_prompt(
     If ``exchange_id`` is omitted, one is generated here and **returned** so
     the caller can pass the same value to :func:`model_completion`. Pairing
     the two is required for the spec's exchange-completeness invariant.
+
+    Caller-supplied ``payload`` keys are overridden by the canonical builder
+    fields (``provider``, ``model``, ``phase``, ``prompt_tokens``,
+    ``exchange_id``) — otherwise a stray ``payload={"phase": "completion"}``
+    could disagree with the postings.
     """
+    project_id = _require_config().project_id
     if exchange_id is None:
         exchange_id = new_id()
 
@@ -40,23 +48,23 @@ def model_prompt(
         post("resource.tokens", f"provider:{provider}", "+tokens", -int(prompt_tokens), {"model": model, "phase": "prompt"}),
         post("resource.tokens", f"project:{project_id}", "+tokens", +int(prompt_tokens), {"model": model, "phase": "prompt"}),
     ]
-    payload_base: Dict[str, Any] = {
+    canonical: Dict[str, Any] = {
         "provider": provider,
         "model": model,
         "prompt_tokens": prompt_tokens,
         "phase": "prompt",
+        "exchange_id": exchange_id,
     }
     if request_text is not None:
-        payload_base["request_text"] = request_text
+        canonical["request_text"] = request_text
 
     event(
         kind="model_prompt",
         actor={"agent_id": agent_id, "task_id": task_id},
         run_id=run_id,
-        payload={**payload_base, **(payload or {}), "exchange_id": exchange_id},
+        # Caller payload first, canonical fields override.
+        payload={**(payload or {}), **canonical},
         postings=postings,
-        project_id=project_id,
-        source="runtime",
         idempotency_key=f"{exchange_id}:prompt",
     )
     return exchange_id
@@ -67,7 +75,6 @@ def model_completion(
     exchange_id: str,
     task_id: str,
     agent_id: str,
-    project_id: str,
     provider: str,
     model: str,
     completion_tokens: int,
@@ -86,6 +93,7 @@ def model_completion(
     aggregator-vs-upstream accounting can emit additional ``truth.money``
     postings via raw :func:`event` / :func:`post`.
     """
+    project_id = _require_config().project_id
     postings = [
         post("resource.tokens", f"provider:{provider}", "+tokens", -int(completion_tokens), {"model": model, "phase": "completion"}),
         post("resource.tokens", f"project:{project_id}", "+tokens", +int(completion_tokens), {"model": model, "phase": "completion"}),
@@ -100,24 +108,23 @@ def model_completion(
             ]
         )
 
-    payload_base: Dict[str, Any] = {
+    canonical: Dict[str, Any] = {
         "provider": provider,
         "model": model,
         "completion_tokens": completion_tokens,
         "wall_ms": wall_ms,
         "phase": "completion",
+        "exchange_id": exchange_id,
     }
     if response_text is not None:
-        payload_base["response_text"] = response_text
+        canonical["response_text"] = response_text
 
     event(
         kind="model_completion",
         actor={"agent_id": agent_id, "task_id": task_id},
         run_id=run_id,
-        payload={**payload_base, **(payload or {}), "exchange_id": exchange_id},
+        payload={**(payload or {}), **canonical},
         postings=postings,
-        project_id=project_id,
-        source="runtime",
         idempotency_key=f"{exchange_id}:completion",
     )
 
@@ -127,7 +134,6 @@ def state_move(
     task_id: str,
     from_: str,
     to: str,
-    project_id: str,
     agent_id: Optional[str] = None,
     run_id: Optional[str] = None,
     payload: Optional[Dict[str, Any]] = None,
@@ -144,6 +150,7 @@ def state_move(
     ``idempotency_key`` if you need a different correlation (e.g., when the
     same transition is legitimately recorded by multiple actors).
     """
+    _require_config()  # surface missing init() now, not inside event()
     postings = [
         post("truth.state", f"task:{task_id}", "tasks", -1, {"from": from_}),
         post("truth.state", f"task:{task_id}", "tasks", +1, {"to": to}),
@@ -154,8 +161,6 @@ def state_move(
         run_id=run_id,
         payload=payload,
         postings=postings,
-        project_id=project_id,
-        source="runtime",
         idempotency_key=idempotency_key or f"{task_id}:{from_}:{to}",
     )
 
@@ -163,7 +168,6 @@ def state_move(
 def utility(
     *,
     task_id: str,
-    project_id: str,
     metric: str,
     value: float,
     agent_id: Optional[str] = None,
@@ -175,6 +179,7 @@ def utility(
     ``metric`` and ``value`` are already recorded on the postings' dims_json
     and delta_numeric; the event payload only carries what the caller passes.
     """
+    project_id = _require_config().project_id
     postings = [
         post("truth.utility", f"task:{task_id}", "points", +float(value), {"metric": metric}),
         post("truth.utility", f"project:{project_id}", "points", -float(value), {"metric": metric}),
@@ -185,6 +190,4 @@ def utility(
         run_id=run_id,
         payload=payload,
         postings=postings,
-        project_id=project_id,
-        source="runtime",
     )

--- a/projects/controllog/src/controllog/motherduck.py
+++ b/projects/controllog/src/controllog/motherduck.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +23,33 @@ except ImportError as e:
         "controllog.motherduck requires the [duckdb] extra. "
         "Install with: pip install 'controllog[duckdb]'"
     ) from e
+
+
+# DuckDB identifier rule (we don't need full SQL; we just need to be safe to
+# interpolate without quoting). Permits letters, digits, and underscore;
+# rejects dots, dashes, spaces, quotes, etc. Single rule, applied everywhere
+# schema/table/column names are interpolated below.
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _ident(name: str) -> str:
+    """Validate ``name`` as a safe SQL identifier and return it unchanged."""
+    if not isinstance(name, str) or not _IDENT_RE.fullmatch(name):
+        raise ValueError(
+            f"unsafe SQL identifier: {name!r} "
+            "(must match [A-Za-z_][A-Za-z0-9_]*)"
+        )
+    return name
+
+
+def _path_literal(path: Path) -> str:
+    """Return ``path`` as a single-quoted SQL string literal.
+
+    DuckDB's ``read_json_auto`` takes a string literal; we only ever
+    interpolate paths the SDK wrote, but doubling single quotes is the
+    standard belt-and-suspenders here.
+    """
+    return "'" + str(path).replace("'", "''") + "'"
 
 
 def _connect(motherduck_db: str, motherduck_token: str | None) -> "duckdb.DuckDBPyConnection":
@@ -44,6 +72,9 @@ def _missing_ids(
     """
     if not local_ids:
         return set()
+    schema = _ident(schema)
+    table = _ident(table)
+    id_column = _ident(id_column)
     missing = set(local_ids)
     chunk_size = 5000
     ids_list = list(local_ids)
@@ -60,10 +91,12 @@ def _missing_ids(
 
 
 def _iter_jsonl_files(log_dir: Path, name: str) -> list[Path]:
-    """Find all ``{name}.jsonl`` files under date-partitioned controllog dirs.
+    """Find all ``{name}.jsonl`` files written by the SDK.
 
-    Looks under both ``log_dir/controllog/{name}.jsonl`` (legacy flat layout)
-    and ``log_dir/controllog/YYYY-MM-DD/{name}.jsonl`` (current layout).
+    Picks up both the flat ``log_dir/controllog/{name}.jsonl`` layout and
+    the date-partitioned ``log_dir/controllog/YYYY-MM-DD/{name}.jsonl``
+    layout. The SDK chooses one based on ``partition_by_date``; the
+    uploader handles whichever it finds.
     """
     base = log_dir / "controllog"
     if not base.exists():
@@ -77,6 +110,7 @@ def _iter_jsonl_files(log_dir: Path, name: str) -> list[Path]:
 
 
 def _ensure_schema(md: "duckdb.DuckDBPyConnection", schema: str) -> None:
+    schema = _ident(schema)
     md.execute(f"CREATE SCHEMA IF NOT EXISTS {schema}")
     md.execute(f"""
         CREATE TABLE IF NOT EXISTS {schema}.events (
@@ -120,6 +154,7 @@ def upload(
     Returns a dict with the number of rows inserted (not total rows in table).
     """
     log_dir = Path(log_dir)
+    schema = _ident(schema)
     event_files = _iter_jsonl_files(log_dir, "events")
     posting_files = _iter_jsonl_files(log_dir, "postings")
     if not event_files and not posting_files:
@@ -156,7 +191,7 @@ def upload(
                     run_id,
                     actor_agent_id,
                     actor_task_id
-                FROM read_json_auto('{ef}') AS src
+                FROM read_json_auto({_path_literal(ef)}) AS src
                 QUALIFY ROW_NUMBER() OVER (
                     PARTITION BY CAST(src.event_id AS VARCHAR)
                     ORDER BY src.ingest_time DESC
@@ -183,7 +218,7 @@ def upload(
                     unit,
                     delta_numeric,
                     dims_json
-                FROM read_json_auto('{pf}') AS src
+                FROM read_json_auto({_path_literal(pf)}) AS src
                 QUALIFY ROW_NUMBER() OVER (
                     PARTITION BY CAST(src.posting_id AS VARCHAR)
                 ) = 1
@@ -209,6 +244,7 @@ def verify(
     Returns row counts, any (account_type, unit) slices that fail the
     trial-balance invariant, and a histogram of event kinds.
     """
+    schema = _ident(schema)
     md = _connect(motherduck_db, motherduck_token)
     try:
         events = md.execute(f"SELECT COUNT(*) FROM {schema}.events").fetchone()[0]
@@ -260,8 +296,21 @@ def cleanup_local(
     offline or when you trust an earlier upload).
     """
     log_dir = Path(log_dir)
+    schema = _ident(schema)
     event_files = _iter_jsonl_files(log_dir, "events")
     posting_files = _iter_jsonl_files(log_dir, "postings")
+
+    # Nothing to clean up — no credentials or network needed for an empty
+    # directory. Return the same shape so callers don't have to special-case it.
+    if not event_files and not posting_files:
+        return {
+            "files_deleted": 0,
+            "files": [],
+            "bytes_freed": 0,
+            "dry_run": dry_run,
+            "local_events": 0,
+            "local_postings": 0,
+        }
 
     local_event_ids: set[str] = set()
     for ef in event_files:

--- a/projects/controllog/src/controllog/motherduck.py
+++ b/projects/controllog/src/controllog/motherduck.py
@@ -1,8 +1,7 @@
 """MotherDuck transport for controllog.
 
 Uploads append-only JSONL into ``controllog.events`` and ``controllog.postings``
-(default schema per spec v1.1 section 10.1). Idempotent on ``event_id`` and
-``posting_id`` — re-running is safe.
+(spec § 10.1). Idempotent on ``event_id`` and ``posting_id`` — re-running is safe.
 
 Requires the ``[duckdb]`` extra::
 
@@ -12,7 +11,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 from pathlib import Path
 from typing import Any
 
@@ -25,30 +23,12 @@ except ImportError as e:
     ) from e
 
 
-# DuckDB identifier rule (we don't need full SQL; we just need to be safe to
-# interpolate without quoting). Permits letters, digits, and underscore;
-# rejects dots, dashes, spaces, quotes, etc. Single rule, applied everywhere
-# schema/table/column names are interpolated below.
-_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-
-
-def _ident(name: str) -> str:
-    """Validate ``name`` as a safe SQL identifier and return it unchanged."""
-    if not isinstance(name, str) or not _IDENT_RE.fullmatch(name):
-        raise ValueError(
-            f"unsafe SQL identifier: {name!r} "
-            "(must match [A-Za-z_][A-Za-z0-9_]*)"
-        )
-    return name
+# Schema is fixed by spec § 10.1.
+_SCHEMA = "controllog"
 
 
 def _path_literal(path: Path) -> str:
-    """Return ``path`` as a single-quoted SQL string literal.
-
-    DuckDB's ``read_json_auto`` takes a string literal; we only ever
-    interpolate paths the SDK wrote, but doubling single quotes is the
-    standard belt-and-suspenders here.
-    """
+    """Return ``path`` as a single-quoted SQL string literal for ``read_json_auto``."""
     return "'" + str(path).replace("'", "''") + "'"
 
 
@@ -61,20 +41,16 @@ def _connect(motherduck_db: str, motherduck_token: str | None) -> "duckdb.DuckDB
 
 def _missing_ids(
     md: "duckdb.DuckDBPyConnection",
-    schema: str,
     table: str,
     id_column: str,
     local_ids: set[str],
 ) -> set[str]:
-    """Return the subset of ``local_ids`` not present in ``schema.table``.
+    """Return the subset of ``local_ids`` not present in ``controllog.{table}``.
 
     Queries in chunks to keep the IN clause manageable on large local sets.
     """
     if not local_ids:
         return set()
-    schema = _ident(schema)
-    table = _ident(table)
-    id_column = _ident(id_column)
     missing = set(local_ids)
     chunk_size = 5000
     ids_list = list(local_ids)
@@ -82,7 +58,7 @@ def _missing_ids(
         chunk = ids_list[start : start + chunk_size]
         placeholders = ", ".join(["?"] * len(chunk))
         rows = md.execute(
-            f"SELECT {id_column} FROM {schema}.{table} WHERE {id_column} IN ({placeholders})",
+            f"SELECT {id_column} FROM {_SCHEMA}.{table} WHERE {id_column} IN ({placeholders})",
             chunk,
         ).fetchall()
         for (rid,) in rows:
@@ -91,29 +67,15 @@ def _missing_ids(
 
 
 def _iter_jsonl_files(log_dir: Path, name: str) -> list[Path]:
-    """Find all ``{name}.jsonl`` files written by the SDK.
-
-    Picks up both the flat ``log_dir/controllog/{name}.jsonl`` layout and
-    the date-partitioned ``log_dir/controllog/YYYY-MM-DD/{name}.jsonl``
-    layout. The SDK chooses one based on ``partition_by_date``; the
-    uploader handles whichever it finds.
-    """
-    base = log_dir / "controllog"
-    if not base.exists():
-        return []
-    files = []
-    flat = base / f"{name}.jsonl"
-    if flat.exists():
-        files.append(flat)
-    files.extend(sorted(base.glob(f"*/{name}.jsonl")))
-    return files
+    """Find ``log_dir/controllog/{name}.jsonl`` written by the SDK."""
+    flat = log_dir / "controllog" / f"{name}.jsonl"
+    return [flat] if flat.exists() else []
 
 
-def _ensure_schema(md: "duckdb.DuckDBPyConnection", schema: str) -> None:
-    schema = _ident(schema)
-    md.execute(f"CREATE SCHEMA IF NOT EXISTS {schema}")
+def _ensure_schema(md: "duckdb.DuckDBPyConnection") -> None:
+    md.execute(f"CREATE SCHEMA IF NOT EXISTS {_SCHEMA}")
     md.execute(f"""
-        CREATE TABLE IF NOT EXISTS {schema}.events (
+        CREATE TABLE IF NOT EXISTS {_SCHEMA}.events (
             event_id VARCHAR PRIMARY KEY,
             event_time TIMESTAMP WITH TIME ZONE,
             ingest_time TIMESTAMP WITH TIME ZONE,
@@ -128,7 +90,7 @@ def _ensure_schema(md: "duckdb.DuckDBPyConnection", schema: str) -> None:
         )
     """)
     md.execute(f"""
-        CREATE TABLE IF NOT EXISTS {schema}.postings (
+        CREATE TABLE IF NOT EXISTS {_SCHEMA}.postings (
             posting_id VARCHAR PRIMARY KEY,
             event_id VARCHAR NOT NULL,
             account_type VARCHAR NOT NULL,
@@ -144,17 +106,14 @@ def upload(
     *,
     motherduck_db: str,
     log_dir: Path | str,
-    schema: str = "controllog",
     motherduck_token: str | None = None,
 ) -> dict[str, int]:
-    """Upload all local JSONL logs under ``log_dir`` into MotherDuck.
+    """Upload local controllog JSONL into ``controllog.events`` and ``controllog.postings``.
 
     Idempotent: existing ``event_id`` / ``posting_id`` rows are skipped.
-
-    Returns a dict with the number of rows inserted (not total rows in table).
+    Returns the number of rows inserted (not total rows in table).
     """
     log_dir = Path(log_dir)
-    schema = _ident(schema)
     event_files = _iter_jsonl_files(log_dir, "events")
     posting_files = _iter_jsonl_files(log_dir, "postings")
     if not event_files and not posting_files:
@@ -162,7 +121,7 @@ def upload(
 
     md = _connect(motherduck_db, motherduck_token)
     try:
-        _ensure_schema(md, schema)
+        _ensure_schema(md)
 
         # Local JSONL can carry duplicate event_id / posting_id rows when an
         # idempotent operation is retried (deterministic IDs collapse onto
@@ -173,9 +132,9 @@ def upload(
         # batch before we add the remote-dedupe filter on top.
         events_inserted = 0
         for ef in event_files:
-            before = md.execute(f"SELECT COUNT(*) FROM {schema}.events").fetchone()[0]
+            before = md.execute(f"SELECT COUNT(*) FROM {_SCHEMA}.events").fetchone()[0]
             md.execute(f"""
-                INSERT INTO {schema}.events (
+                INSERT INTO {_SCHEMA}.events (
                     event_id, event_time, ingest_time, kind, project_id, source,
                     idempotency_key, payload_json, run_id, actor_agent_id, actor_task_id
                 )
@@ -197,16 +156,16 @@ def upload(
                     ORDER BY src.ingest_time DESC
                 ) = 1
                 AND CAST(src.event_id AS VARCHAR)
-                    NOT IN (SELECT event_id FROM {schema}.events)
+                    NOT IN (SELECT event_id FROM {_SCHEMA}.events)
             """)
-            after = md.execute(f"SELECT COUNT(*) FROM {schema}.events").fetchone()[0]
+            after = md.execute(f"SELECT COUNT(*) FROM {_SCHEMA}.events").fetchone()[0]
             events_inserted += after - before
 
         postings_inserted = 0
         for pf in posting_files:
-            before = md.execute(f"SELECT COUNT(*) FROM {schema}.postings").fetchone()[0]
+            before = md.execute(f"SELECT COUNT(*) FROM {_SCHEMA}.postings").fetchone()[0]
             md.execute(f"""
-                INSERT INTO {schema}.postings (
+                INSERT INTO {_SCHEMA}.postings (
                     posting_id, event_id, account_type, account_id,
                     unit, delta_numeric, dims_json
                 )
@@ -223,9 +182,9 @@ def upload(
                     PARTITION BY CAST(src.posting_id AS VARCHAR)
                 ) = 1
                 AND CAST(src.posting_id AS VARCHAR)
-                    NOT IN (SELECT posting_id FROM {schema}.postings)
+                    NOT IN (SELECT posting_id FROM {_SCHEMA}.postings)
             """)
-            after = md.execute(f"SELECT COUNT(*) FROM {schema}.postings").fetchone()[0]
+            after = md.execute(f"SELECT COUNT(*) FROM {_SCHEMA}.postings").fetchone()[0]
             postings_inserted += after - before
 
         return {"events": events_inserted, "postings": postings_inserted}
@@ -236,7 +195,6 @@ def upload(
 def verify(
     *,
     motherduck_db: str,
-    schema: str = "controllog",
     motherduck_token: str | None = None,
 ) -> dict[str, Any]:
     """Run trial-balance checks against the uploaded controllog data.
@@ -244,22 +202,21 @@ def verify(
     Returns row counts, any (account_type, unit) slices that fail the
     trial-balance invariant, and a histogram of event kinds.
     """
-    schema = _ident(schema)
     md = _connect(motherduck_db, motherduck_token)
     try:
-        events = md.execute(f"SELECT COUNT(*) FROM {schema}.events").fetchone()[0]
-        postings = md.execute(f"SELECT COUNT(*) FROM {schema}.postings").fetchone()[0]
+        events = md.execute(f"SELECT COUNT(*) FROM {_SCHEMA}.events").fetchone()[0]
+        postings = md.execute(f"SELECT COUNT(*) FROM {_SCHEMA}.postings").fetchone()[0]
 
         violations = md.execute(f"""
             SELECT account_type, unit, SUM(delta_numeric) AS net
-            FROM {schema}.postings
+            FROM {_SCHEMA}.postings
             GROUP BY account_type, unit
             HAVING ABS(SUM(delta_numeric)) > 0.0001
         """).fetchall()
 
         event_kinds = md.execute(f"""
             SELECT kind, COUNT(*) AS count
-            FROM {schema}.events
+            FROM {_SCHEMA}.events
             GROUP BY kind
             ORDER BY count DESC
         """).fetchall()
@@ -280,7 +237,6 @@ def cleanup_local(
     *,
     log_dir: Path | str,
     motherduck_db: str,
-    schema: str = "controllog",
     motherduck_token: str | None = None,
     verify_uploaded: bool = True,
     dry_run: bool = False,
@@ -296,7 +252,6 @@ def cleanup_local(
     offline or when you trust an earlier upload).
     """
     log_dir = Path(log_dir)
-    schema = _ident(schema)
     event_files = _iter_jsonl_files(log_dir, "events")
     posting_files = _iter_jsonl_files(log_dir, "postings")
 
@@ -331,22 +286,22 @@ def cleanup_local(
     if verify_uploaded:
         md = _connect(motherduck_db, motherduck_token)
         try:
-            missing_events = _missing_ids(md, schema, "events", "event_id", local_event_ids)
-            missing_postings = _missing_ids(md, schema, "postings", "posting_id", local_posting_ids)
+            missing_events = _missing_ids(md, "events", "event_id", local_event_ids)
+            missing_postings = _missing_ids(md, "postings", "posting_id", local_posting_ids)
         finally:
             md.close()
         if missing_events:
             sample = ", ".join(sorted(missing_events)[:5])
             raise RuntimeError(
                 f"Verification failed: {len(missing_events)} local event_id(s) "
-                f"not present in {schema}.events. Sample: [{sample}]. "
+                f"not present in {_SCHEMA}.events. Sample: [{sample}]. "
                 f"Run upload() first or pass verify_uploaded=False."
             )
         if missing_postings:
             sample = ", ".join(sorted(missing_postings)[:5])
             raise RuntimeError(
                 f"Verification failed: {len(missing_postings)} local posting_id(s) "
-                f"not present in {schema}.postings. Sample: [{sample}]. "
+                f"not present in {_SCHEMA}.postings. Sample: [{sample}]. "
                 f"Run upload() first or pass verify_uploaded=False."
             )
 

--- a/projects/controllog/src/controllog/motherduck.py
+++ b/projects/controllog/src/controllog/motherduck.py
@@ -1,0 +1,252 @@
+"""MotherDuck transport for controllog.
+
+Uploads append-only JSONL into ``controllog.events`` and ``controllog.postings``
+(default schema per spec v1.1 section 10.1). Idempotent on ``event_id`` and
+``posting_id`` — re-running is safe.
+
+Requires the ``[duckdb]`` extra::
+
+    pip install "controllog[duckdb]"
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+try:
+    import duckdb
+except ImportError as e:
+    raise ImportError(
+        "controllog.motherduck requires the [duckdb] extra. "
+        "Install with: pip install 'controllog[duckdb]'"
+    ) from e
+
+
+def _connect(motherduck_db: str, motherduck_token: str | None) -> "duckdb.DuckDBPyConnection":
+    token = motherduck_token or os.environ.get("MOTHERDUCK_TOKEN")
+    if not token:
+        raise ValueError("MOTHERDUCK_TOKEN not set")
+    return duckdb.connect(f"md:{motherduck_db}?motherduck_token={token}")
+
+
+def _iter_jsonl_files(log_dir: Path, name: str) -> list[Path]:
+    """Find all ``{name}.jsonl`` files under date-partitioned controllog dirs.
+
+    Looks under both ``log_dir/controllog/{name}.jsonl`` (legacy flat layout)
+    and ``log_dir/controllog/YYYY-MM-DD/{name}.jsonl`` (current layout).
+    """
+    base = log_dir / "controllog"
+    if not base.exists():
+        return []
+    files = []
+    flat = base / f"{name}.jsonl"
+    if flat.exists():
+        files.append(flat)
+    files.extend(sorted(base.glob(f"*/{name}.jsonl")))
+    return files
+
+
+def _ensure_schema(md: "duckdb.DuckDBPyConnection", schema: str) -> None:
+    md.execute(f"CREATE SCHEMA IF NOT EXISTS {schema}")
+    md.execute(f"""
+        CREATE TABLE IF NOT EXISTS {schema}.events (
+            event_id VARCHAR PRIMARY KEY,
+            event_time TIMESTAMP WITH TIME ZONE,
+            ingest_time TIMESTAMP WITH TIME ZONE,
+            kind VARCHAR NOT NULL,
+            project_id VARCHAR NOT NULL,
+            source VARCHAR NOT NULL,
+            idempotency_key VARCHAR NOT NULL,
+            payload_json JSON,
+            run_id VARCHAR,
+            actor_agent_id VARCHAR,
+            actor_task_id VARCHAR
+        )
+    """)
+    md.execute(f"""
+        CREATE TABLE IF NOT EXISTS {schema}.postings (
+            posting_id VARCHAR PRIMARY KEY,
+            event_id VARCHAR NOT NULL,
+            account_type VARCHAR NOT NULL,
+            account_id VARCHAR NOT NULL,
+            unit VARCHAR NOT NULL,
+            delta_numeric DOUBLE NOT NULL,
+            dims_json JSON
+        )
+    """)
+
+
+def upload(
+    *,
+    motherduck_db: str,
+    log_dir: Path | str,
+    schema: str = "controllog",
+    motherduck_token: str | None = None,
+) -> dict[str, int]:
+    """Upload all local JSONL logs under ``log_dir`` into MotherDuck.
+
+    Idempotent: existing ``event_id`` / ``posting_id`` rows are skipped.
+
+    Returns a dict with the number of rows inserted (not total rows in table).
+    """
+    log_dir = Path(log_dir)
+    event_files = _iter_jsonl_files(log_dir, "events")
+    posting_files = _iter_jsonl_files(log_dir, "postings")
+    if not event_files and not posting_files:
+        raise FileNotFoundError(f"No controllog JSONL files found under {log_dir}/controllog/")
+
+    md = _connect(motherduck_db, motherduck_token)
+    try:
+        _ensure_schema(md, schema)
+
+        events_inserted = 0
+        for ef in event_files:
+            before = md.execute(f"SELECT COUNT(*) FROM {schema}.events").fetchone()[0]
+            md.execute(f"""
+                INSERT INTO {schema}.events (
+                    event_id, event_time, ingest_time, kind, project_id, source,
+                    idempotency_key, payload_json, run_id, actor_agent_id, actor_task_id
+                )
+                SELECT
+                    CAST(event_id AS VARCHAR),
+                    event_time,
+                    ingest_time,
+                    kind,
+                    project_id,
+                    source,
+                    idempotency_key,
+                    payload_json,
+                    run_id,
+                    actor_agent_id,
+                    actor_task_id
+                FROM read_json_auto('{ef}') AS src
+                WHERE CAST(src.event_id AS VARCHAR)
+                    NOT IN (SELECT event_id FROM {schema}.events)
+            """)
+            after = md.execute(f"SELECT COUNT(*) FROM {schema}.events").fetchone()[0]
+            events_inserted += after - before
+
+        postings_inserted = 0
+        for pf in posting_files:
+            before = md.execute(f"SELECT COUNT(*) FROM {schema}.postings").fetchone()[0]
+            md.execute(f"""
+                INSERT INTO {schema}.postings (
+                    posting_id, event_id, account_type, account_id,
+                    unit, delta_numeric, dims_json
+                )
+                SELECT
+                    CAST(posting_id AS VARCHAR),
+                    CAST(event_id AS VARCHAR),
+                    account_type,
+                    account_id,
+                    unit,
+                    delta_numeric,
+                    dims_json
+                FROM read_json_auto('{pf}') AS src
+                WHERE CAST(src.posting_id AS VARCHAR)
+                    NOT IN (SELECT posting_id FROM {schema}.postings)
+            """)
+            after = md.execute(f"SELECT COUNT(*) FROM {schema}.postings").fetchone()[0]
+            postings_inserted += after - before
+
+        return {"events": events_inserted, "postings": postings_inserted}
+    finally:
+        md.close()
+
+
+def verify(
+    *,
+    motherduck_db: str,
+    schema: str = "controllog",
+    motherduck_token: str | None = None,
+) -> dict[str, Any]:
+    """Run trial-balance checks against the uploaded controllog data.
+
+    Returns row counts, any (account_type, unit) slices that fail the
+    trial-balance invariant, and a histogram of event kinds.
+    """
+    md = _connect(motherduck_db, motherduck_token)
+    try:
+        events = md.execute(f"SELECT COUNT(*) FROM {schema}.events").fetchone()[0]
+        postings = md.execute(f"SELECT COUNT(*) FROM {schema}.postings").fetchone()[0]
+
+        violations = md.execute(f"""
+            SELECT account_type, unit, SUM(delta_numeric) AS net
+            FROM {schema}.postings
+            GROUP BY account_type, unit
+            HAVING ABS(SUM(delta_numeric)) > 0.0001
+        """).fetchall()
+
+        event_kinds = md.execute(f"""
+            SELECT kind, COUNT(*) AS count
+            FROM {schema}.events
+            GROUP BY kind
+            ORDER BY count DESC
+        """).fetchall()
+
+        return {
+            "events": events,
+            "postings": postings,
+            "trial_balance_violations": [
+                {"account_type": r[0], "unit": r[1], "net": r[2]} for r in violations
+            ],
+            "event_kinds": {row[0]: row[1] for row in event_kinds},
+        }
+    finally:
+        md.close()
+
+
+def cleanup_local(
+    *,
+    log_dir: Path | str,
+    motherduck_db: str,
+    schema: str = "controllog",
+    motherduck_token: str | None = None,
+    verify_uploaded: bool = True,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Delete local controllog JSONL files after confirming MotherDuck has them.
+
+    Set ``verify_uploaded=False`` to skip the row-count check (e.g., if you
+    are running offline or trust an earlier upload).
+    """
+    log_dir = Path(log_dir)
+    event_files = _iter_jsonl_files(log_dir, "events")
+    posting_files = _iter_jsonl_files(log_dir, "postings")
+
+    local_events = sum(1 for ef in event_files for line in open(ef) if line.strip())
+    local_postings = sum(1 for pf in posting_files for line in open(pf) if line.strip())
+
+    if verify_uploaded:
+        md = _connect(motherduck_db, motherduck_token)
+        try:
+            remote_events = md.execute(f"SELECT COUNT(*) FROM {schema}.events").fetchone()[0]
+            remote_postings = md.execute(f"SELECT COUNT(*) FROM {schema}.postings").fetchone()[0]
+        finally:
+            md.close()
+        if remote_events < local_events:
+            raise RuntimeError(
+                f"Verification failed: local has {local_events} events, "
+                f"MotherDuck has {remote_events}. Run upload() first or pass verify_uploaded=False."
+            )
+        if remote_postings < local_postings:
+            raise RuntimeError(
+                f"Verification failed: local has {local_postings} postings, "
+                f"MotherDuck has {remote_postings}. Run upload() first or pass verify_uploaded=False."
+            )
+
+    to_delete = event_files + posting_files
+    bytes_freed = sum(f.stat().st_size for f in to_delete)
+    if not dry_run:
+        for f in to_delete:
+            f.unlink()
+
+    return {
+        "files_deleted": 0 if dry_run else len(to_delete),
+        "files": [str(f) for f in to_delete],
+        "bytes_freed": bytes_freed,
+        "dry_run": dry_run,
+        "local_events": local_events,
+        "local_postings": local_postings,
+    }

--- a/projects/controllog/src/controllog/motherduck.py
+++ b/projects/controllog/src/controllog/motherduck.py
@@ -129,6 +129,13 @@ def upload(
     try:
         _ensure_schema(md, schema)
 
+        # Local JSONL can carry duplicate event_id / posting_id rows when an
+        # idempotent operation is retried (deterministic IDs collapse onto
+        # the same value). The remote dedupe ``NOT IN`` only filters IDs
+        # already in the table — if the duplicate is new remotely, both
+        # local rows pass the filter and the PRIMARY KEY rejects the batch.
+        # ``QUALIFY ROW_NUMBER() ... = 1`` keeps one row per ID inside the
+        # batch before we add the remote-dedupe filter on top.
         events_inserted = 0
         for ef in event_files:
             before = md.execute(f"SELECT COUNT(*) FROM {schema}.events").fetchone()[0]
@@ -150,7 +157,11 @@ def upload(
                     actor_agent_id,
                     actor_task_id
                 FROM read_json_auto('{ef}') AS src
-                WHERE CAST(src.event_id AS VARCHAR)
+                QUALIFY ROW_NUMBER() OVER (
+                    PARTITION BY CAST(src.event_id AS VARCHAR)
+                    ORDER BY src.ingest_time DESC
+                ) = 1
+                AND CAST(src.event_id AS VARCHAR)
                     NOT IN (SELECT event_id FROM {schema}.events)
             """)
             after = md.execute(f"SELECT COUNT(*) FROM {schema}.events").fetchone()[0]
@@ -173,7 +184,10 @@ def upload(
                     delta_numeric,
                     dims_json
                 FROM read_json_auto('{pf}') AS src
-                WHERE CAST(src.posting_id AS VARCHAR)
+                QUALIFY ROW_NUMBER() OVER (
+                    PARTITION BY CAST(src.posting_id AS VARCHAR)
+                ) = 1
+                AND CAST(src.posting_id AS VARCHAR)
                     NOT IN (SELECT posting_id FROM {schema}.postings)
             """)
             after = md.execute(f"SELECT COUNT(*) FROM {schema}.postings").fetchone()[0]

--- a/projects/controllog/src/controllog/motherduck.py
+++ b/projects/controllog/src/controllog/motherduck.py
@@ -10,6 +10,7 @@ Requires the ``[duckdb]`` extra::
 """
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from typing import Any
@@ -28,6 +29,34 @@ def _connect(motherduck_db: str, motherduck_token: str | None) -> "duckdb.DuckDB
     if not token:
         raise ValueError("MOTHERDUCK_TOKEN not set")
     return duckdb.connect(f"md:{motherduck_db}?motherduck_token={token}")
+
+
+def _missing_ids(
+    md: "duckdb.DuckDBPyConnection",
+    schema: str,
+    table: str,
+    id_column: str,
+    local_ids: set[str],
+) -> set[str]:
+    """Return the subset of ``local_ids`` not present in ``schema.table``.
+
+    Queries in chunks to keep the IN clause manageable on large local sets.
+    """
+    if not local_ids:
+        return set()
+    missing = set(local_ids)
+    chunk_size = 5000
+    ids_list = list(local_ids)
+    for start in range(0, len(ids_list), chunk_size):
+        chunk = ids_list[start : start + chunk_size]
+        placeholders = ", ".join(["?"] * len(chunk))
+        rows = md.execute(
+            f"SELECT {id_column} FROM {schema}.{table} WHERE {id_column} IN ({placeholders})",
+            chunk,
+        ).fetchall()
+        for (rid,) in rows:
+            missing.discard(str(rid))
+    return missing
 
 
 def _iter_jsonl_files(log_dir: Path, name: str) -> list[Path]:
@@ -208,32 +237,54 @@ def cleanup_local(
 ) -> dict[str, Any]:
     """Delete local controllog JSONL files after confirming MotherDuck has them.
 
-    Set ``verify_uploaded=False`` to skip the row-count check (e.g., if you
-    are running offline or trust an earlier upload).
+    Verifies the specific local ``event_id`` and ``posting_id`` values are
+    actually present in the remote tables — comparing row counts alone
+    would pass spuriously if the table already had unrelated rows from
+    another project or run.
+
+    Set ``verify_uploaded=False`` to skip verification (e.g., when running
+    offline or when you trust an earlier upload).
     """
     log_dir = Path(log_dir)
     event_files = _iter_jsonl_files(log_dir, "events")
     posting_files = _iter_jsonl_files(log_dir, "postings")
 
-    local_events = sum(1 for ef in event_files for line in open(ef) if line.strip())
-    local_postings = sum(1 for pf in posting_files for line in open(pf) if line.strip())
+    local_event_ids: set[str] = set()
+    for ef in event_files:
+        with open(ef) as fh:
+            for line in fh:
+                if not line.strip():
+                    continue
+                local_event_ids.add(str(json.loads(line)["event_id"]))
+
+    local_posting_ids: set[str] = set()
+    for pf in posting_files:
+        with open(pf) as fh:
+            for line in fh:
+                if not line.strip():
+                    continue
+                local_posting_ids.add(str(json.loads(line)["posting_id"]))
 
     if verify_uploaded:
         md = _connect(motherduck_db, motherduck_token)
         try:
-            remote_events = md.execute(f"SELECT COUNT(*) FROM {schema}.events").fetchone()[0]
-            remote_postings = md.execute(f"SELECT COUNT(*) FROM {schema}.postings").fetchone()[0]
+            missing_events = _missing_ids(md, schema, "events", "event_id", local_event_ids)
+            missing_postings = _missing_ids(md, schema, "postings", "posting_id", local_posting_ids)
         finally:
             md.close()
-        if remote_events < local_events:
+        if missing_events:
+            sample = ", ".join(sorted(missing_events)[:5])
             raise RuntimeError(
-                f"Verification failed: local has {local_events} events, "
-                f"MotherDuck has {remote_events}. Run upload() first or pass verify_uploaded=False."
+                f"Verification failed: {len(missing_events)} local event_id(s) "
+                f"not present in {schema}.events. Sample: [{sample}]. "
+                f"Run upload() first or pass verify_uploaded=False."
             )
-        if remote_postings < local_postings:
+        if missing_postings:
+            sample = ", ".join(sorted(missing_postings)[:5])
             raise RuntimeError(
-                f"Verification failed: local has {local_postings} postings, "
-                f"MotherDuck has {remote_postings}. Run upload() first or pass verify_uploaded=False."
+                f"Verification failed: {len(missing_postings)} local posting_id(s) "
+                f"not present in {schema}.postings. Sample: [{sample}]. "
+                f"Run upload() first or pass verify_uploaded=False."
             )
 
     to_delete = event_files + posting_files
@@ -247,6 +298,6 @@ def cleanup_local(
         "files": [str(f) for f in to_delete],
         "bytes_freed": bytes_freed,
         "dry_run": dry_run,
-        "local_events": local_events,
-        "local_postings": local_postings,
+        "local_events": len(local_event_ids),
+        "local_postings": len(local_posting_ids),
     }

--- a/projects/controllog/src/controllog/sdk.py
+++ b/projects/controllog/src/controllog/sdk.py
@@ -136,6 +136,31 @@ def is_initialized() -> bool:
     return _config is not None
 
 
+# Fixed namespace UUID for deriving stable v5 IDs from idempotency keys.
+# Anchors the controllog id-space; any UUID is fine here as long as it's stable.
+_CONTROLLOG_NAMESPACE = uuid.UUID("8ba6b5dc-1c1c-5d29-9b0e-43c4d2c3a9f1")
+
+
+def _deterministic_event_id(project_id: str, idempotency_key: str) -> str:
+    """Derive a stable event_id from (project_id, idempotency_key).
+
+    Per spec § 11, idempotency_key dedupes emission. To actually enforce that
+    on retries we anchor event_id to the key — so the MotherDuck PRIMARY KEY
+    on event_id rejects duplicates instead of letting them accumulate.
+    """
+    return str(uuid.uuid5(_CONTROLLOG_NAMESPACE, f"{project_id}\0{idempotency_key}"))
+
+
+def _deterministic_posting_id(event_id: str, index: int) -> str:
+    """Derive a stable posting_id from (event_id, position).
+
+    Postings within an event are unordered for accounting purposes, but the
+    list order is stable for a given builder call. Pinning posting_id to
+    position keeps retries idempotent at upload.
+    """
+    return str(uuid.uuid5(_CONTROLLOG_NAMESPACE, f"{event_id}\0posting:{index}"))
+
+
 def post(
     account_type: str,
     account_id: str,
@@ -160,12 +185,13 @@ def post(
 
 
 def _check_invariants(kind: str, postings: List[Dict[str, Any]]) -> None:
-    """Enforce minimal double-entry invariants at write-time.
+    """Enforce per-event double-entry invariant (spec § 8.1).
 
-    Per spec § 8.1, for the spec's minimum account set
-    (``truth.money``, ``truth.time``, ``truth.state``, ``truth.utility``)
-    and any ``resource.*`` extension accounts, sum(delta_numeric) per
-    (account_type, unit) must be zero within a reasonable epsilon.
+    For every (account_type, unit) pair within a single event,
+    sum(delta_numeric) must be zero within a reasonable epsilon. This
+    applies to all account types — the spec's minimum set
+    (``truth.money`` / ``truth.time`` / ``truth.state`` / ``truth.utility``)
+    and any extension namespaces (``resource.*``, custom domains) alike.
     """
     if not postings:
         return
@@ -177,11 +203,11 @@ def _check_invariants(kind: str, postings: List[Dict[str, Any]]) -> None:
 
     epsilon = 1e-9
     for (acct, unit), total in sums.items():
-        if acct.startswith("resource.") or acct.startswith("truth."):
-            if abs(total) > epsilon:
-                raise ValueError(
-                    f"UNBALANCED_POSTINGS: account_type={acct}, unit={unit}, net={total} for event kind={kind}"
-                )
+        if abs(total) > epsilon:
+            raise ValueError(
+                f"UNBALANCED_POSTINGS: account_type={acct}, unit={unit}, "
+                f"net={total} for event kind={kind}"
+            )
 
 
 def event(
@@ -201,9 +227,6 @@ def event(
     """
     assert _config is not None, "controllog.init() must be called before use"
 
-    event_id = _uuid7_str()
-    event_time = _now_iso()
-
     # Fill defaults
     actor = actor or {}
     payload = payload or {}
@@ -212,6 +235,19 @@ def event(
 
     # Invariant checks
     _check_invariants(kind, postings)
+
+    # When the caller provides an idempotency_key, derive event_id and
+    # posting_ids deterministically from it so retries collapse to the same
+    # row at MotherDuck (PRIMARY KEY on event_id / posting_id). Without
+    # this, retries write fresh random IDs and upload accumulates duplicate
+    # postings, defeating the spec § 11 dedupe contract.
+    if idempotency_key is not None:
+        event_id = _deterministic_event_id(project, idempotency_key)
+    else:
+        event_id = _uuid7_str()
+        idempotency_key = event_id  # event_id IS the key in this case
+
+    event_time = _now_iso()
 
     # default_dims merge into payload_json (events) and dims_json (postings)
     # rather than spreading top-level — top-level fields aren't carried into
@@ -231,16 +267,17 @@ def event(
         "project_id": project,
         "run_id": run_id,
         "source": source,
-        "idempotency_key": idempotency_key or event_id,
+        "idempotency_key": idempotency_key,
         "payload_json": {**defaults, **payload},
     }
 
     _write_jsonl(_events_file(), event_row)
 
-    # Persist postings (attach event_id, merge defaults into dims_json)
-    for p in postings:
+    # Persist postings (attach event_id and deterministic posting_id, merge defaults into dims_json)
+    for i, p in enumerate(postings):
         p_out = dict(p)
         p_out["event_id"] = event_id
+        p_out["posting_id"] = _deterministic_posting_id(event_id, i)
         p_out["dims_json"] = {**defaults, **(p_out.get("dims_json") or {})}
         _write_jsonl(_postings_file(), p_out)
 

--- a/projects/controllog/src/controllog/sdk.py
+++ b/projects/controllog/src/controllog/sdk.py
@@ -3,7 +3,6 @@ import os
 import time
 import uuid
 from dataclasses import dataclass, field
-import hashlib
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -20,7 +19,6 @@ class SDKConfig:
     log_dir: Path
     default_dims: Dict[str, Any] = field(default_factory=dict)
     partition_by_date: bool = False
-    pii_scrub: bool = False  # keep raw payloads (user requested)
 
 
 _config: Optional[SDKConfig] = None
@@ -53,7 +51,6 @@ def init(
         log_dir=log_dir,
         default_dims=default_dims or {},
         partition_by_date=partition_by_date,
-        pii_scrub=False,
     )
 
 
@@ -172,16 +169,13 @@ def post(
 
     Returns a plain dict; the caller passes the collection to event().
     """
-    posting = {
-        "posting_id": _uuid7_str(),
-        "event_id": None,  # filled during event()
+    return {
         "account_type": account_type,
         "account_id": account_id,
         "unit": unit,
         "delta_numeric": float(delta),
         "dims_json": dims or {},
     }
-    return posting
 
 
 def _check_invariants(kind: str, postings: List[Dict[str, Any]]) -> None:
@@ -282,6 +276,3 @@ def event(
         _write_jsonl(_postings_file(), p_out)
 
     return event_row
-
-
-

--- a/projects/controllog/src/controllog/sdk.py
+++ b/projects/controllog/src/controllog/sdk.py
@@ -213,6 +213,13 @@ def event(
     # Invariant checks
     _check_invariants(kind, postings)
 
+    # default_dims merge into payload_json (events) and dims_json (postings)
+    # rather than spreading top-level — top-level fields aren't carried into
+    # MotherDuck (the upload only selects the fixed event columns and the
+    # postings.dims_json field), so spreading top-level would silently drop
+    # them after upload and leave them unqueryable.
+    defaults = _config.default_dims or {}
+
     # Persist event
     event_row = {
         "event_id": event_id,
@@ -225,17 +232,17 @@ def event(
         "run_id": run_id,
         "source": source,
         "idempotency_key": idempotency_key or event_id,
-        "payload_json": {**payload},
+        "payload_json": {**defaults, **payload},
     }
 
-    # Write event
-    _write_jsonl(_events_file(), {**_config.default_dims, **event_row})
+    _write_jsonl(_events_file(), event_row)
 
-    # Persist postings (attach event_id)
+    # Persist postings (attach event_id, merge defaults into dims_json)
     for p in postings:
         p_out = dict(p)
         p_out["event_id"] = event_id
-        _write_jsonl(_postings_file(), {**_config.default_dims, **p_out})
+        p_out["dims_json"] = {**defaults, **(p_out.get("dims_json") or {})}
+        _write_jsonl(_postings_file(), p_out)
 
     return event_row
 

--- a/projects/controllog/src/controllog/sdk.py
+++ b/projects/controllog/src/controllog/sdk.py
@@ -162,9 +162,10 @@ def post(
 def _check_invariants(kind: str, postings: List[Dict[str, Any]]) -> None:
     """Enforce minimal double-entry invariants at write-time.
 
-    Rules implemented (per event):
-      - For account_types in {resource.tokens, resource.money, resource.time_ms, value.utility, truth.state},
-        sum(delta_numeric) per (account_type, unit) must be zero within reasonable epsilon.
+    Per spec § 8.1, for the spec's minimum account set
+    (``truth.money``, ``truth.time``, ``truth.state``, ``truth.utility``)
+    and any ``resource.*`` extension accounts, sum(delta_numeric) per
+    (account_type, unit) must be zero within a reasonable epsilon.
     """
     if not postings:
         return
@@ -176,7 +177,7 @@ def _check_invariants(kind: str, postings: List[Dict[str, Any]]) -> None:
 
     epsilon = 1e-9
     for (acct, unit), total in sums.items():
-        if acct.startswith("resource.") or acct in ("value.utility", "truth.state"):
+        if acct.startswith("resource.") or acct.startswith("truth."):
             if abs(total) > epsilon:
                 raise ValueError(
                     f"UNBALANCED_POSTINGS: account_type={acct}, unit={unit}, net={total} for event kind={kind}"

--- a/projects/controllog/src/controllog/sdk.py
+++ b/projects/controllog/src/controllog/sdk.py
@@ -1,0 +1,242 @@
+import json
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+# -------------------------
+# Configuration and globals
+# -------------------------
+
+
+@dataclass
+class SDKConfig:
+    project_id: str
+    log_dir: Path
+    default_dims: Dict[str, Any] = field(default_factory=dict)
+    partition_by_date: bool = False
+    pii_scrub: bool = False  # keep raw payloads (user requested)
+
+
+_config: Optional[SDKConfig] = None
+
+
+def init(
+    project_id: str,
+    log_dir: Path,
+    default_dims: Optional[Dict[str, Any]] = None,
+    partition_by_date: bool = False,
+) -> None:
+    """Initialize controllog SDK for JSONL transport.
+
+    Args:
+        project_id: Logical project identifier.
+        log_dir: Base directory where JSONL logs will be written.
+        default_dims: Default dimensions to add to every event/posting.
+        partition_by_date: If True, logs are written under
+            ``log_dir/controllog/YYYY-MM-DD/{events,postings}.jsonl``.
+            If False (default), flat layout:
+            ``log_dir/controllog/{events,postings}.jsonl``.
+            Both layouts are accepted by ``controllog.motherduck.upload``.
+    """
+    global _config
+
+    log_dir = Path(log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    _config = SDKConfig(
+        project_id=project_id,
+        log_dir=log_dir,
+        default_dims=default_dims or {},
+        partition_by_date=partition_by_date,
+        pii_scrub=False,
+    )
+
+
+# -------------------------
+# JSONL transport helpers
+# -------------------------
+
+
+def _events_dir() -> Path:
+    assert _config is not None, "controllog.init() must be called before use"
+    if _config.partition_by_date:
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        part = _config.log_dir / "controllog" / today
+    else:
+        part = _config.log_dir / "controllog"
+    part.mkdir(parents=True, exist_ok=True)
+    return part
+
+
+def _events_file() -> Path:
+    return _events_dir() / "events.jsonl"
+
+
+def _postings_file() -> Path:
+    return _events_dir() / "postings.jsonl"
+
+
+def _write_jsonl(path: Path, obj: Dict[str, Any]) -> None:
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(obj, ensure_ascii=False) + "\n")
+
+
+# -------------------------
+# Core data constructors
+# -------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _uuid7_str() -> str:
+    """Generate a UUIDv7 string (sortable by time) without relying on stdlib uuid7.
+
+    Layout (per draft RFC 4122 v7):
+      - 48 bits: unix time in milliseconds
+      - 4 bits: version (0b0111)
+      - 12 bits: random
+      - 2 bits: variant (0b10)
+      - 62 bits: random
+    """
+    ts_ms = int(time.time() * 1000) & ((1 << 48) - 1)
+    rand_a = int.from_bytes(os.urandom(2), "big") & 0x0FFF
+    rand_b = int.from_bytes(os.urandom(8), "big")  # 64 bits
+
+    b = bytearray(16)
+    # 48-bit timestamp big-endian
+    b[0:6] = ts_ms.to_bytes(6, "big")
+    # version (0x7) in high nibble of byte 6, top 4 bits of rand_a in low nibble
+    b[6] = (0x70 | ((rand_a >> 8) & 0x0F))
+    b[7] = rand_a & 0xFF
+    # variant '10' in top two bits of byte 8, then top 6 bits of rand_b
+    b[8] = 0x80 | ((rand_b >> 56) & 0x3F)
+    # remaining 56 bits of rand_b into bytes 9..15
+    lower_56 = rand_b & ((1 << 56) - 1)
+    for i in range(7):
+        shift = (6 - i) * 8
+        b[9 + i] = (lower_56 >> shift) & 0xFF
+
+    return str(uuid.UUID(bytes=bytes(b)))
+
+
+def new_id() -> str:
+    """Public UUIDv7 generator for correlation (e.g., exchange_id)."""
+    return _uuid7_str()
+
+
+def is_initialized() -> bool:
+    """Return True if ``init()`` has been called in this process."""
+    return _config is not None
+
+
+def post(
+    account_type: str,
+    account_id: str,
+    unit: str,
+    delta: float,
+    dims: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Create a posting line (not yet persisted).
+
+    Returns a plain dict; the caller passes the collection to event().
+    """
+    posting = {
+        "posting_id": _uuid7_str(),
+        "event_id": None,  # filled during event()
+        "account_type": account_type,
+        "account_id": account_id,
+        "unit": unit,
+        "delta_numeric": float(delta),
+        "dims_json": dims or {},
+    }
+    return posting
+
+
+def _check_invariants(kind: str, postings: List[Dict[str, Any]]) -> None:
+    """Enforce minimal double-entry invariants at write-time.
+
+    Rules implemented (per event):
+      - For account_types in {resource.tokens, resource.money, resource.time_ms, value.utility, truth.state},
+        sum(delta_numeric) per (account_type, unit) must be zero within reasonable epsilon.
+    """
+    if not postings:
+        return
+
+    sums: Dict[tuple, float] = {}
+    for p in postings:
+        key = (p["account_type"], p["unit"])
+        sums[key] = sums.get(key, 0.0) + float(p["delta_numeric"])
+
+    epsilon = 1e-9
+    for (acct, unit), total in sums.items():
+        if acct.startswith("resource.") or acct in ("value.utility", "truth.state"):
+            if abs(total) > epsilon:
+                raise ValueError(
+                    f"UNBALANCED_POSTINGS: account_type={acct}, unit={unit}, net={total} for event kind={kind}"
+                )
+
+
+def event(
+    *,
+    kind: str,
+    actor: Optional[Dict[str, str]] = None,
+    run_id: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+    postings: Optional[List[Dict[str, Any]]] = None,
+    project_id: Optional[str] = None,
+    source: str = "sdk",
+    idempotency_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Emit a structured event and balanced postings to JSONL.
+
+    Returns the persisted event dict.
+    """
+    assert _config is not None, "controllog.init() must be called before use"
+
+    event_id = _uuid7_str()
+    event_time = _now_iso()
+
+    # Fill defaults
+    actor = actor or {}
+    payload = payload or {}
+    postings = postings or []
+    project = project_id or _config.project_id
+
+    # Invariant checks
+    _check_invariants(kind, postings)
+
+    # Persist event
+    event_row = {
+        "event_id": event_id,
+        "event_time": event_time,
+        "ingest_time": _now_iso(),
+        "kind": kind,
+        "actor_agent_id": actor.get("agent_id"),
+        "actor_task_id": actor.get("task_id"),
+        "project_id": project,
+        "run_id": run_id,
+        "source": source,
+        "idempotency_key": idempotency_key or event_id,
+        "payload_json": {**payload},
+    }
+
+    # Write event
+    _write_jsonl(_events_file(), {**_config.default_dims, **event_row})
+
+    # Persist postings (attach event_id)
+    for p in postings:
+        p_out = dict(p)
+        p_out["event_id"] = event_id
+        _write_jsonl(_postings_file(), {**_config.default_dims, **p_out})
+
+    return event_row
+
+
+

--- a/projects/controllog/src/controllog/sdk.py
+++ b/projects/controllog/src/controllog/sdk.py
@@ -59,13 +59,25 @@ def init(
 # -------------------------
 
 
+def _require_config() -> SDKConfig:
+    """Return the active SDKConfig or raise if init() was never called.
+
+    Plain ``assert`` would be stripped under ``python -O``, turning the
+    helpful error into a later AttributeError when callers touch
+    ``_config.something``.
+    """
+    if _config is None:
+        raise RuntimeError("controllog.init() must be called before use")
+    return _config
+
+
 def _events_dir() -> Path:
-    assert _config is not None, "controllog.init() must be called before use"
-    if _config.partition_by_date:
+    cfg = _require_config()
+    if cfg.partition_by_date:
         today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        part = _config.log_dir / "controllog" / today
+        part = cfg.log_dir / "controllog" / today
     else:
-        part = _config.log_dir / "controllog"
+        part = cfg.log_dir / "controllog"
     part.mkdir(parents=True, exist_ok=True)
     return part
 
@@ -219,13 +231,13 @@ def event(
 
     Returns the persisted event dict.
     """
-    assert _config is not None, "controllog.init() must be called before use"
+    cfg = _require_config()
 
     # Fill defaults
     actor = actor or {}
     payload = payload or {}
     postings = postings or []
-    project = project_id or _config.project_id
+    project = project_id or cfg.project_id
 
     # Invariant checks
     _check_invariants(kind, postings)
@@ -248,7 +260,7 @@ def event(
     # MotherDuck (the upload only selects the fixed event columns and the
     # postings.dims_json field), so spreading top-level would silently drop
     # them after upload and leave them unqueryable.
-    defaults = _config.default_dims or {}
+    defaults = cfg.default_dims or {}
 
     # Persist event
     event_row = {

--- a/projects/controllog/src/controllog/sdk.py
+++ b/projects/controllog/src/controllog/sdk.py
@@ -8,17 +8,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
-# -------------------------
-# Configuration and globals
-# -------------------------
-
-
 @dataclass
 class SDKConfig:
     project_id: str
     log_dir: Path
     default_dims: Dict[str, Any] = field(default_factory=dict)
-    partition_by_date: bool = False
 
 
 _config: Optional[SDKConfig] = None
@@ -28,19 +22,17 @@ def init(
     project_id: str,
     log_dir: Path,
     default_dims: Optional[Dict[str, Any]] = None,
-    partition_by_date: bool = False,
 ) -> None:
     """Initialize controllog SDK for JSONL transport.
+
+    Writes append-only JSONL to ``log_dir/controllog/{events,postings}.jsonl``
+    (spec § 3.2).
 
     Args:
         project_id: Logical project identifier.
         log_dir: Base directory where JSONL logs will be written.
-        default_dims: Default dimensions to add to every event/posting.
-        partition_by_date: If True, logs are written under
-            ``log_dir/controllog/YYYY-MM-DD/{events,postings}.jsonl``.
-            If False (default), flat layout:
-            ``log_dir/controllog/{events,postings}.jsonl``.
-            Both layouts are accepted by ``controllog.motherduck.upload``.
+        default_dims: Default dimensions merged into every event's
+            ``payload_json`` and every posting's ``dims_json``.
     """
     global _config
 
@@ -50,13 +42,7 @@ def init(
         project_id=project_id,
         log_dir=log_dir,
         default_dims=default_dims or {},
-        partition_by_date=partition_by_date,
     )
-
-
-# -------------------------
-# JSONL transport helpers
-# -------------------------
 
 
 def _require_config() -> SDKConfig:
@@ -73,11 +59,7 @@ def _require_config() -> SDKConfig:
 
 def _events_dir() -> Path:
     cfg = _require_config()
-    if cfg.partition_by_date:
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        part = cfg.log_dir / "controllog" / today
-    else:
-        part = cfg.log_dir / "controllog"
+    part = cfg.log_dir / "controllog"
     part.mkdir(parents=True, exist_ok=True)
     return part
 
@@ -93,11 +75,6 @@ def _postings_file() -> Path:
 def _write_jsonl(path: Path, obj: Dict[str, Any]) -> None:
     with open(path, "a", encoding="utf-8") as f:
         f.write(json.dumps(obj, ensure_ascii=False) + "\n")
-
-
-# -------------------------
-# Core data constructors
-# -------------------------
 
 
 def _now_iso() -> str:
@@ -233,13 +210,11 @@ def event(
     """
     cfg = _require_config()
 
-    # Fill defaults
     actor = actor or {}
     payload = payload or {}
     postings = postings or []
     project = project_id or cfg.project_id
 
-    # Invariant checks
     _check_invariants(kind, postings)
 
     # When the caller provides an idempotency_key, derive event_id and
@@ -262,7 +237,6 @@ def event(
     # them after upload and leave them unqueryable.
     defaults = cfg.default_dims or {}
 
-    # Persist event
     event_row = {
         "event_id": event_id,
         "event_time": event_time,
@@ -276,10 +250,8 @@ def event(
         "idempotency_key": idempotency_key,
         "payload_json": {**defaults, **payload},
     }
-
     _write_jsonl(_events_file(), event_row)
 
-    # Persist postings (attach event_id and deterministic posting_id, merge defaults into dims_json)
     for i, p in enumerate(postings):
         p_out = dict(p)
         p_out["event_id"] = event_id

--- a/projects/controllog/src/controllog/sdk.py
+++ b/projects/controllog/src/controllog/sdk.py
@@ -200,11 +200,14 @@ def event(
     run_id: Optional[str] = None,
     payload: Optional[Dict[str, Any]] = None,
     postings: Optional[List[Dict[str, Any]]] = None,
-    project_id: Optional[str] = None,
-    source: str = "sdk",
+    source: str = "runtime",
     idempotency_key: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Emit a structured event and balanced postings to JSONL.
+
+    ``project_id`` is taken from :func:`init` — one project per SDK instance,
+    per spec § 3.1. ``source`` matches what builders pass so mixed raw/builder
+    logs stay readable.
 
     Returns the persisted event dict.
     """
@@ -213,7 +216,7 @@ def event(
     actor = actor or {}
     payload = payload or {}
     postings = postings or []
-    project = project_id or cfg.project_id
+    project = cfg.project_id
 
     _check_invariants(kind, postings)
 

--- a/projects/controllog/tests/conftest.py
+++ b/projects/controllog/tests/conftest.py
@@ -1,0 +1,48 @@
+"""Test fixtures.
+
+Each test gets a fresh ``controllog.init()`` against a tmp_path log dir
+so module-global state doesn't bleed between cases.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import controllog
+from controllog import sdk as _sdk
+
+
+@pytest.fixture(autouse=True)
+def _reset_controllog():
+    """Reset module-global config before each test."""
+    _sdk._config = None
+    yield
+    _sdk._config = None
+
+
+@pytest.fixture
+def log_dir(tmp_path: Path) -> Path:
+    """A pristine log_dir, initialized for a 'test' project."""
+    controllog.init(project_id="test", log_dir=tmp_path)
+    return tmp_path
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    """Load a JSONL file as a list of dicts."""
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+@pytest.fixture
+def read_events(log_dir):
+    def _read() -> list[dict]:
+        return read_jsonl(log_dir / "controllog" / "events.jsonl")
+    return _read
+
+
+@pytest.fixture
+def read_postings(log_dir):
+    def _read() -> list[dict]:
+        return read_jsonl(log_dir / "controllog" / "postings.jsonl")
+    return _read

--- a/projects/controllog/tests/test_builders.py
+++ b/projects/controllog/tests/test_builders.py
@@ -13,7 +13,7 @@ import controllog
 
 def test_model_prompt_returns_exchange_id(log_dir):
     xid = controllog.model_prompt(
-        task_id="t1", agent_id="a", run_id="r", project_id="test",
+        task_id="t1", agent_id="a", run_id="r",
         provider="openai", model="gpt-5", prompt_tokens=100,
     )
     assert isinstance(xid, str)
@@ -24,12 +24,12 @@ def test_model_prompt_returns_exchange_id(log_dir):
 
 def test_model_prompt_and_completion_share_exchange_id(log_dir, read_events):
     xid = controllog.model_prompt(
-        task_id="t1", agent_id="a", run_id="r", project_id="test",
+        task_id="t1", agent_id="a", run_id="r",
         provider="openai", model="gpt-5", prompt_tokens=100,
     )
     controllog.model_completion(
         exchange_id=xid,
-        task_id="t1", agent_id="a", run_id="r", project_id="test",
+        task_id="t1", agent_id="a", run_id="r",
         provider="openai", model="gpt-5", completion_tokens=10, wall_ms=500,
     )
     events = read_events()
@@ -42,7 +42,7 @@ def test_model_prompt_and_completion_share_exchange_id(log_dir, read_events):
 def test_model_completion_requires_exchange_id(log_dir):
     with pytest.raises(TypeError):
         controllog.model_completion(  # type: ignore[call-arg]
-            task_id="t1", agent_id="a", run_id="r", project_id="test",
+            task_id="t1", agent_id="a", run_id="r",
             provider="openai", model="gpt-5", completion_tokens=10, wall_ms=500,
         )
 
@@ -50,12 +50,12 @@ def test_model_completion_requires_exchange_id(log_dir):
 def test_model_call_idempotency_keys_use_exchange_id(log_dir, read_events):
     """Spec § 5.1 — idempotency keys are {exchange_id}:prompt and :completion."""
     xid = controllog.model_prompt(
-        task_id="t1", agent_id="a", run_id="r", project_id="test",
+        task_id="t1", agent_id="a", run_id="r",
         provider="openai", model="gpt-5", prompt_tokens=10,
     )
     controllog.model_completion(
         exchange_id=xid,
-        task_id="t1", agent_id="a", run_id="r", project_id="test",
+        task_id="t1", agent_id="a", run_id="r",
         provider="openai", model="gpt-5", completion_tokens=5, wall_ms=100,
     )
     events = read_events()
@@ -64,15 +64,30 @@ def test_model_call_idempotency_keys_use_exchange_id(log_dir, read_events):
     assert by_kind["model_completion"]["idempotency_key"] == f"{xid}:completion"
 
 
+def test_canonical_fields_override_caller_payload(log_dir, read_events):
+    """A stray payload={"phase": "completion"} on model_prompt must not flip
+    the event's recorded phase — postings already say 'prompt'."""
+    controllog.model_prompt(
+        task_id="t1", agent_id="a",
+        provider="openai", model="gpt-5", prompt_tokens=100,
+        payload={"phase": "completion", "provider": "anthropic", "extra": "kept"},
+    )
+    e = read_events()[0]
+    assert e["payload_json"]["phase"] == "prompt"
+    assert e["payload_json"]["provider"] == "openai"
+    # Non-conflicting caller keys still pass through
+    assert e["payload_json"]["extra"] == "kept"
+
+
 def test_model_completion_postings_balance(log_dir, read_postings):
     """Tokens, time, money must all sum to zero per (account_type, unit)."""
     xid = controllog.model_prompt(
-        task_id="t1", agent_id="a", run_id="r", project_id="test",
+        task_id="t1", agent_id="a", run_id="r",
         provider="openai", model="gpt-5", prompt_tokens=100,
     )
     controllog.model_completion(
         exchange_id=xid,
-        task_id="t1", agent_id="a", run_id="r", project_id="test",
+        task_id="t1", agent_id="a", run_id="r",
         provider="openai", model="gpt-5", completion_tokens=10, wall_ms=500,
         cost_money=0.002,
     )
@@ -90,23 +105,23 @@ def test_model_completion_postings_balance(log_dir, read_postings):
 
 
 def test_state_move_default_idempotency_key(log_dir, read_events):
-    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP")
     e = read_events()[0]
     assert e["idempotency_key"] == "t1:NEW:WIP"
 
 
 def test_state_move_retry_collapses_event_id(log_dir, read_events):
     """Retried state_move keeps same event_id so MD PK dedupes on upload."""
-    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
-    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP")
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP")
     events = read_events()
     assert len(events) == 2  # local JSONL keeps both rows
     assert events[0]["event_id"] == events[1]["event_id"]
 
 
 def test_state_move_different_transitions_distinct(log_dir, read_events):
-    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
-    controllog.state_move(task_id="t1", from_="WIP", to="DONE", project_id="test")
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP")
+    controllog.state_move(task_id="t1", from_="WIP", to="DONE")
     events = read_events()
     keys = {e["idempotency_key"] for e in events}
     assert keys == {"t1:NEW:WIP", "t1:WIP:DONE"}
@@ -114,7 +129,7 @@ def test_state_move_different_transitions_distinct(log_dir, read_events):
 
 def test_state_move_custom_idempotency_key(log_dir, read_events):
     controllog.state_move(
-        task_id="t1", from_="NEW", to="WIP", project_id="test",
+        task_id="t1", from_="NEW", to="WIP",
         idempotency_key="custom-key",
     )
     assert read_events()[0]["idempotency_key"] == "custom-key"
@@ -126,7 +141,7 @@ def test_state_move_custom_idempotency_key(log_dir, read_events):
 
 
 def test_utility_balances(log_dir, read_postings):
-    controllog.utility(task_id="t1", project_id="test", metric="reward", value=0.7)
+    controllog.utility(task_id="t1", metric="reward", value=0.7)
     p = read_postings()
     assert len(p) == 2
     assert all(row["account_type"] == "truth.utility" for row in p)
@@ -135,7 +150,7 @@ def test_utility_balances(log_dir, read_postings):
 
 def test_utility_omits_payload_when_none(log_dir, read_events):
     """metric and value are already on the postings — no need for a payload placeholder."""
-    controllog.utility(task_id="t1", project_id="test", metric="reward", value=1.0)
+    controllog.utility(task_id="t1", metric="reward", value=1.0)
     e = read_events()[0]
     # No {"metric": ..., "value": ...} placeholder when caller passes no payload
     assert e["payload_json"] == {}
@@ -149,12 +164,12 @@ def test_utility_omits_payload_when_none(log_dir, read_events):
 def test_cost_posting_uses_provider_argument(log_dir, read_postings):
     """truth.money should land on vendor:{provider}, not vendor:openrouter."""
     xid = controllog.model_prompt(
-        task_id="t1", agent_id="a", project_id="test",
+        task_id="t1", agent_id="a",
         provider="anthropic", model="claude-sonnet", prompt_tokens=100,
     )
     controllog.model_completion(
         exchange_id=xid,
-        task_id="t1", agent_id="a", project_id="test",
+        task_id="t1", agent_id="a",
         provider="anthropic", model="claude-sonnet",
         completion_tokens=10, wall_ms=500, cost_money=0.005,
     )
@@ -164,21 +179,30 @@ def test_cost_posting_uses_provider_argument(log_dir, read_postings):
 
 
 # -------------------------
-# Required project_id (no None placeholder)
+# project_id resolution
 # -------------------------
 
 
-def test_builders_reject_missing_project_id(log_dir):
-    """Without project_id, postings would record account_id='project:None'."""
-    with pytest.raises(TypeError):
-        controllog.model_prompt(  # type: ignore[call-arg]
-            task_id="t1", agent_id="a",
-            provider="openai", model="gpt-5", prompt_tokens=100,
-        )
+def test_builders_use_configured_project_id(log_dir, read_postings):
+    """Builders pull project_id from init() rather than per-call kwargs."""
+    controllog.utility(task_id="t1", metric="reward", value=1.0)
+    project_postings = [p for p in read_postings() if p["account_id"].startswith("project:")]
+    assert all(p["account_id"] == "project:test" for p in project_postings)
+
+
+def test_builders_reject_per_call_project_id(log_dir):
+    """project_id was dropped; passing it is now a TypeError."""
     with pytest.raises(TypeError):
         controllog.state_move(  # type: ignore[call-arg]
-            task_id="t1", from_="NEW", to="WIP",
+            task_id="t1", from_="NEW", to="WIP", project_id="other",
         )
+
+
+def test_builders_raise_when_init_missing(tmp_path):
+    """Calling a builder before init() surfaces RuntimeError, not AttributeError."""
+    # autouse fixture clears _config; no init() call here
+    with pytest.raises(RuntimeError, match="init"):
+        controllog.utility(task_id="t1", metric="reward", value=1.0)
 
 
 # -------------------------
@@ -188,7 +212,7 @@ def test_builders_reject_missing_project_id(log_dir):
 
 def test_state_move_omits_payload_when_none(log_dir, read_events):
     """Spec § 6 transitions shouldn't carry a placeholder reason=null."""
-    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP")
     e = read_events()[0]
     assert "reason" not in e["payload_json"]
     assert e["payload_json"] == {}
@@ -196,7 +220,7 @@ def test_state_move_omits_payload_when_none(log_dir, read_events):
 
 def test_state_move_preserves_caller_payload(log_dir, read_events):
     controllog.state_move(
-        task_id="t1", from_="NEW", to="WIP", project_id="test",
+        task_id="t1", from_="NEW", to="WIP",
         payload={"reason": "operator-resumed"},
     )
     assert read_events()[0]["payload_json"]["reason"] == "operator-resumed"

--- a/projects/controllog/tests/test_builders.py
+++ b/projects/controllog/tests/test_builders.py
@@ -1,0 +1,133 @@
+"""Tests for controllog.builders — model_prompt/completion, state_move, utility."""
+from __future__ import annotations
+
+import pytest
+
+import controllog
+
+
+# -------------------------
+# model_prompt / model_completion (spec § 5: two-phase, shared exchange_id)
+# -------------------------
+
+
+def test_model_prompt_returns_exchange_id(log_dir):
+    xid = controllog.model_prompt(
+        task_id="t1", agent_id="a", run_id="r", project_id="test",
+        provider="openai", model="gpt-5", prompt_tokens=100,
+    )
+    assert isinstance(xid, str)
+    # UUIDv7-ish
+    import uuid
+    uuid.UUID(xid)
+
+
+def test_model_prompt_and_completion_share_exchange_id(log_dir, read_events):
+    xid = controllog.model_prompt(
+        task_id="t1", agent_id="a", run_id="r", project_id="test",
+        provider="openai", model="gpt-5", prompt_tokens=100,
+    )
+    controllog.model_completion(
+        exchange_id=xid,
+        task_id="t1", agent_id="a", run_id="r", project_id="test",
+        provider="openai", model="gpt-5", completion_tokens=10, wall_ms=500,
+    )
+    events = read_events()
+    kinds = {e["kind"] for e in events}
+    assert kinds == {"model_prompt", "model_completion"}
+    xids = {e["payload_json"]["exchange_id"] for e in events}
+    assert xids == {xid}
+
+
+def test_model_completion_requires_exchange_id(log_dir):
+    with pytest.raises(TypeError):
+        controllog.model_completion(  # type: ignore[call-arg]
+            task_id="t1", agent_id="a", run_id="r", project_id="test",
+            provider="openai", model="gpt-5", completion_tokens=10, wall_ms=500,
+        )
+
+
+def test_model_call_idempotency_keys_use_exchange_id(log_dir, read_events):
+    """Spec § 5.1 — idempotency keys are {exchange_id}:prompt and :completion."""
+    xid = controllog.model_prompt(
+        task_id="t1", agent_id="a", run_id="r", project_id="test",
+        provider="openai", model="gpt-5", prompt_tokens=10,
+    )
+    controllog.model_completion(
+        exchange_id=xid,
+        task_id="t1", agent_id="a", run_id="r", project_id="test",
+        provider="openai", model="gpt-5", completion_tokens=5, wall_ms=100,
+    )
+    events = read_events()
+    by_kind = {e["kind"]: e for e in events}
+    assert by_kind["model_prompt"]["idempotency_key"] == f"{xid}:prompt"
+    assert by_kind["model_completion"]["idempotency_key"] == f"{xid}:completion"
+
+
+def test_model_completion_postings_balance(log_dir, read_postings):
+    """Tokens, time, money must all sum to zero per (account_type, unit)."""
+    xid = controllog.model_prompt(
+        task_id="t1", agent_id="a", run_id="r", project_id="test",
+        provider="openai", model="gpt-5", prompt_tokens=100,
+    )
+    controllog.model_completion(
+        exchange_id=xid,
+        task_id="t1", agent_id="a", run_id="r", project_id="test",
+        provider="openai", model="gpt-5", completion_tokens=10, wall_ms=500,
+        cost_money=0.002,
+    )
+    by_key: dict[tuple[str, str], float] = {}
+    for p in read_postings():
+        key = (p["account_type"], p["unit"])
+        by_key[key] = by_key.get(key, 0.0) + p["delta_numeric"]
+    # Every (account_type, unit) must sum to zero
+    assert all(abs(v) < 1e-9 for v in by_key.values()), by_key
+
+
+# -------------------------
+# state_move (spec § 6 — exactly-once lifecycle)
+# -------------------------
+
+
+def test_state_move_default_idempotency_key(log_dir, read_events):
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
+    e = read_events()[0]
+    assert e["idempotency_key"] == "t1:NEW:WIP"
+
+
+def test_state_move_retry_collapses_event_id(log_dir, read_events):
+    """Retried state_move keeps same event_id so MD PK dedupes on upload."""
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
+    events = read_events()
+    assert len(events) == 2  # local JSONL keeps both rows
+    assert events[0]["event_id"] == events[1]["event_id"]
+
+
+def test_state_move_different_transitions_distinct(log_dir, read_events):
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
+    controllog.state_move(task_id="t1", from_="WIP", to="DONE", project_id="test")
+    events = read_events()
+    keys = {e["idempotency_key"] for e in events}
+    assert keys == {"t1:NEW:WIP", "t1:WIP:DONE"}
+
+
+def test_state_move_custom_idempotency_key(log_dir, read_events):
+    controllog.state_move(
+        task_id="t1", from_="NEW", to="WIP", project_id="test",
+        idempotency_key="custom-key",
+    )
+    assert read_events()[0]["idempotency_key"] == "custom-key"
+
+
+# -------------------------
+# utility
+# -------------------------
+
+
+def test_utility_balances(log_dir, read_postings):
+    controllog.utility(task_id="t1", project_id="test", metric="reward", value=0.7)
+    p = read_postings()
+    assert len(p) == 2
+    assert all(row["account_type"] == "truth.utility" for row in p)
+    assert sum(row["delta_numeric"] for row in p) == pytest.approx(0.0)

--- a/projects/controllog/tests/test_builders.py
+++ b/projects/controllog/tests/test_builders.py
@@ -131,3 +131,81 @@ def test_utility_balances(log_dir, read_postings):
     assert len(p) == 2
     assert all(row["account_type"] == "truth.utility" for row in p)
     assert sum(row["delta_numeric"] for row in p) == pytest.approx(0.0)
+
+
+# -------------------------
+# vendor account uses provider (not hardcoded openrouter)
+# -------------------------
+
+
+def test_cost_posting_uses_provider_argument(log_dir, read_postings):
+    """truth.money should land on vendor:{provider}, not vendor:openrouter."""
+    xid = controllog.model_prompt(
+        task_id="t1", agent_id="a", project_id="test",
+        provider="anthropic", model="claude-sonnet", prompt_tokens=100,
+    )
+    controllog.model_completion(
+        exchange_id=xid,
+        task_id="t1", agent_id="a", project_id="test",
+        provider="anthropic", model="claude-sonnet",
+        completion_tokens=10, wall_ms=500, cost_money=0.005,
+    )
+    money_postings = [p for p in read_postings() if p["account_type"] == "truth.money"]
+    vendors = {p["account_id"] for p in money_postings if p["account_id"].startswith("vendor:")}
+    assert vendors == {"vendor:anthropic"}, f"unexpected vendors: {vendors}"
+
+
+def test_upstream_cost_lands_on_vendor_upstream(log_dir, read_postings):
+    xid = controllog.model_prompt(
+        task_id="t1", agent_id="a", project_id="test",
+        provider="openrouter", model="gpt-5", prompt_tokens=100,
+    )
+    controllog.model_completion(
+        exchange_id=xid,
+        task_id="t1", agent_id="a", project_id="test",
+        provider="openrouter", model="gpt-5",
+        completion_tokens=10, wall_ms=500,
+        cost_money=0.001, upstream_cost_money=0.0008,
+    )
+    money_postings = [p for p in read_postings() if p["account_type"] == "truth.money"]
+    vendors = {p["account_id"] for p in money_postings if p["account_id"].startswith("vendor:")}
+    assert vendors == {"vendor:openrouter", "vendor:upstream"}
+
+
+# -------------------------
+# Required project_id (no None placeholder)
+# -------------------------
+
+
+def test_builders_reject_missing_project_id(log_dir):
+    """Without project_id, postings would record account_id='project:None'."""
+    with pytest.raises(TypeError):
+        controllog.model_prompt(  # type: ignore[call-arg]
+            task_id="t1", agent_id="a",
+            provider="openai", model="gpt-5", prompt_tokens=100,
+        )
+    with pytest.raises(TypeError):
+        controllog.state_move(  # type: ignore[call-arg]
+            task_id="t1", from_="NEW", to="WIP",
+        )
+
+
+# -------------------------
+# No placeholder payloads
+# -------------------------
+
+
+def test_state_move_omits_payload_when_none(log_dir, read_events):
+    """Spec § 6 transitions shouldn't carry a placeholder reason=null."""
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
+    e = read_events()[0]
+    assert "reason" not in e["payload_json"]
+    assert e["payload_json"] == {}
+
+
+def test_state_move_preserves_caller_payload(log_dir, read_events):
+    controllog.state_move(
+        task_id="t1", from_="NEW", to="WIP", project_id="test",
+        payload={"reason": "operator-resumed"},
+    )
+    assert read_events()[0]["payload_json"]["reason"] == "operator-resumed"

--- a/projects/controllog/tests/test_builders.py
+++ b/projects/controllog/tests/test_builders.py
@@ -133,6 +133,14 @@ def test_utility_balances(log_dir, read_postings):
     assert sum(row["delta_numeric"] for row in p) == pytest.approx(0.0)
 
 
+def test_utility_omits_payload_when_none(log_dir, read_events):
+    """metric and value are already on the postings — no need for a payload placeholder."""
+    controllog.utility(task_id="t1", project_id="test", metric="reward", value=1.0)
+    e = read_events()[0]
+    # No {"metric": ..., "value": ...} placeholder when caller passes no payload
+    assert e["payload_json"] == {}
+
+
 # -------------------------
 # vendor account uses provider (not hardcoded openrouter)
 # -------------------------
@@ -153,23 +161,6 @@ def test_cost_posting_uses_provider_argument(log_dir, read_postings):
     money_postings = [p for p in read_postings() if p["account_type"] == "truth.money"]
     vendors = {p["account_id"] for p in money_postings if p["account_id"].startswith("vendor:")}
     assert vendors == {"vendor:anthropic"}, f"unexpected vendors: {vendors}"
-
-
-def test_upstream_cost_lands_on_vendor_upstream(log_dir, read_postings):
-    xid = controllog.model_prompt(
-        task_id="t1", agent_id="a", project_id="test",
-        provider="openrouter", model="gpt-5", prompt_tokens=100,
-    )
-    controllog.model_completion(
-        exchange_id=xid,
-        task_id="t1", agent_id="a", project_id="test",
-        provider="openrouter", model="gpt-5",
-        completion_tokens=10, wall_ms=500,
-        cost_money=0.001, upstream_cost_money=0.0008,
-    )
-    money_postings = [p for p in read_postings() if p["account_type"] == "truth.money"]
-    vendors = {p["account_id"] for p in money_postings if p["account_id"].startswith("vendor:")}
-    assert vendors == {"vendor:openrouter", "vendor:upstream"}
 
 
 # -------------------------

--- a/projects/controllog/tests/test_motherduck.py
+++ b/projects/controllog/tests/test_motherduck.py
@@ -1,0 +1,210 @@
+"""Tests for controllog.motherduck — runs against an in-memory DuckDB.
+
+The real MotherDuck client connects via ``duckdb.connect("md:...")``; we
+monkeypatch ``_connect`` to hand back an in-memory DuckDB instance so the
+SQL paths (table creation, upload dedupe, ID verification) run end-to-end
+without a MotherDuck token.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+import controllog
+from controllog import motherduck
+
+
+class _SharedConn:
+    """Proxy that no-ops close() so the in-memory DB survives across calls.
+
+    motherduck.upload / verify / cleanup_local each wrap their work in
+    ``try / finally: md.close()``. DuckDB connection attributes are
+    read-only, so we proxy instead of patching.
+    """
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+    def close(self):
+        pass  # leave the underlying conn alive for the test
+
+
+@pytest.fixture
+def md_conn(monkeypatch):
+    """In-memory DuckDB that mimics MotherDuck across multiple calls."""
+    real_conn = duckdb.connect(":memory:")
+    proxy = _SharedConn(real_conn)
+    monkeypatch.setattr(motherduck, "_connect", lambda *a, **k: proxy)
+    yield real_conn
+    real_conn.close()
+
+
+def _emit_sample(project: str = "test") -> str:
+    """Emit one paired model call. Returns the exchange_id."""
+    xid = controllog.model_prompt(
+        task_id="t1", agent_id="a", run_id="r", project_id=project,
+        provider="openai", model="gpt-5", prompt_tokens=100,
+    )
+    controllog.model_completion(
+        exchange_id=xid,
+        task_id="t1", agent_id="a", run_id="r", project_id=project,
+        provider="openai", model="gpt-5",
+        completion_tokens=10, wall_ms=500, cost_money=0.002,
+    )
+    return xid
+
+
+# -------------------------
+# upload()
+# -------------------------
+
+
+def test_upload_creates_schema_and_inserts(log_dir, md_conn):
+    _emit_sample()
+    result = motherduck.upload(motherduck_db="x", log_dir=log_dir)
+    assert result["events"] == 2
+    assert result["postings"] > 0
+
+    assert md_conn.execute("SELECT COUNT(*) FROM controllog.events").fetchone()[0] == 2
+    n_postings = md_conn.execute("SELECT COUNT(*) FROM controllog.postings").fetchone()[0]
+    assert n_postings > 0
+
+
+def test_upload_is_idempotent(log_dir, md_conn):
+    _emit_sample()
+    first = motherduck.upload(motherduck_db="x", log_dir=log_dir)
+    second = motherduck.upload(motherduck_db="x", log_dir=log_dir)
+    # Second pass inserts nothing — same IDs already there
+    assert second["events"] == 0
+    assert second["postings"] == 0
+    # Total still matches first pass
+    assert md_conn.execute("SELECT COUNT(*) FROM controllog.events").fetchone()[0] == first["events"]
+
+
+def test_upload_handles_duplicate_local_rows(log_dir, md_conn, read_events):
+    """Retries write duplicate event_ids locally — QUALIFY ROW_NUMBER dedupes
+    inside the batch so the PRIMARY KEY constraint doesn't reject the INSERT."""
+    # Two retries of the same state transition → same event_id on disk
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
+    events = read_events()
+    assert len(events) == 2
+    assert events[0]["event_id"] == events[1]["event_id"]
+
+    result = motherduck.upload(motherduck_db="x", log_dir=log_dir)
+    assert result["events"] == 1
+    assert md_conn.execute("SELECT COUNT(*) FROM controllog.events").fetchone()[0] == 1
+
+
+def test_upload_raises_on_missing_files(log_dir, md_conn):
+    with pytest.raises(FileNotFoundError):
+        motherduck.upload(motherduck_db="x", log_dir=log_dir)
+
+
+def test_upload_finds_partitioned_files(tmp_path, md_conn):
+    controllog.init(project_id="t", log_dir=tmp_path, partition_by_date=True)
+    _emit_sample(project="t")
+    result = motherduck.upload(motherduck_db="x", log_dir=tmp_path)
+    assert result["events"] == 2
+
+
+# -------------------------
+# verify()
+# -------------------------
+
+
+def test_verify_reports_counts_and_kinds(log_dir, md_conn):
+    _emit_sample()
+    motherduck.upload(motherduck_db="x", log_dir=log_dir)
+    out = motherduck.verify(motherduck_db="x")
+
+    assert out["events"] == 2
+    assert out["postings"] > 0
+    assert out["event_kinds"] == {"model_prompt": 1, "model_completion": 1}
+    # Per spec § 8.2 trial balance: no violations on a clean upload
+    assert out["trial_balance_violations"] == []
+
+
+def test_verify_catches_trial_balance_violation(log_dir, md_conn):
+    """If postings.dims_json gets corrupted s.t. totals don't net to zero,
+    verify() must surface the slice that's off."""
+    _emit_sample()
+    motherduck.upload(motherduck_db="x", log_dir=log_dir)
+    # Manually insert an unbalanced posting (bypassing the SDK)
+    md_conn.execute("""
+        INSERT INTO controllog.postings VALUES (
+            'bad-id', 'unknown-event', 'truth.money', 'project:test',
+            '$', 99.99, '{}'::JSON
+        )
+    """)
+    out = motherduck.verify(motherduck_db="x")
+    assert any(v["account_type"] == "truth.money" for v in out["trial_balance_violations"])
+
+
+# -------------------------
+# cleanup_local()
+# -------------------------
+
+
+def test_cleanup_local_deletes_after_verification(log_dir, md_conn):
+    _emit_sample()
+    motherduck.upload(motherduck_db="x", log_dir=log_dir)
+
+    events_file = log_dir / "controllog" / "events.jsonl"
+    postings_file = log_dir / "controllog" / "postings.jsonl"
+    assert events_file.exists() and postings_file.exists()
+
+    result = motherduck.cleanup_local(log_dir=log_dir, motherduck_db="x")
+    assert result["files_deleted"] == 2
+    assert not events_file.exists()
+    assert not postings_file.exists()
+
+
+def test_cleanup_local_refuses_when_ids_missing(log_dir, md_conn):
+    """Naïve count comparison would pass spuriously if unrelated rows exist.
+    Per-ID verification must catch this."""
+    _emit_sample()
+    # Don't upload. Instead, plant unrelated rows so the remote count >= local count.
+    motherduck.upload(motherduck_db="x", log_dir=log_dir)  # populates schema
+    md_conn.execute("DELETE FROM controllog.events")
+    md_conn.execute("DELETE FROM controllog.postings")
+    md_conn.execute("""
+        INSERT INTO controllog.events VALUES (
+            'unrelated-1', NOW(), NOW(), 'x', 'other', 'sdk', 'k1', '{}'::JSON,
+            NULL, NULL, NULL
+        )
+    """)
+    md_conn.execute("""
+        INSERT INTO controllog.events VALUES (
+            'unrelated-2', NOW(), NOW(), 'x', 'other', 'sdk', 'k2', '{}'::JSON,
+            NULL, NULL, NULL
+        )
+    """)
+
+    with pytest.raises(RuntimeError, match="not present"):
+        motherduck.cleanup_local(log_dir=log_dir, motherduck_db="x")
+    # Files still on disk
+    assert (log_dir / "controllog" / "events.jsonl").exists()
+
+
+def test_cleanup_local_dry_run(log_dir, md_conn):
+    _emit_sample()
+    motherduck.upload(motherduck_db="x", log_dir=log_dir)
+    result = motherduck.cleanup_local(log_dir=log_dir, motherduck_db="x", dry_run=True)
+    assert result["dry_run"] is True
+    assert result["files_deleted"] == 0
+    assert (log_dir / "controllog" / "events.jsonl").exists()
+
+
+def test_cleanup_local_skip_verification(log_dir, md_conn):
+    _emit_sample()
+    # No upload — verify_uploaded=False bypasses the check
+    result = motherduck.cleanup_local(
+        log_dir=log_dir, motherduck_db="x", verify_uploaded=False
+    )
+    assert result["files_deleted"] == 2

--- a/projects/controllog/tests/test_motherduck.py
+++ b/projects/controllog/tests/test_motherduck.py
@@ -208,3 +208,50 @@ def test_cleanup_local_skip_verification(log_dir, md_conn):
         log_dir=log_dir, motherduck_db="x", verify_uploaded=False
     )
     assert result["files_deleted"] == 2
+
+
+def test_cleanup_local_empty_dir_is_true_no_op(tmp_path, monkeypatch):
+    """No JSONL → no MotherDuck connection should be opened at all."""
+    calls = []
+    monkeypatch.setattr(
+        motherduck, "_connect",
+        lambda *a, **k: calls.append((a, k)) or (_ for _ in ()).throw(
+            AssertionError("should not connect on empty dir")
+        ),
+    )
+    # No init(), no files written — dir is bare.
+    result = motherduck.cleanup_local(log_dir=tmp_path, motherduck_db="x")
+    assert calls == []
+    assert result["files_deleted"] == 0
+    assert result["local_events"] == 0
+
+
+# -------------------------
+# SQL identifier safety
+# -------------------------
+
+
+def test_upload_rejects_unsafe_schema_name(log_dir, md_conn):
+    """Schema names get interpolated into DDL — must be validated."""
+    _emit_sample()
+    with pytest.raises(ValueError, match="unsafe SQL identifier"):
+        motherduck.upload(motherduck_db="x", log_dir=log_dir, schema="bad; DROP TABLE")
+
+
+def test_verify_rejects_unsafe_schema_name(md_conn):
+    with pytest.raises(ValueError, match="unsafe SQL identifier"):
+        motherduck.verify(motherduck_db="x", schema='"; DROP TABLE events; --')
+
+
+def test_cleanup_local_rejects_unsafe_schema_name(log_dir, md_conn):
+    _emit_sample()
+    with pytest.raises(ValueError, match="unsafe SQL identifier"):
+        motherduck.cleanup_local(log_dir=log_dir, motherduck_db="x", schema="x.y")
+
+
+def test_safe_schema_names_pass(log_dir, md_conn):
+    """Underscored / alpha names are fine."""
+    _emit_sample()
+    motherduck.upload(motherduck_db="x", log_dir=log_dir, schema="my_eval_2")
+    out = motherduck.verify(motherduck_db="x", schema="my_eval_2")
+    assert out["events"] == 2

--- a/projects/controllog/tests/test_motherduck.py
+++ b/projects/controllog/tests/test_motherduck.py
@@ -47,12 +47,12 @@ def md_conn(monkeypatch):
 def _emit_sample(project: str = "test") -> str:
     """Emit one paired model call. Returns the exchange_id."""
     xid = controllog.model_prompt(
-        task_id="t1", agent_id="a", run_id="r", project_id=project,
+        task_id="t1", agent_id="a", run_id="r",
         provider="openai", model="gpt-5", prompt_tokens=100,
     )
     controllog.model_completion(
         exchange_id=xid,
-        task_id="t1", agent_id="a", run_id="r", project_id=project,
+        task_id="t1", agent_id="a", run_id="r",
         provider="openai", model="gpt-5",
         completion_tokens=10, wall_ms=500, cost_money=0.002,
     )
@@ -90,8 +90,8 @@ def test_upload_handles_duplicate_local_rows(log_dir, md_conn, read_events):
     """Retries write duplicate event_ids locally — QUALIFY ROW_NUMBER dedupes
     inside the batch so the PRIMARY KEY constraint doesn't reject the INSERT."""
     # Two retries of the same state transition → same event_id on disk
-    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
-    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP")
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP")
     events = read_events()
     assert len(events) == 2
     assert events[0]["event_id"] == events[1]["event_id"]

--- a/projects/controllog/tests/test_motherduck.py
+++ b/projects/controllog/tests/test_motherduck.py
@@ -106,13 +106,6 @@ def test_upload_raises_on_missing_files(log_dir, md_conn):
         motherduck.upload(motherduck_db="x", log_dir=log_dir)
 
 
-def test_upload_finds_partitioned_files(tmp_path, md_conn):
-    controllog.init(project_id="t", log_dir=tmp_path, partition_by_date=True)
-    _emit_sample(project="t")
-    result = motherduck.upload(motherduck_db="x", log_dir=tmp_path)
-    assert result["events"] == 2
-
-
 # -------------------------
 # verify()
 # -------------------------
@@ -227,31 +220,16 @@ def test_cleanup_local_empty_dir_is_true_no_op(tmp_path, monkeypatch):
 
 
 # -------------------------
-# SQL identifier safety
+# Schema is hardcoded per spec §10.1
 # -------------------------
 
 
-def test_upload_rejects_unsafe_schema_name(log_dir, md_conn):
-    """Schema names get interpolated into DDL — must be validated."""
+def test_schema_is_hardcoded(log_dir, md_conn):
+    """The library writes to controllog.events / controllog.postings — no override."""
     _emit_sample()
-    with pytest.raises(ValueError, match="unsafe SQL identifier"):
-        motherduck.upload(motherduck_db="x", log_dir=log_dir, schema="bad; DROP TABLE")
-
-
-def test_verify_rejects_unsafe_schema_name(md_conn):
-    with pytest.raises(ValueError, match="unsafe SQL identifier"):
-        motherduck.verify(motherduck_db="x", schema='"; DROP TABLE events; --')
-
-
-def test_cleanup_local_rejects_unsafe_schema_name(log_dir, md_conn):
-    _emit_sample()
-    with pytest.raises(ValueError, match="unsafe SQL identifier"):
-        motherduck.cleanup_local(log_dir=log_dir, motherduck_db="x", schema="x.y")
-
-
-def test_safe_schema_names_pass(log_dir, md_conn):
-    """Underscored / alpha names are fine."""
-    _emit_sample()
-    motherduck.upload(motherduck_db="x", log_dir=log_dir, schema="my_eval_2")
-    out = motherduck.verify(motherduck_db="x", schema="my_eval_2")
-    assert out["events"] == 2
+    motherduck.upload(motherduck_db="x", log_dir=log_dir)
+    n = md_conn.execute("SELECT COUNT(*) FROM controllog.events").fetchone()[0]
+    assert n == 2
+    # No schema= kwarg accepted on any public function
+    with pytest.raises(TypeError):
+        motherduck.upload(motherduck_db="x", log_dir=log_dir, schema="other")  # type: ignore[call-arg]

--- a/projects/controllog/tests/test_sdk.py
+++ b/projects/controllog/tests/test_sdk.py
@@ -25,17 +25,11 @@ def test_is_initialized_round_trip(tmp_path):
     assert controllog.is_initialized() is True
 
 
-def test_flat_layout_is_default(log_dir):
+def test_flat_layout_is_spec(log_dir):
+    """Spec §3.2 — flat layout, no partitioning options."""
     controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
     assert (log_dir / "controllog" / "events.jsonl").exists()
-    assert not list((log_dir / "controllog").glob("20*/events.jsonl"))
-
-
-def test_partition_by_date(tmp_path):
-    controllog.init(project_id="t", log_dir=tmp_path, partition_by_date=True)
-    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="t")
-    found = list((tmp_path / "controllog").glob("*/events.jsonl"))
-    assert len(found) == 1, found
+    assert (log_dir / "controllog" / "postings.jsonl").exists()
 
 
 # -------------------------

--- a/projects/controllog/tests/test_sdk.py
+++ b/projects/controllog/tests/test_sdk.py
@@ -1,0 +1,229 @@
+"""Tests for controllog.sdk — init / event / post / invariants / idempotency."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import controllog
+
+
+# -------------------------
+# init() and layout
+# -------------------------
+
+
+def test_init_required_before_use(tmp_path):
+    with pytest.raises(AssertionError, match="init"):
+        controllog.event(kind="x", postings=[])
+
+
+def test_is_initialized_round_trip(tmp_path):
+    assert controllog.is_initialized() is False
+    controllog.init(project_id="t", log_dir=tmp_path)
+    assert controllog.is_initialized() is True
+
+
+def test_flat_layout_is_default(log_dir):
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
+    assert (log_dir / "controllog" / "events.jsonl").exists()
+    assert not list((log_dir / "controllog").glob("20*/events.jsonl"))
+
+
+def test_partition_by_date(tmp_path):
+    controllog.init(project_id="t", log_dir=tmp_path, partition_by_date=True)
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="t")
+    found = list((tmp_path / "controllog").glob("*/events.jsonl"))
+    assert len(found) == 1, found
+
+
+# -------------------------
+# new_id() / UUIDv7
+# -------------------------
+
+
+def test_new_id_is_uuid7_and_sortable():
+    import time
+    ids = []
+    for _ in range(5):
+        ids.append(controllog.new_id())
+        time.sleep(0.002)
+    # Sortable by time
+    assert ids == sorted(ids)
+    # UUID format
+    import uuid
+    for s in ids:
+        u = uuid.UUID(s)
+        assert u.version == 7
+
+
+# -------------------------
+# post()
+# -------------------------
+
+
+def test_post_returns_only_accounting_fields():
+    p = controllog.post("truth.state", "task:t1", "tasks", -1, {"from": "NEW"})
+    assert set(p.keys()) == {"account_type", "account_id", "unit", "delta_numeric", "dims_json"}
+    assert p["delta_numeric"] == -1.0  # coerced to float
+    assert p["dims_json"] == {"from": "NEW"}
+
+
+def test_post_dims_default_empty():
+    p = controllog.post("x", "y", "z", 1)
+    assert p["dims_json"] == {}
+
+
+# -------------------------
+# Invariants (§ 8.1)
+# -------------------------
+
+
+def test_balanced_postings_pass(log_dir, read_postings):
+    controllog.event(
+        kind="t",
+        postings=[
+            controllog.post("truth.state", "task:1", "tasks", -1),
+            controllog.post("truth.state", "task:1", "tasks", +1),
+        ],
+    )
+    assert len(read_postings()) == 2
+
+
+def test_unbalanced_postings_raise(log_dir):
+    with pytest.raises(ValueError, match="UNBALANCED_POSTINGS"):
+        controllog.event(
+            kind="t",
+            postings=[
+                controllog.post("truth.state", "task:1", "tasks", -1),
+                controllog.post("truth.state", "task:1", "tasks", +2),  # net=+1
+            ],
+        )
+
+
+def test_custom_account_namespace_still_balanced(log_dir):
+    """Spec § 8.1 — every account_type, including extensions, must balance."""
+    with pytest.raises(ValueError, match="mydomain.custom"):
+        controllog.event(
+            kind="t",
+            postings=[
+                controllog.post("mydomain.custom", "a", "units", 1.0),
+                controllog.post("mydomain.custom", "b", "units", 2.0),  # net=+3
+            ],
+        )
+
+
+def test_separate_units_balanced_independently(log_dir, read_postings):
+    """Two account_types or two units don't 'borrow' from each other."""
+    with pytest.raises(ValueError, match="UNBALANCED_POSTINGS"):
+        controllog.event(
+            kind="t",
+            postings=[
+                controllog.post("truth.state", "task:1", "tasks", -1),
+                controllog.post("truth.state", "task:1", "tasks", +1),
+                controllog.post("truth.money", "vendor:x", "$", -1.0),
+                # missing: matching +1.0 to project on truth.money
+            ],
+        )
+
+
+def test_empty_postings_no_invariant(log_dir, read_events):
+    """Events with no postings are valid (lifecycle markers per spec § 15)."""
+    controllog.event(kind="marker", postings=[], idempotency_key="m1")
+    assert len(read_events()) == 1
+
+
+# -------------------------
+# default_dims (must land in payload_json / dims_json, not top-level)
+# -------------------------
+
+
+def test_default_dims_merge_into_payload_and_dims(tmp_path, read_events, read_postings):
+    controllog.init(
+        project_id="t",
+        log_dir=tmp_path,
+        default_dims={"arm": "baseline", "split": "train"},
+    )
+    controllog.event(
+        kind="x",
+        payload={"q": 42},
+        postings=[
+            controllog.post("truth.state", "task:1", "tasks", -1, {"from": "NEW"}),
+            controllog.post("truth.state", "task:1", "tasks", +1, {"to": "WIP"}),
+        ],
+    )
+    e = read_events()[0]
+    # NOT spread at top level
+    assert "arm" not in e
+    assert "split" not in e
+    # Merged into payload_json
+    assert e["payload_json"]["arm"] == "baseline"
+    assert e["payload_json"]["split"] == "train"
+    assert e["payload_json"]["q"] == 42
+
+    # Merged into each posting's dims_json
+    p = read_postings()
+    assert all(row["dims_json"]["arm"] == "baseline" for row in p)
+    assert all(row["dims_json"]["split"] == "train" for row in p)
+    # Per-posting dims preserved alongside defaults
+    assert {row["dims_json"].get("from") or row["dims_json"].get("to") for row in p} == {"NEW", "WIP"}
+
+
+def test_payload_dim_overrides_default(tmp_path, read_events):
+    controllog.init(project_id="t", log_dir=tmp_path, default_dims={"arm": "baseline"})
+    controllog.event(kind="x", payload={"arm": "overridden"}, postings=[])
+    assert read_events()[0]["payload_json"]["arm"] == "overridden"
+
+
+# -------------------------
+# Idempotency (§ 11)
+# -------------------------
+
+
+def test_deterministic_event_id_from_idempotency_key(log_dir, read_events):
+    """Same project + idempotency_key → same event_id (so MD PK dedupes on upload)."""
+    controllog.event(kind="x", postings=[], idempotency_key="abc")
+    controllog.event(kind="x", postings=[], idempotency_key="abc")  # retry
+
+    events = read_events()
+    assert len(events) == 2  # both rows on disk (process doesn't dedupe locally)
+    assert events[0]["event_id"] == events[1]["event_id"]
+
+
+def test_deterministic_posting_id_from_idempotency_key(log_dir, read_postings):
+    """Posting IDs collapse on retry too — otherwise dedupe at upload fails."""
+    for _ in range(2):
+        controllog.event(
+            kind="x",
+            idempotency_key="k1",
+            postings=[
+                controllog.post("truth.state", "task:1", "tasks", -1),
+                controllog.post("truth.state", "task:1", "tasks", +1),
+            ],
+        )
+    p = read_postings()
+    # 4 rows on disk, but only 2 distinct posting_ids
+    assert len(p) == 4
+    assert len({row["posting_id"] for row in p}) == 2
+
+
+def test_event_id_differs_across_projects(tmp_path):
+    """Same idempotency_key under different project_id must NOT collide."""
+    controllog.init(project_id="p1", log_dir=tmp_path)
+    controllog.event(kind="x", postings=[], idempotency_key="abc")
+    e1_id = (tmp_path / "controllog" / "events.jsonl").read_text().splitlines()[-1]
+
+    controllog.init(project_id="p2", log_dir=tmp_path)
+    controllog.event(kind="x", postings=[], idempotency_key="abc")
+    e2_id = (tmp_path / "controllog" / "events.jsonl").read_text().splitlines()[-1]
+
+    import json
+    assert json.loads(e1_id)["event_id"] != json.loads(e2_id)["event_id"]
+
+
+def test_no_idempotency_key_gets_random_id(log_dir, read_events):
+    """Without idempotency_key, each call gets a fresh random event_id."""
+    controllog.event(kind="x", postings=[])
+    controllog.event(kind="x", postings=[])
+    events = read_events()
+    assert events[0]["event_id"] != events[1]["event_id"]

--- a/projects/controllog/tests/test_sdk.py
+++ b/projects/controllog/tests/test_sdk.py
@@ -27,7 +27,7 @@ def test_is_initialized_round_trip(tmp_path):
 
 def test_flat_layout_is_spec(log_dir):
     """Spec §3.2 — flat layout, no partitioning options."""
-    controllog.state_move(task_id="t1", from_="NEW", to="WIP", project_id="test")
+    controllog.state_move(task_id="t1", from_="NEW", to="WIP")
     assert (log_dir / "controllog" / "events.jsonl").exists()
     assert (log_dir / "controllog" / "postings.jsonl").exists()
 
@@ -126,6 +126,12 @@ def test_empty_postings_no_invariant(log_dir, read_events):
     """Events with no postings are valid (lifecycle markers per spec § 15)."""
     controllog.event(kind="marker", postings=[], idempotency_key="m1")
     assert len(read_events()) == 1
+
+
+def test_event_default_source_matches_builders(log_dir, read_events):
+    """Raw event() defaults to source='runtime' to match builder output."""
+    controllog.event(kind="custom", postings=[])
+    assert read_events()[0]["source"] == "runtime"
 
 
 # -------------------------

--- a/projects/controllog/tests/test_sdk.py
+++ b/projects/controllog/tests/test_sdk.py
@@ -14,7 +14,8 @@ import controllog
 
 
 def test_init_required_before_use(tmp_path):
-    with pytest.raises(AssertionError, match="init"):
+    """Use RuntimeError (not assert) so the check survives python -O."""
+    with pytest.raises(RuntimeError, match="init"):
         controllog.event(kind="x", postings=[])
 
 


### PR DESCRIPTION
First in a stack of four. Adds the **controllog** library to the labs monorepo.

Lean, functional API extracted from the working implementations in `~/code/agentic-sql` and `~/code/eval-connections`, plus the MotherDuck upload/cleanup/verify code from `labs/projects/bird-bench`. Implements the v1.1 spec (events + balanced postings, JSONL transport).

## Layout

\`\`\`
controllog/
├── docs/spec-v1.1.md             # canonical spec, promoted from agentic-sql
└── src/controllog/
    ├── sdk.py                    # init, event, post, new_id, is_initialized
    ├── builders.py               # model_prompt, model_completion, model_response,
    │                             # state_move, utility, agent_run
    └── motherduck.py             # upload, cleanup_local, verify (under [duckdb] extra)
\`\`\`

## Notes

- Zero required deps; \`duckdb\` is optional via \`[duckdb]\` extra
- JSONL layout is flat by default (\`log_dir/controllog/{events,postings}.jsonl\`); pass \`partition_by_date=True\` for date-partitioned layout. Uploader handles both
- README updated to list controllog as a sibling project
- No consumers migrated in this PR — see follow-ups #02 / #03 / #04

## Stack

- **01 (this PR)** → controllog library
- 02 → bird-bench migration
- 03 → connections-eval-mini migration
- 04 → agentic-sql-mini adoption