### PR TITLE
04/04 — agentic-sql-mini: adopt controllog

### DIFF
--- a/projects/agentic-sql-mini/.gitignore
+++ b/projects/agentic-sql-mini/.gitignore
@@ -4,5 +4,6 @@ __pycache__/
 .env
 results/*.jsonl
 results/_*.log
+results/controllog/
 *.db
 .DS_Store

--- a/projects/agentic-sql-mini/pyproject.toml
+++ b/projects/agentic-sql-mini/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "openai-agents>=0.12.5",
     "python-dotenv>=1.2.2",
     "rich>=13.0",
+    "controllog",
 ]
 
 [project.scripts]
@@ -21,6 +22,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
+
+[tool.uv.sources]
+controllog = { git = "https://github.com/motherduckdb/labs", subdirectory = "projects/controllog" }
 
 [tool.ruff]
 target-version = "py311"

--- a/projects/agentic-sql-mini/src/run.py
+++ b/projects/agentic-sql-mini/src/run.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import click
+import controllog
 import duckdb
 from dotenv import load_dotenv
 from rich.console import Console
@@ -267,6 +268,20 @@ async def _evaluate_loop(
     f = out.open("w")
     wall_t0 = time.time()
 
+    # Fresh per-invocation run_id (uuid7, sortable by time). out.stem is just
+    # a human-readable label — relying on it for run_id breaks when --out is
+    # reused, because deterministic controllog event_ids would collapse the
+    # new run's rows into the prior run at upload time.
+    run_id = controllog.new_id()
+    controllog.init(
+        project_id="agentic-sql-mini",
+        log_dir=RESULTS_DIR,
+        default_dims={
+            "arm": arm, "split": split, "model": model,
+            "run_id": run_id, "run_label": out.stem,
+        },
+    )
+
     async def run_one(q: dict) -> None:
         nonlocal correct, total_cost, total_elapsed, total_turns, n_hit_limit, completed
         tid = str(q["task_id"])
@@ -290,6 +305,16 @@ async def _evaluate_loop(
                 gold_text.append("gold: ", style="dim")
                 gold_text.append(str(q.get("answer")), style="green")
                 console.print(Padding(gold_text, (0, 0, 0, 4)))
+
+            # Spec § 6 lifecycle: NEW -> WIP before terminal transition.
+            # Idempotency key scoped to run_id so re-running the same arm/split
+            # gets a fresh event_id; without it the deterministic uuid5 would
+            # collapse across runs.
+            controllog.state_move(
+                task_id=tid, from_="NEW", to="WIP",
+                agent_id="asm-sql", run_id=run_id,
+                idempotency_key=f"{run_id}:{tid}:NEW:WIP",
+            )
 
             conn = duckdb.connect(str(db), read_only=True)
             t0 = time.time()
@@ -364,6 +389,43 @@ async def _evaluate_loop(
                 "error": err,
                 "ts": datetime.now(timezone.utc).isoformat(),
             }
+
+            # One balanced task_complete event covering all the accounting for
+            # this question. Built directly with event() + post() since the lib's
+            # generic builders are per-model-call, not per-task-aggregate.
+            project_id = "agentic-sql-mini"
+            total_tokens = (run.prompt_tokens + run.completion_tokens) if run else 0
+            wall_ms = int(elapsed * 1000)
+            reward = 1.0 if result.is_correct else 0.0
+            terminal_state = "DONE" if run is not None else "FAILED"
+            postings = [
+                controllog.post("resource.tokens", "provider:openrouter", "+tokens", -total_tokens, {"model": model}),
+                controllog.post("resource.tokens", f"project:{project_id}", "+tokens", +total_tokens, {"model": model}),
+                controllog.post("truth.time", "agent:asm-sql", "ms", -wall_ms, {"kind": "wall"}),
+                controllog.post("truth.time", f"project:{project_id}", "ms", +wall_ms, {"kind": "wall"}),
+                controllog.post("truth.money", "vendor:openrouter", "$", -float(cost), {"model": model}),
+                controllog.post("truth.money", f"project:{project_id}", "$", +float(cost), {"model": model}),
+                controllog.post("truth.state", f"task:{tid}", "tasks", -1, {"from": "WIP"}),
+                controllog.post("truth.state", f"task:{tid}", "tasks", +1, {"to": terminal_state}),
+                controllog.post("truth.utility", f"task:{tid}", "points", +reward, {"metric": "reward"}),
+                controllog.post("truth.utility", f"project:{project_id}", "points", -reward, {"metric": "reward"}),
+            ]
+            controllog.event(
+                kind="task_complete",
+                actor={"agent_id": "asm-sql", "task_id": tid},
+                run_id=run_id,
+                payload={
+                    "question_id": tid,
+                    "level": q.get("level"),
+                    "correctness": result.correctness.value,
+                    "hit_limit": run.hit_limit if run else False,
+                    "n_tool_calls": n_turns,
+                    "cached_tokens": run.cached_tokens if run else 0,
+                    "error": err,
+                },
+                postings=postings,
+                idempotency_key=f"{run_id}:task:{tid}",
+            )
 
             async with write_lock:
                 if result.is_correct:

--- a/projects/agentic-sql-mini/uv.lock
+++ b/projects/agentic-sql-mini/uv.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "controllog" },
     { name = "duckdb" },
     { name = "openai-agents" },
     { name = "python-dotenv" },
@@ -17,6 +18,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.0" },
+    { name = "controllog", git = "https://github.com/motherduckdb/labs?subdirectory=projects%2Fcontrollog" },
     { name = "duckdb", specifier = ">=1.4.4,<1.5" },
     { name = "openai-agents", specifier = ">=0.12.5" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
@@ -242,6 +244,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
+
+[[package]]
+name = "controllog"
+version = "0.1.0"
+source = { git = "https://github.com/motherduckdb/labs?subdirectory=projects%2Fcontrollog#a985febe252a956e3bbfb9451d01909c452f62d1" }
 
 [[package]]
 name = "cryptography"


### PR DESCRIPTION
Last in the stack. Adds controllog to **agentic-sql-mini**, which previously had no structured logging — just a per-question JSONL row written directly to \`results/{arm}_{split}_{ts}.jsonl\`.

## What changes

Each task now also emits a balanced \`model_response\` event with postings for:
- tokens (provider ↔ project)
- wall time (agent ↔ project)
- cost (vendor ↔ project)
- task state (\`WIP → DONE\` or \`WIP → FAILED\`)
- utility (correctness as reward)

The existing per-question summary file **stays** — it remains the input for \`_trace.py\` and the writeup analysis. controllog logs go alongside under \`results/controllog/{events,postings}.jsonl\`.

## Changes

- \`pyproject.toml\`: add \`controllog\` dep + uv source
- \`src/run.py\`: import controllog, \`init()\` in \`_evaluate_loop\`, emit \`model_response\` per task with full balanced postings

## Diff stats
\`\`\`
 2 files changed, 36 insertions(+)
\`\`\`

## Stack
- 01 → controllog library
- 02 → bird-bench migration
- 03 → connections-eval-mini migration
- **04 (this PR)** → agentic-sql-mini adoption

> **Base branch is \`03-connections-eval-migration\`.** Retarget to \`main\` after #1, #2, #3 land.