### PR TITLE
fix(metadata-generator): pin duckdb<=1.5.2 for MotherDuck compatibility

### DIFF
--- a/projects/metadata_generator/pyproject.toml
+++ b/projects/metadata_generator/pyproject.toml
@@ -5,7 +5,7 @@ description = "Generate metadata for MotherDuck databases - profiles, descriptio
 requires-python = ">=3.11"
 dependencies = [
     "datasketch>=1.6.0",
-    "duckdb>=1.4.4",
+    "duckdb>=1.4.4,<=1.5.2",
     "openai>=1.0.0",
     "pandas>=2.0.0",
     "pyyaml>=6.0",


### PR DESCRIPTION
## Summary

`duckdb` 1.5.3 was just published, but MotherDuck only supports up to 1.5.2 today. When `uvx` (or any resolver) sees `duckdb>=1.4.4`, it picks 1.5.3 and the metadata generator fails at startup before doing any work:

```
_duckdb.InvalidInputException: Invalid Input Error: Initialization function
"motherduck_duckdb_cpp_init" ... threw an exception:
"Your DuckDB version (v1.5.3) is not yet supported by MotherDuck.
 The latest supported version is v1.5.2. Please downgrade to use MotherDuck."
```

This caps the dependency at `<=1.5.2` so fresh installs resolve to a MotherDuck-compatible version. Once MotherDuck catches up to 1.5.3 the cap can be lifted (or relaxed to `<=1.5.3` etc.).

## Repro

```
uvx --from 'git+https://github.com/motherduckdb/labs#subdirectory=projects/metadata_generator' \
  metadata-generator generate main --database <any-md-db> -x
```

Without this patch, the run dies during STEP 1/4 profiling. With it, the resolver picks 1.5.2 and the tool runs.

## Test plan

- [ ] Fresh `uvx` invocation against a real MotherDuck database completes profiling.
- [ ] Existing tests in `projects/metadata_generator/tests/` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)