### PR TITLE
nba-box-scores-pipeline: wire flights end-to-end

### DIFF
--- a/projects/nba-box-scores-pipeline/flights/nba_backfill/main.py
+++ b/projects/nba-box-scores-pipeline/flights/nba_backfill/main.py
@@ -1,25 +1,101 @@
 """Entrypoint for the nba_backfill Flight.
 
-Placeholder. The real backfill driver ports from `scripts/ingest/backfill-raw.ts`
-in the legacy repo (see plan.md §1.2). Reads season-range bounds from
-`config` once that's wired up.
+On-demand historical-season backfill. Use when v3's raw or hydrated
+tables are missing seasons that the nightly didn't cover (Phase 0's
+clone preloaded everything through v2's coverage, so this is rarely
+needed at cutover).
+
+Env vars (all optional unless noted):
+  MOTHERDUCK_TOKEN              required
+  NBA_BACKFILL_START_SEASON     required; first season-start year
+  NBA_BACKFILL_END_SEASON       required; last season-start year (inclusive)
+  NBA_INGEST_BOX_SCORES_TABLE   target box-score table (default
+                                box_scores — backfills target prod
+                                since they're typically historical)
+  NBA_INGEST_FORCE / NBA_INGEST_FILL_RAW / NBA_INGEST_DRY_RUN
+                                "1" enables; same semantics as nightly
 """
 
+import logging
 import os
+from dataclasses import replace
 
-import duckdb
+from nba_box_scores_pipeline.api.nba import PBPStatsClient
+from nba_box_scores_pipeline.config import (
+    PipelineConfig,
+    SEASON_TYPES,
+    Season,
+    build_config_from_env,
+)
+from nba_box_scores_pipeline.db.connection import connect
+from nba_box_scores_pipeline.db.loader import Loader
+from nba_box_scores_pipeline.db.schema import ensure_schema
+from nba_box_scores_pipeline.rate_limiter import RateLimiter
+from nba_box_scores_pipeline.workers.season_worker import process_season
+
+
+DATABASE = "nba_box_scores_v3"
 
 
 def main() -> None:
-    start = os.environ.get("BACKFILL_START_SEASON", "<unset>")
-    end = os.environ.get("BACKFILL_END_SEASON", "<unset>")
-    print(f"nba_backfill placeholder — start={start} end={end}")
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    log = logging.getLogger("nba_backfill")
 
-    con = duckdb.connect("md:")
-    (count,) = con.execute(
-        "SELECT COUNT(*) FROM nba_box_scores_v3.main.raw_game_data_pbpstats"
-    ).fetchone()
-    print(f"raw_game_data_pbpstats current row count: {count:,}")
+    start = os.environ.get("NBA_BACKFILL_START_SEASON")
+    end = os.environ.get("NBA_BACKFILL_END_SEASON")
+    if not start or not end:
+        raise RuntimeError("NBA_BACKFILL_START_SEASON and NBA_BACKFILL_END_SEASON are required")
+    start_year, end_year = int(start), int(end)
+    if start_year > end_year:
+        raise RuntimeError(f"start ({start_year}) must be <= end ({end_year})")
+
+    seasons = tuple(
+        Season(year=y, type=st)
+        for y in range(start_year, end_year + 1)
+        for st in SEASON_TYPES
+    )
+
+    base_config = build_config_from_env()
+    config: PipelineConfig = replace(base_config, seasons=seasons)
+    box_scores_table = os.environ.get("NBA_INGEST_BOX_SCORES_TABLE", "box_scores")
+
+    log.info(
+        "starting backfill database=%s box_scores_table=%s years=%d-%d force=%s fill_raw=%s dry_run=%s",
+        DATABASE, box_scores_table, start_year, end_year,
+        config.force, config.fill_raw, config.dry_run,
+    )
+
+    con = connect(DATABASE)
+    ensure_schema(con, db=DATABASE)
+
+    loader = Loader(con, box_scores_table=box_scores_table)
+    rate_limiter = RateLimiter(
+        base_delay_ms=config.delay_ms,
+        min_delay_ms=config.min_delay_ms,
+        max_delay_ms=config.max_delay_ms,
+    )
+
+    totals = {"completed": 0, "skipped": 0, "failed": 0}
+    with PBPStatsClient(rate_limiter) as client:
+        for season in config.seasons:
+            progress = process_season(
+                season_year=season.year,
+                season_type=season.type,
+                client=client,
+                loader=loader,
+                config=config,
+            )
+            totals["completed"] += progress.completed
+            totals["skipped"] += progress.skipped
+            totals["failed"] += progress.failed
+
+    log.info(
+        "backfill complete completed=%d skipped=%d failed=%d",
+        totals["completed"], totals["skipped"], totals["failed"],
+    )
 
 
 if __name__ == "__main__":

--- a/projects/nba-box-scores-pipeline/flights/nba_nightly/main.py
+++ b/projects/nba-box-scores-pipeline/flights/nba_nightly/main.py
@@ -1,28 +1,116 @@
 """Entrypoint for the nba_nightly Flight.
 
-Placeholder: connects to MotherDuck and prints row counts for the v3 base
-tables, proving the runtime + token wiring. The real ingest logic ports
-incrementally from the legacy TS pipeline (see plan.md §1.2).
+Runs the full ingest stack for the current NBA season — both Regular
+Season and Playoffs — once per scheduled run. Mirrors the legacy
+nightly-sync.yml workflow.
+
+Env vars (all optional unless noted):
+  MOTHERDUCK_TOKEN              required; injected by Flight runtime
+  NBA_INGEST_SEASON             override the season-start year
+  NBA_INGEST_BOX_SCORES_TABLE   target box-score table (default
+                                box_scores_new — validation phase;
+                                flip to box_scores once parity is
+                                confirmed against the cloned baseline)
+  NBA_INGEST_FORCE              "1" → ignore skip set
+  NBA_INGEST_FILL_RAW           "1" → only fetch raw, skip hydration
+  NBA_INGEST_DRY_RUN            "1" → log plan, write nothing
+  NBA_INGEST_DELAY_MS / NBA_INGEST_MIN_DELAY_MS / NBA_INGEST_MAX_DELAY_MS
+                                rate-limiter tuning
 """
 
-import duckdb
+import logging
+import os
+
+from nba_box_scores_pipeline.api.nba import PBPStatsClient
+from nba_box_scores_pipeline.config import build_config_from_env
+from nba_box_scores_pipeline.db.connection import connect
+from nba_box_scores_pipeline.db.loader import Loader
+from nba_box_scores_pipeline.db.schema import ensure_schema
+from nba_box_scores_pipeline.rate_limiter import RateLimiter
+from nba_box_scores_pipeline.workers.season_worker import process_season
 
 
-TABLES = [
-    "raw_game_data_pbpstats",
-    "schedule",
-    "box_scores",
-    "ingestion_log",
-]
+DATABASE = "nba_box_scores_v3"
+DEFAULT_BOX_SCORES_TABLE = "box_scores_new"  # validation phase target
+
+
+# Same DDL as the canonical box_scores table, but parameterized so the
+# sandbox table (default box_scores_new) gets the same PK and therefore
+# the same INSERT OR REPLACE idempotency.
+_SANDBOX_BOX_SCORES_DDL = """
+CREATE TABLE IF NOT EXISTS main.{table} (
+  game_id VARCHAR,
+  team_abbreviation VARCHAR,
+  entity_id VARCHAR,
+  player_name VARCHAR,
+  period VARCHAR NOT NULL DEFAULT 'FullGame',
+  minutes VARCHAR,
+  points INTEGER NOT NULL DEFAULT 0,
+  rebounds INTEGER NOT NULL DEFAULT 0,
+  assists INTEGER NOT NULL DEFAULT 0,
+  steals INTEGER NOT NULL DEFAULT 0,
+  blocks INTEGER NOT NULL DEFAULT 0,
+  turnovers INTEGER NOT NULL DEFAULT 0,
+  fg_made INTEGER NOT NULL DEFAULT 0,
+  fg_attempted INTEGER NOT NULL DEFAULT 0,
+  fg3_made INTEGER NOT NULL DEFAULT 0,
+  fg3_attempted INTEGER NOT NULL DEFAULT 0,
+  ft_made INTEGER NOT NULL DEFAULT 0,
+  ft_attempted INTEGER NOT NULL DEFAULT 0,
+  starter INTEGER,
+  PRIMARY KEY (game_id, entity_id, period)
+);
+"""
 
 
 def main() -> None:
-    con = duckdb.connect("md:")
-    for table in TABLES:
-        (count,) = con.execute(
-            f"SELECT COUNT(*) FROM nba_box_scores_v3.main.{table}"
-        ).fetchone()
-        print(f"nba_box_scores_v3.main.{table}: {count:,}")
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    config = build_config_from_env()
+    box_scores_table = os.environ.get("NBA_INGEST_BOX_SCORES_TABLE", DEFAULT_BOX_SCORES_TABLE)
+
+    log = logging.getLogger("nba_nightly")
+    log.info(
+        "starting nightly database=%s box_scores_table=%s seasons=%s force=%s fill_raw=%s dry_run=%s",
+        DATABASE, box_scores_table, [(s.year, s.type) for s in config.seasons],
+        config.force, config.fill_raw, config.dry_run,
+    )
+
+    con = connect(DATABASE)
+    ensure_schema(con, db=DATABASE)
+
+    if box_scores_table != "box_scores":
+        con.execute(_SANDBOX_BOX_SCORES_DDL.format(table=box_scores_table))
+        log.info("ensured sandbox table main.%s exists", box_scores_table)
+
+    loader = Loader(con, box_scores_table=box_scores_table)
+    rate_limiter = RateLimiter(
+        base_delay_ms=config.delay_ms,
+        min_delay_ms=config.min_delay_ms,
+        max_delay_ms=config.max_delay_ms,
+    )
+
+    totals = {"completed": 0, "skipped": 0, "failed": 0}
+    with PBPStatsClient(rate_limiter) as client:
+        for season in config.seasons:
+            progress = process_season(
+                season_year=season.year,
+                season_type=season.type,
+                client=client,
+                loader=loader,
+                config=config,
+            )
+            totals["completed"] += progress.completed
+            totals["skipped"] += progress.skipped
+            totals["failed"] += progress.failed
+
+    log.info(
+        "nightly complete completed=%d skipped=%d failed=%d",
+        totals["completed"], totals["skipped"], totals["failed"],
+    )
 
 
 if __name__ == "__main__":

--- a/projects/nba-box-scores-pipeline/src/nba_box_scores_pipeline/config.py
+++ b/projects/nba-box-scores-pipeline/src/nba_box_scores_pipeline/config.py
@@ -120,3 +120,40 @@ def build_config(argv: list[str] | None = None, *, env: dict[str, str] | None = 
         verbose=args.verbose,
         motherduck_token=token,
     )
+
+
+def build_config_from_env(env: dict[str, str] | None = None) -> PipelineConfig:
+    """Build a PipelineConfig from env vars only.
+
+    Used inside Flights, where there's no argv. Defaults to ingesting
+    the current season's Regular Season + Playoffs in one invocation —
+    same coverage as the legacy nightly-sync.yml workflow.
+
+    Recognized env vars:
+      MOTHERDUCK_TOKEN — required, injected by Flight runtime
+      NBA_INGEST_SEASON — season-start year (default: current)
+      NBA_INGEST_DELAY_MS, NBA_INGEST_MIN_DELAY_MS, NBA_INGEST_MAX_DELAY_MS
+      NBA_INGEST_FORCE, NBA_INGEST_FILL_RAW, NBA_INGEST_DRY_RUN — '1' enables
+    """
+    environ = env if env is not None else os.environ
+    token = environ.get("MOTHERDUCK_TOKEN")
+    if not token:
+        raise RuntimeError("MOTHERDUCK_TOKEN is required")
+
+    year = int(environ.get("NBA_INGEST_SEASON") or current_season_year())
+    seasons = tuple(Season(year=year, type=st) for st in SEASON_TYPES)
+
+    def _bool(name: str) -> bool:
+        return environ.get(name, "").strip() == "1"
+
+    return PipelineConfig(
+        seasons=seasons,
+        delay_ms=int(environ.get("NBA_INGEST_DELAY_MS") or 500),
+        min_delay_ms=int(environ.get("NBA_INGEST_MIN_DELAY_MS") or 200),
+        max_delay_ms=int(environ.get("NBA_INGEST_MAX_DELAY_MS") or 10_000),
+        force=_bool("NBA_INGEST_FORCE"),
+        fill_raw=_bool("NBA_INGEST_FILL_RAW"),
+        dry_run=_bool("NBA_INGEST_DRY_RUN"),
+        verbose=_bool("NBA_INGEST_VERBOSE"),
+        motherduck_token=token,
+    )

--- a/projects/nba-box-scores-pipeline/tests/test_config_env.py
+++ b/projects/nba-box-scores-pipeline/tests/test_config_env.py
@@ -1,0 +1,96 @@
+"""Tests for `build_config_from_env` — the env-only config builder used inside Flights."""
+
+from __future__ import annotations
+
+import pytest
+
+from nba_box_scores_pipeline.config import (
+    SEASON_TYPES,
+    build_config_from_env,
+    current_season_year,
+)
+
+
+class TestRequiredToken:
+    def test_missing_token_raises(self):
+        with pytest.raises(RuntimeError, match="MOTHERDUCK_TOKEN"):
+            build_config_from_env(env={})
+
+
+class TestDefaults:
+    def test_defaults_to_current_season_both_types(self):
+        cfg = build_config_from_env(env={"MOTHERDUCK_TOKEN": "t"})
+        year = current_season_year()
+        assert cfg.seasons == tuple(
+            type(cfg.seasons[0])(year=year, type=st) for st in SEASON_TYPES
+        )
+        assert cfg.delay_ms == 500
+        assert cfg.min_delay_ms == 200
+        assert cfg.max_delay_ms == 10_000
+        assert cfg.force is False
+        assert cfg.fill_raw is False
+        assert cfg.dry_run is False
+        assert cfg.motherduck_token == "t"
+
+
+class TestOverrides:
+    def test_season_override(self):
+        cfg = build_config_from_env(env={"MOTHERDUCK_TOKEN": "t", "NBA_INGEST_SEASON": "2020"})
+        assert {s.year for s in cfg.seasons} == {2020}
+        assert {s.type for s in cfg.seasons} == set(SEASON_TYPES)
+
+    def test_boolean_flags(self):
+        cfg = build_config_from_env(env={
+            "MOTHERDUCK_TOKEN": "t",
+            "NBA_INGEST_FORCE": "1",
+            "NBA_INGEST_FILL_RAW": "1",
+            "NBA_INGEST_DRY_RUN": "1",
+        })
+        assert cfg.force and cfg.fill_raw and cfg.dry_run
+
+    def test_boolean_flag_non_one_does_not_enable(self):
+        cfg = build_config_from_env(env={
+            "MOTHERDUCK_TOKEN": "t",
+            "NBA_INGEST_FORCE": "true",  # only "1" enables
+            "NBA_INGEST_FILL_RAW": "0",
+        })
+        assert cfg.force is False
+        assert cfg.fill_raw is False
+
+    def test_delay_overrides(self):
+        cfg = build_config_from_env(env={
+            "MOTHERDUCK_TOKEN": "t",
+            "NBA_INGEST_DELAY_MS": "750",
+            "NBA_INGEST_MIN_DELAY_MS": "300",
+            "NBA_INGEST_MAX_DELAY_MS": "20000",
+        })
+        assert cfg.delay_ms == 750
+        assert cfg.min_delay_ms == 300
+        assert cfg.max_delay_ms == 20_000
+
+
+class TestFlightMainsImportCleanly:
+    """Both flight entrypoints must import without raising — proves all
+    package-internal imports resolve from a fresh interpreter."""
+
+    def test_nba_nightly_imports(self):
+        import importlib.util
+        from pathlib import Path
+
+        path = Path(__file__).parent.parent / "flights" / "nba_nightly" / "main.py"
+        spec = importlib.util.spec_from_file_location("nba_nightly_main", path)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        assert callable(module.main)
+
+    def test_nba_backfill_imports(self):
+        import importlib.util
+        from pathlib import Path
+
+        path = Path(__file__).parent.parent / "flights" / "nba_backfill" / "main.py"
+        spec = importlib.util.spec_from_file_location("nba_backfill_main", path)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        assert callable(module.main)


### PR DESCRIPTION
## Summary

Stacks on top of #14. Replaces the hello-world flight placeholders with the real pipeline wiring.

- \`config.py\`: \`build_config_from_env()\` — env-only \`PipelineConfig\` builder for use inside Flights (no argv). Defaults to current season + both season types. Env vars: \`NBA_INGEST_SEASON\`, \`NBA_INGEST_{FORCE,FILL_RAW,DRY_RUN,VERBOSE}\`, \`NBA_INGEST_{DELAY,MIN_DELAY,MAX_DELAY}_MS\`
- \`flights/nba_nightly/main.py\`: connect → \`ensure_schema\` → \`process_season\` for each (year, type) in config. Targets \`main.box_scores_new\` by default (validation sandbox — keeps the cloned baseline frozen for diffing). \`NBA_INGEST_BOX_SCORES_TABLE\` overrides
- \`flights/nba_backfill/main.py\`: same shape, takes \`NBA_BACKFILL_{START,END}_SEASON\`. Defaults to writing \`box_scores\` since backfills typically target prod

8 new tests (46 total): env-config builder semantics + import-smoke tests that exec both flight entrypoints. Smoke tests catch broken imports without needing a real MotherDuck connection.

## Test plan

- [x] \`pytest tests/\` — 46/46 green
- [ ] Register the new \`nba_nightly\` flight via MCP \`create_flight\` (next stack slice or manual) and trigger one run to confirm end-to-end against v3
- [ ] Once a run completes, diff \`main.box_scores_new\` vs \`main.box_scores\` for games covered by both — drives the validation phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)