### PR TITLE
docs: add controllog-viz to the root project index

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Each experiment lives in its own directory under [`projects/`](./projects/). Bro
 | [`bird-bench`](./projects/bird-bench/) | Text-to-SQL evaluation framework using the BIRD Mini-Dev benchmark with MotherDuck as the execution backend. |
 | [`connections-eval-mini`](./projects/connections-eval-mini/) | Evaluate AI models on NYT Connections puzzles. Built for the Seattle Startup Summit evals workshop. |
 | [`controllog`](./projects/controllog/) | Controllable logging library for AI/agentic systems — events + balanced postings, JSONL transport, optional MotherDuck upload. Shared dep of `agentic-sql-mini`, `bird-bench`, and `connections-eval-mini`. |
+| [`controllog-viz`](./projects/controllog-viz/) | Static HTML views for `controllog` datasets (JSONL or MotherDuck via one DuckDB layer) — a per-run review with a chain-of-thought conversation explorer and a cross-run dashboard with a run × question progression/regression matrix. |
 | [`metadata_generator`](./projects/metadata_generator/) | Generate rich metadata for MotherDuck databases — profile statistics, LLM-generated descriptions, and SQL `COMMENT` statements. Used as a dep by `bird-bench`. |
 | [`react-components`](./projects/react-components/) | Open-source React components extracted from MotherDuck's website and docs — embed a public Dive, embed a private Dive, and an in-browser MotherDuck SQL editor. |
 <!-- END PROJECT LIST -->


### PR DESCRIPTION
Follow-up to #16 — that PR shipped `projects/controllog-viz` with its own README but didn't add a row to the root README's project-index table. This adds it (alphabetically after `controllog`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)