### PR TITLE
nba-box-scores-pipeline: bootstrapper flights (validated on runtime)

### DIFF
--- a/projects/nba-box-scores-pipeline/flights/nba_backfill/main.py
+++ b/projects/nba-box-scores-pipeline/flights/nba_backfill/main.py
@@ -26,12 +26,15 @@ PROJECT_SUBDIR = REPO_DIR / "projects" / "nba-box-scores-pipeline"
 ENTRYPOINT_COMMAND = "backfill"
 
 
-def sh(cmd, cwd=None, env=None, check=True):
-    print("$ " + cmd, flush=True)
+def sh(args, cwd=None, env=None, check=True):
+    # argv list, never shell=True — env-derived values (e.g. the branch) must
+    # not be interpolated into a shell string in a process that holds the
+    # MotherDuck token.
+    print("$ " + " ".join(args), flush=True)
     merged = dict(os.environ)
     merged.update(env or {})
     r = subprocess.run(
-        cmd, shell=True, cwd=str(cwd) if cwd else None,
+        args, cwd=str(cwd) if cwd else None,
         env=merged, capture_output=True, text=True,
     )
     if r.stdout:
@@ -39,15 +42,15 @@ def sh(cmd, cwd=None, env=None, check=True):
     if r.stderr:
         print("STDERR:", r.stderr, flush=True)
     if check and r.returncode != 0:
-        raise RuntimeError("command failed rc=" + str(r.returncode) + ": " + cmd)
+        raise RuntimeError("command failed rc=" + str(r.returncode) + ": " + " ".join(args))
     return r
 
 
 def ensure_git():
     if shutil.which("git"):
         return
-    sh("apt-get update -y", check=False)
-    sh("apt-get install -y --no-install-recommends git ca-certificates")
+    sh(["apt-get", "update", "-y"], check=False)
+    sh(["apt-get", "install", "-y", "--no-install-recommends", "git", "ca-certificates"])
 
 
 def main():
@@ -57,12 +60,14 @@ def main():
     ensure_git()
     if REPO_DIR.exists():
         shutil.rmtree(REPO_DIR)
-    sh(f"git clone --depth 1 --branch {branch} {REPO_URL} {REPO_DIR}")
-    sh("git log -1 --oneline", cwd=REPO_DIR)
+    sh(["git", "clone", "--depth", "1", "--branch", branch, REPO_URL, str(REPO_DIR)])
+    sh(["git", "log", "-1", "--oneline"], cwd=REPO_DIR)
 
-    sh("uv sync", cwd=PROJECT_SUBDIR, env={"UV_LINK_MODE": "copy"})
+    # --locked: fail rather than silently re-resolve if uv.lock is stale.
+    # --no-dev: runtime doesn't need pytest/pydantic.
+    sh(["uv", "sync", "--locked", "--no-dev"], cwd=PROJECT_SUBDIR, env={"UV_LINK_MODE": "copy"})
     sh(
-        f".venv/bin/python -m nba_box_scores_pipeline.entrypoints {ENTRYPOINT_COMMAND}",
+        [".venv/bin/python", "-m", "nba_box_scores_pipeline.entrypoints", ENTRYPOINT_COMMAND],
         cwd=PROJECT_SUBDIR,
     )
 

--- a/projects/nba-box-scores-pipeline/flights/nba_backfill/main.py
+++ b/projects/nba-box-scores-pipeline/flights/nba_backfill/main.py
@@ -1,100 +1,69 @@
-"""Entrypoint for the nba_backfill Flight.
+"""Bootstrapper for the nba_backfill Flight.
 
-On-demand historical-season backfill. Use when v3's raw or hydrated
-tables are missing seasons that the nightly didn't cover (Phase 0's
-clone preloaded everything through v2's coverage, so this is rarely
-needed at cutover).
+Thin, stable bootstrapper (see flights/nba_nightly/main.py for the full
+rationale): clones the labs repo at a branch, `uv sync`s the pipeline
+package, and runs the backfill entrypoint from the synced venv.
 
-Env vars (all optional unless noted):
-  MOTHERDUCK_TOKEN              required
-  NBA_BACKFILL_START_SEASON     required; first season-start year
-  NBA_BACKFILL_END_SEASON       required; last season-start year (inclusive)
-  NBA_INGEST_BOX_SCORES_TABLE   target box-score table (default
-                                box_scores — backfills target prod
-                                since they're typically historical)
-  NBA_INGEST_FORCE / NBA_INGEST_FILL_RAW / NBA_INGEST_DRY_RUN
-                                "1" enables; same semantics as nightly
+Env vars consumed here:
+  NBA_FLIGHT_REPO_BRANCH   branch to clone (default: nba-migration)
+Required by the entrypoint (pass through to the subprocess):
+  NBA_BACKFILL_START_SEASON / NBA_BACKFILL_END_SEASON
+Plus the usual NBA_INGEST_* / MOTHERDUCK_TOKEN.
 """
 
-import logging
+from __future__ import annotations
+
 import os
-from dataclasses import replace
+import shutil
+import subprocess
+import sys
+from pathlib import Path
 
-from nba_box_scores_pipeline.api.nba import PBPStatsClient
-from nba_box_scores_pipeline.config import (
-    PipelineConfig,
-    SEASON_TYPES,
-    Season,
-    build_config_from_env,
-)
-from nba_box_scores_pipeline.db.connection import connect
-from nba_box_scores_pipeline.db.loader import Loader
-from nba_box_scores_pipeline.db.schema import ensure_schema
-from nba_box_scores_pipeline.rate_limiter import RateLimiter
-from nba_box_scores_pipeline.workers.season_worker import process_season
+REPO_URL = "https://github.com/motherduckdb/labs"
+DEFAULT_BRANCH = "nba-migration"
+REPO_DIR = Path("/app/labs")
+PROJECT_SUBDIR = REPO_DIR / "projects" / "nba-box-scores-pipeline"
+ENTRYPOINT_COMMAND = "backfill"
 
 
-DATABASE = "nba_box_scores_v3"
-
-
-def main() -> None:
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+def sh(cmd, cwd=None, env=None, check=True):
+    print("$ " + cmd, flush=True)
+    merged = dict(os.environ)
+    merged.update(env or {})
+    r = subprocess.run(
+        cmd, shell=True, cwd=str(cwd) if cwd else None,
+        env=merged, capture_output=True, text=True,
     )
-    log = logging.getLogger("nba_backfill")
+    if r.stdout:
+        print(r.stdout, flush=True)
+    if r.stderr:
+        print("STDERR:", r.stderr, flush=True)
+    if check and r.returncode != 0:
+        raise RuntimeError("command failed rc=" + str(r.returncode) + ": " + cmd)
+    return r
 
-    start = os.environ.get("NBA_BACKFILL_START_SEASON")
-    end = os.environ.get("NBA_BACKFILL_END_SEASON")
-    if not start or not end:
-        raise RuntimeError("NBA_BACKFILL_START_SEASON and NBA_BACKFILL_END_SEASON are required")
-    start_year, end_year = int(start), int(end)
-    if start_year > end_year:
-        raise RuntimeError(f"start ({start_year}) must be <= end ({end_year})")
 
-    seasons = tuple(
-        Season(year=y, type=st)
-        for y in range(start_year, end_year + 1)
-        for st in SEASON_TYPES
-    )
+def ensure_git():
+    if shutil.which("git"):
+        return
+    sh("apt-get update -y", check=False)
+    sh("apt-get install -y --no-install-recommends git ca-certificates")
 
-    base_config = build_config_from_env()
-    config: PipelineConfig = replace(base_config, seasons=seasons)
-    box_scores_table = os.environ.get("NBA_INGEST_BOX_SCORES_TABLE", "box_scores")
 
-    log.info(
-        "starting backfill database=%s box_scores_table=%s years=%d-%d force=%s fill_raw=%s dry_run=%s",
-        DATABASE, box_scores_table, start_year, end_year,
-        config.force, config.fill_raw, config.dry_run,
-    )
+def main():
+    print("python:", sys.version, flush=True)
+    branch = os.environ.get("NBA_FLIGHT_REPO_BRANCH", DEFAULT_BRANCH)
 
-    con = connect(DATABASE)
-    ensure_schema(con, db=DATABASE)
+    ensure_git()
+    if REPO_DIR.exists():
+        shutil.rmtree(REPO_DIR)
+    sh(f"git clone --depth 1 --branch {branch} {REPO_URL} {REPO_DIR}")
+    sh("git log -1 --oneline", cwd=REPO_DIR)
 
-    loader = Loader(con, box_scores_table=box_scores_table)
-    rate_limiter = RateLimiter(
-        base_delay_ms=config.delay_ms,
-        min_delay_ms=config.min_delay_ms,
-        max_delay_ms=config.max_delay_ms,
-    )
-
-    totals = {"completed": 0, "skipped": 0, "failed": 0}
-    with PBPStatsClient(rate_limiter) as client:
-        for season in config.seasons:
-            progress = process_season(
-                season_year=season.year,
-                season_type=season.type,
-                client=client,
-                loader=loader,
-                config=config,
-            )
-            totals["completed"] += progress.completed
-            totals["skipped"] += progress.skipped
-            totals["failed"] += progress.failed
-
-    log.info(
-        "backfill complete completed=%d skipped=%d failed=%d",
-        totals["completed"], totals["skipped"], totals["failed"],
+    sh("uv sync", cwd=PROJECT_SUBDIR, env={"UV_LINK_MODE": "copy"})
+    sh(
+        f".venv/bin/python -m nba_box_scores_pipeline.entrypoints {ENTRYPOINT_COMMAND}",
+        cwd=PROJECT_SUBDIR,
     )
 
 

--- a/projects/nba-box-scores-pipeline/flights/nba_nightly/main.py
+++ b/projects/nba-box-scores-pipeline/flights/nba_nightly/main.py
@@ -1,115 +1,74 @@
-"""Entrypoint for the nba_nightly Flight.
+"""Bootstrapper for the nba_nightly Flight.
 
-Runs the full ingest stack for the current NBA season — both Regular
-Season and Playoffs — once per scheduled run. Mirrors the legacy
-nightly-sync.yml workflow.
+This file is the flight's registered `source_code`. It is deliberately
+thin and stable: it clones the labs repo at a branch, `uv sync`s the
+pipeline package, and runs the real entrypoint from the synced venv.
 
-Env vars (all optional unless noted):
-  MOTHERDUCK_TOKEN              required; injected by Flight runtime
-  NBA_INGEST_SEASON             override the season-start year
-  NBA_INGEST_BOX_SCORES_TABLE   target box-score table (default
-                                box_scores_new — validation phase;
-                                flip to box_scores once parity is
-                                confirmed against the cloned baseline)
-  NBA_INGEST_FORCE              "1" → ignore skip set
-  NBA_INGEST_FILL_RAW           "1" → only fetch raw, skip hydration
-  NBA_INGEST_DRY_RUN            "1" → log plan, write nothing
-  NBA_INGEST_DELAY_MS / NBA_INGEST_MIN_DELAY_MS / NBA_INGEST_MAX_DELAY_MS
-                                rate-limiter tuning
+Because the code is fetched at run time, pushing to the branch updates
+what the next run executes — no flight re-registration needed. That's
+what lets us skip a deploy.py / CI step while the Flights SQL surface
+(MD_CREATE_FLIGHT etc.) is still rolling out.
+
+Env vars consumed here:
+  NBA_FLIGHT_REPO_BRANCH   branch to clone (default: nba-migration; flip
+                           to main once the migration branch merges)
+All other NBA_INGEST_* / MOTHERDUCK_TOKEN vars pass through to the
+subprocess and are read by entrypoints.run_nightly().
 """
 
-import logging
+from __future__ import annotations
+
 import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
 
-from nba_box_scores_pipeline.api.nba import PBPStatsClient
-from nba_box_scores_pipeline.config import build_config_from_env
-from nba_box_scores_pipeline.db.connection import connect
-from nba_box_scores_pipeline.db.loader import Loader
-from nba_box_scores_pipeline.db.schema import ensure_schema
-from nba_box_scores_pipeline.rate_limiter import RateLimiter
-from nba_box_scores_pipeline.workers.season_worker import process_season
-
-
-DATABASE = "nba_box_scores_v3"
-DEFAULT_BOX_SCORES_TABLE = "box_scores_new"  # validation phase target
+REPO_URL = "https://github.com/motherduckdb/labs"
+DEFAULT_BRANCH = "nba-migration"
+REPO_DIR = Path("/app/labs")
+PROJECT_SUBDIR = REPO_DIR / "projects" / "nba-box-scores-pipeline"
+ENTRYPOINT_COMMAND = "nightly"
 
 
-# Same DDL as the canonical box_scores table, but parameterized so the
-# sandbox table (default box_scores_new) gets the same PK and therefore
-# the same INSERT OR REPLACE idempotency.
-_SANDBOX_BOX_SCORES_DDL = """
-CREATE TABLE IF NOT EXISTS main.{table} (
-  game_id VARCHAR,
-  team_abbreviation VARCHAR,
-  entity_id VARCHAR,
-  player_name VARCHAR,
-  period VARCHAR NOT NULL DEFAULT 'FullGame',
-  minutes VARCHAR,
-  points INTEGER NOT NULL DEFAULT 0,
-  rebounds INTEGER NOT NULL DEFAULT 0,
-  assists INTEGER NOT NULL DEFAULT 0,
-  steals INTEGER NOT NULL DEFAULT 0,
-  blocks INTEGER NOT NULL DEFAULT 0,
-  turnovers INTEGER NOT NULL DEFAULT 0,
-  fg_made INTEGER NOT NULL DEFAULT 0,
-  fg_attempted INTEGER NOT NULL DEFAULT 0,
-  fg3_made INTEGER NOT NULL DEFAULT 0,
-  fg3_attempted INTEGER NOT NULL DEFAULT 0,
-  ft_made INTEGER NOT NULL DEFAULT 0,
-  ft_attempted INTEGER NOT NULL DEFAULT 0,
-  starter INTEGER,
-  PRIMARY KEY (game_id, entity_id, period)
-);
-"""
-
-
-def main() -> None:
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+def sh(cmd, cwd=None, env=None, check=True):
+    print("$ " + cmd, flush=True)
+    merged = dict(os.environ)
+    merged.update(env or {})
+    r = subprocess.run(
+        cmd, shell=True, cwd=str(cwd) if cwd else None,
+        env=merged, capture_output=True, text=True,
     )
+    if r.stdout:
+        print(r.stdout, flush=True)
+    if r.stderr:
+        print("STDERR:", r.stderr, flush=True)
+    if check and r.returncode != 0:
+        raise RuntimeError("command failed rc=" + str(r.returncode) + ": " + cmd)
+    return r
 
-    config = build_config_from_env()
-    box_scores_table = os.environ.get("NBA_INGEST_BOX_SCORES_TABLE", DEFAULT_BOX_SCORES_TABLE)
 
-    log = logging.getLogger("nba_nightly")
-    log.info(
-        "starting nightly database=%s box_scores_table=%s seasons=%s force=%s fill_raw=%s dry_run=%s",
-        DATABASE, box_scores_table, [(s.year, s.type) for s in config.seasons],
-        config.force, config.fill_raw, config.dry_run,
-    )
+def ensure_git():
+    if shutil.which("git"):
+        return
+    sh("apt-get update -y", check=False)
+    sh("apt-get install -y --no-install-recommends git ca-certificates")
 
-    con = connect(DATABASE)
-    ensure_schema(con, db=DATABASE)
 
-    if box_scores_table != "box_scores":
-        con.execute(_SANDBOX_BOX_SCORES_DDL.format(table=box_scores_table))
-        log.info("ensured sandbox table main.%s exists", box_scores_table)
+def main():
+    print("python:", sys.version, flush=True)
+    branch = os.environ.get("NBA_FLIGHT_REPO_BRANCH", DEFAULT_BRANCH)
 
-    loader = Loader(con, box_scores_table=box_scores_table)
-    rate_limiter = RateLimiter(
-        base_delay_ms=config.delay_ms,
-        min_delay_ms=config.min_delay_ms,
-        max_delay_ms=config.max_delay_ms,
-    )
+    ensure_git()
+    if REPO_DIR.exists():
+        shutil.rmtree(REPO_DIR)
+    sh(f"git clone --depth 1 --branch {branch} {REPO_URL} {REPO_DIR}")
+    sh("git log -1 --oneline", cwd=REPO_DIR)
 
-    totals = {"completed": 0, "skipped": 0, "failed": 0}
-    with PBPStatsClient(rate_limiter) as client:
-        for season in config.seasons:
-            progress = process_season(
-                season_year=season.year,
-                season_type=season.type,
-                client=client,
-                loader=loader,
-                config=config,
-            )
-            totals["completed"] += progress.completed
-            totals["skipped"] += progress.skipped
-            totals["failed"] += progress.failed
-
-    log.info(
-        "nightly complete completed=%d skipped=%d failed=%d",
-        totals["completed"], totals["skipped"], totals["failed"],
+    sh("uv sync", cwd=PROJECT_SUBDIR, env={"UV_LINK_MODE": "copy"})
+    sh(
+        f".venv/bin/python -m nba_box_scores_pipeline.entrypoints {ENTRYPOINT_COMMAND}",
+        cwd=PROJECT_SUBDIR,
     )
 
 

--- a/projects/nba-box-scores-pipeline/flights/nba_nightly/main.py
+++ b/projects/nba-box-scores-pipeline/flights/nba_nightly/main.py
@@ -31,12 +31,15 @@ PROJECT_SUBDIR = REPO_DIR / "projects" / "nba-box-scores-pipeline"
 ENTRYPOINT_COMMAND = "nightly"
 
 
-def sh(cmd, cwd=None, env=None, check=True):
-    print("$ " + cmd, flush=True)
+def sh(args, cwd=None, env=None, check=True):
+    # argv list, never shell=True — env-derived values (e.g. the branch) must
+    # not be interpolated into a shell string in a process that holds the
+    # MotherDuck token.
+    print("$ " + " ".join(args), flush=True)
     merged = dict(os.environ)
     merged.update(env or {})
     r = subprocess.run(
-        cmd, shell=True, cwd=str(cwd) if cwd else None,
+        args, cwd=str(cwd) if cwd else None,
         env=merged, capture_output=True, text=True,
     )
     if r.stdout:
@@ -44,15 +47,15 @@ def sh(cmd, cwd=None, env=None, check=True):
     if r.stderr:
         print("STDERR:", r.stderr, flush=True)
     if check and r.returncode != 0:
-        raise RuntimeError("command failed rc=" + str(r.returncode) + ": " + cmd)
+        raise RuntimeError("command failed rc=" + str(r.returncode) + ": " + " ".join(args))
     return r
 
 
 def ensure_git():
     if shutil.which("git"):
         return
-    sh("apt-get update -y", check=False)
-    sh("apt-get install -y --no-install-recommends git ca-certificates")
+    sh(["apt-get", "update", "-y"], check=False)
+    sh(["apt-get", "install", "-y", "--no-install-recommends", "git", "ca-certificates"])
 
 
 def main():
@@ -62,12 +65,14 @@ def main():
     ensure_git()
     if REPO_DIR.exists():
         shutil.rmtree(REPO_DIR)
-    sh(f"git clone --depth 1 --branch {branch} {REPO_URL} {REPO_DIR}")
-    sh("git log -1 --oneline", cwd=REPO_DIR)
+    sh(["git", "clone", "--depth", "1", "--branch", branch, REPO_URL, str(REPO_DIR)])
+    sh(["git", "log", "-1", "--oneline"], cwd=REPO_DIR)
 
-    sh("uv sync", cwd=PROJECT_SUBDIR, env={"UV_LINK_MODE": "copy"})
+    # --locked: fail rather than silently re-resolve if uv.lock is stale.
+    # --no-dev: runtime doesn't need pytest/pydantic.
+    sh(["uv", "sync", "--locked", "--no-dev"], cwd=PROJECT_SUBDIR, env={"UV_LINK_MODE": "copy"})
     sh(
-        f".venv/bin/python -m nba_box_scores_pipeline.entrypoints {ENTRYPOINT_COMMAND}",
+        [".venv/bin/python", "-m", "nba_box_scores_pipeline.entrypoints", ENTRYPOINT_COMMAND],
         cwd=PROJECT_SUBDIR,
     )
 

--- a/projects/nba-box-scores-pipeline/plan.md
+++ b/projects/nba-box-scores-pipeline/plan.md
@@ -196,7 +196,27 @@ Naming note: the live Flights SQL function and MCP tool use `md_token_name`. The
 
 `flight_schema.py` (pydantic) validates this on every build, mirroring the zod validation blessed-dives does for `package.json`.
 
-### 1.4 Deploy pattern (lifted from blessed-dives, retargeted at Flights SQL)
+### 1.4 Deploy pattern
+
+> **Superseded (2026-05-29) by the bootstrapper-flight pattern — see below.** The `deploy.py` / CI-deploy material that follows is shelved (not deleted): it's the path back to SHA-pinned, preview-per-PR deploys if/when the Flights SQL surface ships.
+
+#### Bootstrapper pattern (current approach)
+
+Each flight's registered `source_code` is a thin, stable bootstrapper (`flights/<name>/main.py`) that at run time:
+1. `apt-get install git` if needed
+2. shallow-clones `labs@<branch>` (`NBA_FLIGHT_REPO_BRANCH`, default `nba-migration` → flip to `main` post-merge)
+3. `uv sync` the pipeline package
+4. runs `python -m nba_box_scores_pipeline.entrypoints {nightly|backfill}` from the synced venv
+
+Because code is fetched at run time, **pushing to the branch updates the next run** — no re-registration, no `MD_CREATE_FLIGHT` SQL, no CI deploy step. Each flight is registered **once** via the MCP `create_flight`. The real `run_nightly()`/`run_backfill()` logic lives in the importable `entrypoints.py` (unit-tested); the bootstrappers are stdlib-only (`apt-get`/`git`/`uv`/`subprocess`).
+
+Validated end-to-end on the live runtime 2026-05-29 (throwaway flights, deleted after): a read-only harness (clone → `uv sync` → import → `md:` connect → row count = 3,049,526) and a dry-run of the real bootstrapper (real `get-games` API for RS + Playoffs, skip logic matched all 1314 cloned 2024-25 games). Two findings now in the code:
+- **duckdb pinned `<1.5.3`** — MotherDuck server rejects client ≥1.5.3 (max supported 1.5.2). Local tests use `:memory:` so were unaffected.
+- **`dry_run` skips schema mutations** — inspect-only.
+
+Tradeoffs accepted: clone-at-branch-HEAD → no SHA pinning/reproducibility, no per-PR preview flights. Fine for a nightly scrape; recoverable via `deploy.py` once SQL ships.
+
+#### deploy.py (shelved — original plan, lifted from blessed-dives)
 
 `deploy.py` is the analog of `deploy.ts`. The plan was to use **only the SQL functions from the [Flights docs PR](https://github.com/motherduckdb/motherduck-docs/pull/1633)** — no private APIs.
 

--- a/projects/nba-box-scores-pipeline/pyproject.toml
+++ b/projects/nba-box-scores-pipeline/pyproject.toml
@@ -18,8 +18,11 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
 ]
+# duckdb is capped below 1.5.3: MotherDuck's server rejects newer client
+# versions ("latest supported version is v1.5.2"). The cap is what the
+# flight's `md:` connection needs — local tests use :memory: and don't care.
 dependencies = [
-    "duckdb>=1.3.0",
+    "duckdb>=1.3.0,<1.5.3",
     "httpx>=0.27.0",
     "controllog @ git+https://github.com/motherduckdb/labs#subdirectory=projects/controllog",
 ]

--- a/projects/nba-box-scores-pipeline/src/nba_box_scores_pipeline/db/loader.py
+++ b/projects/nba-box-scores-pipeline/src/nba_box_scores_pipeline/db/loader.py
@@ -146,7 +146,19 @@ class Loader:
 
     # ── Reads (skip-on-retry) ───────────────────────────────────────
 
+    def _table_exists(self, table: str) -> bool:
+        row = self._con.execute(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = 'main' AND table_name = ? LIMIT 1",
+            [table],
+        ).fetchone()
+        return row is not None
+
     def is_game_ingested(self, game_id: str) -> bool:
+        # A missing log table means nothing has been ingested yet (e.g. a
+        # dry run against a not-yet-created sandbox set). Treat as not-done.
+        if not self._table_exists(self._ingestion_log):
+            return False
         (cnt,) = self._con.execute(
             f"SELECT COUNT(*) FROM main.{self._ingestion_log} "
             "WHERE game_id = ? AND ingestion_status = 'success'",
@@ -155,6 +167,8 @@ class Loader:
         return cnt > 0
 
     def get_ingested_game_ids(self, season_year: int, season_type: str) -> set[str]:
+        if not self._table_exists(self._ingestion_log):
+            return set()
         rows = self._con.execute(
             f"SELECT game_id FROM main.{self._ingestion_log} "
             "WHERE season_year = ? AND season_type = ? AND ingestion_status = 'success'",
@@ -163,6 +177,8 @@ class Loader:
         return {r[0] for r in rows}
 
     def get_raw_game_ids(self, season_year: int, season_type: str) -> set[str]:
+        if not self._table_exists(self._raw_pbpstats):
+            return set()
         rows = self._con.execute(
             f"SELECT game_id FROM main.{self._raw_pbpstats} "
             "WHERE season_year = ? AND season_type = ?",

--- a/projects/nba-box-scores-pipeline/src/nba_box_scores_pipeline/db/schema.py
+++ b/projects/nba-box-scores-pipeline/src/nba_box_scores_pipeline/db/schema.py
@@ -257,6 +257,17 @@ def ensure_tables(con: duckdb.DuckDBPyConnection) -> None:
         con.execute(ddl)
 
 
+def ensure_box_scores_table(con: duckdb.DuckDBPyConnection, table: str) -> None:
+    """Create a box_scores-shaped table under an alternate name.
+
+    Used for the validation sandbox (default `box_scores_new`). Reuses the
+    canonical CREATE_BOX_SCORES DDL so the sandbox gets the same
+    (game_id, entity_id, period) PK — without the PK the loader's
+    INSERT OR REPLACE has no conflict target.
+    """
+    con.execute(CREATE_BOX_SCORES.replace("main.box_scores", f"main.{table}", 1))
+
+
 def ensure_views(con: duckdb.DuckDBPyConnection, *, db: str) -> None:
     """Always issues CREATE OR REPLACE so the views point at `db`'s tables.
 

--- a/projects/nba-box-scores-pipeline/src/nba_box_scores_pipeline/db/schema.py
+++ b/projects/nba-box-scores-pipeline/src/nba_box_scores_pipeline/db/schema.py
@@ -237,12 +237,17 @@ FROM cte_final;
 """
 
 
-TABLE_DDL = (
-    CREATE_SCHEDULE,
-    CREATE_BOX_SCORES,
-    CREATE_INGESTION_LOG,
-    CREATE_RAW_GAME_DATA_PBPSTATS,
-)
+# The four operational tables, keyed by their canonical name. Suffixed
+# variants (e.g. box_scores_new / ingestion_log_new) form an isolated
+# "table set" for sandbox/validation runs — see ensure_tables_suffixed.
+TABLE_DDL_BY_NAME = {
+    "schedule": CREATE_SCHEDULE,
+    "box_scores": CREATE_BOX_SCORES,
+    "ingestion_log": CREATE_INGESTION_LOG,
+    "raw_game_data_pbpstats": CREATE_RAW_GAME_DATA_PBPSTATS,
+}
+
+TABLE_DDL = tuple(TABLE_DDL_BY_NAME.values())
 
 VIEW_DDL = (
     CREATE_TEAM_STATS_VIEW,
@@ -252,20 +257,29 @@ VIEW_DDL = (
 
 
 def ensure_tables(con: duckdb.DuckDBPyConnection) -> None:
-    """Idempotent: creates any missing tables, leaves existing ones alone."""
+    """Idempotent: creates any missing canonical tables, leaves existing ones alone."""
     for ddl in TABLE_DDL:
         con.execute(ddl)
 
 
-def ensure_box_scores_table(con: duckdb.DuckDBPyConnection, table: str) -> None:
-    """Create a box_scores-shaped table under an alternate name.
+def ensure_tables_suffixed(con: duckdb.DuckDBPyConnection, suffix: str) -> None:
+    """Create the full operational table set under a name suffix.
 
-    Used for the validation sandbox (default `box_scores_new`). Reuses the
-    canonical CREATE_BOX_SCORES DDL so the sandbox gets the same
-    (game_id, entity_id, period) PK — without the PK the loader's
-    INSERT OR REPLACE has no conflict target.
+    A sandbox run (suffix e.g. ``_new``) must isolate ALL of its operational
+    state — not just box_scores. If a sandbox run wrote box scores to
+    box_scores_new but marked success in the canonical ingestion_log, a later
+    production run would skip-on-retry and never write those games to
+    box_scores. So box_scores, schedule, ingestion_log, and raw_game_data_pbpstats
+    are all suffixed together. Empty suffix is a no-op alias for ensure_tables.
+
+    Each table reuses its canonical DDL (so suffixed tables keep the same PKs,
+    which is what gives INSERT OR REPLACE its conflict target).
     """
-    con.execute(CREATE_BOX_SCORES.replace("main.box_scores", f"main.{table}", 1))
+    if not suffix:
+        ensure_tables(con)
+        return
+    for name, ddl in TABLE_DDL_BY_NAME.items():
+        con.execute(ddl.replace(f"main.{name}", f"main.{name}{suffix}", 1))
 
 
 def ensure_views(con: duckdb.DuckDBPyConnection, *, db: str) -> None:

--- a/projects/nba-box-scores-pipeline/src/nba_box_scores_pipeline/entrypoints.py
+++ b/projects/nba-box-scores-pipeline/src/nba_box_scores_pipeline/entrypoints.py
@@ -30,7 +30,7 @@ from .config import (
 )
 from .db.connection import connect
 from .db.loader import Loader
-from .db.schema import ensure_box_scores_table, ensure_schema
+from .db.schema import ensure_tables_suffixed, ensure_views
 from .rate_limiter import RateLimiter
 from .workers.season_worker import process_season
 
@@ -38,25 +38,45 @@ from .workers.season_worker import process_season
 DATABASE = "nba_box_scores_v3"
 
 
-def _run(config: PipelineConfig, *, box_scores_table: str, label: str) -> None:
+def _loader_for(con, suffix: str) -> Loader:
+    """Build a Loader over a full table set sharing one name suffix.
+
+    The whole operational set is suffixed together (not just box_scores) so a
+    sandbox run's skip/log state stays isolated from production — see
+    schema.ensure_tables_suffixed for why this matters.
+    """
+    return Loader(
+        con,
+        box_scores_table=f"box_scores{suffix}",
+        schedule_table=f"schedule{suffix}",
+        ingestion_log_table=f"ingestion_log{suffix}",
+        raw_pbpstats_table=f"raw_game_data_pbpstats{suffix}",
+    )
+
+
+def _run(config: PipelineConfig, *, suffix: str, label: str) -> None:
     log = logging.getLogger(label)
+    table_set = "production" if not suffix else f"sandbox (suffix '{suffix}')"
     log.info(
-        "starting %s database=%s box_scores_table=%s seasons=%s force=%s fill_raw=%s dry_run=%s",
-        label, DATABASE, box_scores_table,
+        "starting %s database=%s table_set=%s seasons=%s force=%s fill_raw=%s dry_run=%s",
+        label, DATABASE, table_set,
         [(s.year, s.type) for s in config.seasons],
         config.force, config.fill_raw, config.dry_run,
     )
 
     con = connect(DATABASE)
     if config.dry_run:
-        log.info("dry_run: skipping schema bootstrap (no mutations)")
+        # No mutations at all. The loader's skip-reads tolerate missing tables,
+        # so the plan is reported even if the (sandbox) table set isn't created.
+        log.info("dry_run: no schema changes, no writes")
     else:
-        ensure_schema(con, db=DATABASE)
-        if box_scores_table != "box_scores":
-            ensure_box_scores_table(con, box_scores_table)
-            log.info("ensured sandbox table main.%s exists", box_scores_table)
+        ensure_tables_suffixed(con, suffix)
+        # Repoint the prod-facing views only on a real production run — they
+        # read the canonical box_scores, and a clone leaves them aimed at v2.
+        if not suffix:
+            ensure_views(con, db=DATABASE)
 
-    loader = Loader(con, box_scores_table=box_scores_table)
+    loader = _loader_for(con, suffix)
     rate_limiter = RateLimiter(
         base_delay_ms=config.delay_ms,
         min_delay_ms=config.min_delay_ms,
@@ -83,24 +103,31 @@ def _run(config: PipelineConfig, *, box_scores_table: str, label: str) -> None:
     )
 
 
+# Default table-set suffix per command. Nightly defaults to the `_new`
+# sandbox set during the validation phase (diff box_scores_new vs the frozen
+# box_scores baseline, then flip to "" to write production). Backfill targets
+# production directly. Either can be overridden with NBA_INGEST_TABLE_SUFFIX
+# ("" = production).
+def _suffix(default: str) -> str:
+    return os.environ.get("NBA_INGEST_TABLE_SUFFIX", default)
+
+
 def run_nightly() -> None:
     """Current-season ingest (Regular Season + Playoffs).
 
-    Defaults to writing the validation sandbox table `box_scores_new`;
-    set NBA_INGEST_BOX_SCORES_TABLE=box_scores to write production once
-    parity against the cloned baseline is confirmed.
+    Writes the `_new` sandbox table set by default. Set
+    NBA_INGEST_TABLE_SUFFIX="" to write production once parity against the
+    cloned baseline is confirmed.
     """
     config = build_config_from_env()
-    box_scores_table = os.environ.get("NBA_INGEST_BOX_SCORES_TABLE", "box_scores_new")
-    _run(config, box_scores_table=box_scores_table, label="nba_nightly")
+    _run(config, suffix=_suffix("_new"), label="nba_nightly")
 
 
 def run_backfill() -> None:
     """On-demand historical backfill across a season range.
 
     Requires NBA_BACKFILL_START_SEASON and NBA_BACKFILL_END_SEASON.
-    Defaults to writing the canonical `box_scores` table since backfills
-    are typically historical and target prod.
+    Targets the production table set by default.
     """
     start = os.environ.get("NBA_BACKFILL_START_SEASON")
     end = os.environ.get("NBA_BACKFILL_END_SEASON")
@@ -116,8 +143,7 @@ def run_backfill() -> None:
         for st in SEASON_TYPES
     )
     config = replace(build_config_from_env(), seasons=seasons)
-    box_scores_table = os.environ.get("NBA_INGEST_BOX_SCORES_TABLE", "box_scores")
-    _run(config, box_scores_table=box_scores_table, label="nba_backfill")
+    _run(config, suffix=_suffix(""), label="nba_backfill")
 
 
 _COMMANDS = {"nightly": run_nightly, "backfill": run_backfill}

--- a/projects/nba-box-scores-pipeline/src/nba_box_scores_pipeline/entrypoints.py
+++ b/projects/nba-box-scores-pipeline/src/nba_box_scores_pipeline/entrypoints.py
@@ -1,0 +1,135 @@
+"""Runnable entrypoints for the ingest flights.
+
+These live in the package (not in flights/<name>/main.py) so the flight
+bootstrappers can invoke them from the uv-synced venv via:
+
+    python -m nba_box_scores_pipeline.entrypoints nightly
+    python -m nba_box_scores_pipeline.entrypoints backfill
+
+The flights/<name>/main.py files are thin bootstrappers: they clone the
+repo, `uv sync`, and shell out to the command above. All real work is here
+so it's importable and unit-testable.
+
+Config comes entirely from env vars (see config.build_config_from_env and
+the per-command notes below) — there's no argv inside a flight.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from dataclasses import replace
+
+from .api.nba import PBPStatsClient
+from .config import (
+    SEASON_TYPES,
+    PipelineConfig,
+    Season,
+    build_config_from_env,
+)
+from .db.connection import connect
+from .db.loader import Loader
+from .db.schema import ensure_box_scores_table, ensure_schema
+from .rate_limiter import RateLimiter
+from .workers.season_worker import process_season
+
+
+DATABASE = "nba_box_scores_v3"
+
+
+def _run(config: PipelineConfig, *, box_scores_table: str, label: str) -> None:
+    log = logging.getLogger(label)
+    log.info(
+        "starting %s database=%s box_scores_table=%s seasons=%s force=%s fill_raw=%s dry_run=%s",
+        label, DATABASE, box_scores_table,
+        [(s.year, s.type) for s in config.seasons],
+        config.force, config.fill_raw, config.dry_run,
+    )
+
+    con = connect(DATABASE)
+    ensure_schema(con, db=DATABASE)
+    if box_scores_table != "box_scores":
+        ensure_box_scores_table(con, box_scores_table)
+        log.info("ensured sandbox table main.%s exists", box_scores_table)
+
+    loader = Loader(con, box_scores_table=box_scores_table)
+    rate_limiter = RateLimiter(
+        base_delay_ms=config.delay_ms,
+        min_delay_ms=config.min_delay_ms,
+        max_delay_ms=config.max_delay_ms,
+    )
+
+    totals = {"completed": 0, "skipped": 0, "failed": 0}
+    with PBPStatsClient(rate_limiter) as client:
+        for season in config.seasons:
+            progress = process_season(
+                season_year=season.year,
+                season_type=season.type,
+                client=client,
+                loader=loader,
+                config=config,
+            )
+            totals["completed"] += progress.completed
+            totals["skipped"] += progress.skipped
+            totals["failed"] += progress.failed
+
+    log.info(
+        "%s complete completed=%d skipped=%d failed=%d",
+        label, totals["completed"], totals["skipped"], totals["failed"],
+    )
+
+
+def run_nightly() -> None:
+    """Current-season ingest (Regular Season + Playoffs).
+
+    Defaults to writing the validation sandbox table `box_scores_new`;
+    set NBA_INGEST_BOX_SCORES_TABLE=box_scores to write production once
+    parity against the cloned baseline is confirmed.
+    """
+    config = build_config_from_env()
+    box_scores_table = os.environ.get("NBA_INGEST_BOX_SCORES_TABLE", "box_scores_new")
+    _run(config, box_scores_table=box_scores_table, label="nba_nightly")
+
+
+def run_backfill() -> None:
+    """On-demand historical backfill across a season range.
+
+    Requires NBA_BACKFILL_START_SEASON and NBA_BACKFILL_END_SEASON.
+    Defaults to writing the canonical `box_scores` table since backfills
+    are typically historical and target prod.
+    """
+    start = os.environ.get("NBA_BACKFILL_START_SEASON")
+    end = os.environ.get("NBA_BACKFILL_END_SEASON")
+    if not start or not end:
+        raise RuntimeError("NBA_BACKFILL_START_SEASON and NBA_BACKFILL_END_SEASON are required")
+    start_year, end_year = int(start), int(end)
+    if start_year > end_year:
+        raise RuntimeError(f"start ({start_year}) must be <= end ({end_year})")
+
+    seasons = tuple(
+        Season(year=y, type=st)
+        for y in range(start_year, end_year + 1)
+        for st in SEASON_TYPES
+    )
+    config = replace(build_config_from_env(), seasons=seasons)
+    box_scores_table = os.environ.get("NBA_INGEST_BOX_SCORES_TABLE", "box_scores")
+    _run(config, box_scores_table=box_scores_table, label="nba_backfill")
+
+
+_COMMANDS = {"nightly": run_nightly, "backfill": run_backfill}
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if len(argv) != 1 or argv[0] not in _COMMANDS:
+        raise SystemExit(f"usage: python -m nba_box_scores_pipeline.entrypoints {{{'|'.join(_COMMANDS)}}}")
+    _COMMANDS[argv[0]]()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/nba-box-scores-pipeline/src/nba_box_scores_pipeline/entrypoints.py
+++ b/projects/nba-box-scores-pipeline/src/nba_box_scores_pipeline/entrypoints.py
@@ -48,10 +48,13 @@ def _run(config: PipelineConfig, *, box_scores_table: str, label: str) -> None:
     )
 
     con = connect(DATABASE)
-    ensure_schema(con, db=DATABASE)
-    if box_scores_table != "box_scores":
-        ensure_box_scores_table(con, box_scores_table)
-        log.info("ensured sandbox table main.%s exists", box_scores_table)
+    if config.dry_run:
+        log.info("dry_run: skipping schema bootstrap (no mutations)")
+    else:
+        ensure_schema(con, db=DATABASE)
+        if box_scores_table != "box_scores":
+            ensure_box_scores_table(con, box_scores_table)
+            log.info("ensured sandbox table main.%s exists", box_scores_table)
 
     loader = Loader(con, box_scores_table=box_scores_table)
     rate_limiter = RateLimiter(

--- a/projects/nba-box-scores-pipeline/tests/test_config_env.py
+++ b/projects/nba-box-scores-pipeline/tests/test_config_env.py
@@ -69,28 +69,59 @@ class TestOverrides:
         assert cfg.max_delay_ms == 20_000
 
 
-class TestFlightMainsImportCleanly:
-    """Both flight entrypoints must import without raising — proves all
-    package-internal imports resolve from a fresh interpreter."""
+def _exec_flight_main(name: str):
+    import importlib.util
+    from pathlib import Path
 
-    def test_nba_nightly_imports(self):
-        import importlib.util
-        from pathlib import Path
+    path = Path(__file__).parent.parent / "flights" / name / "main.py"
+    spec = importlib.util.spec_from_file_location(f"{name}_main", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
-        path = Path(__file__).parent.parent / "flights" / "nba_nightly" / "main.py"
-        spec = importlib.util.spec_from_file_location("nba_nightly_main", path)
-        assert spec and spec.loader
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        assert callable(module.main)
 
-    def test_nba_backfill_imports(self):
-        import importlib.util
-        from pathlib import Path
+class TestFlightBootstrappersParse:
+    """The flight bootstrappers are stdlib-only (clone + uv sync + subprocess);
+    they must parse and expose main()/ENTRYPOINT_COMMAND."""
 
-        path = Path(__file__).parent.parent / "flights" / "nba_backfill" / "main.py"
-        spec = importlib.util.spec_from_file_location("nba_backfill_main", path)
-        assert spec and spec.loader
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        assert callable(module.main)
+    def test_nba_nightly_bootstrapper(self):
+        m = _exec_flight_main("nba_nightly")
+        assert callable(m.main)
+        assert m.ENTRYPOINT_COMMAND == "nightly"
+
+    def test_nba_backfill_bootstrapper(self):
+        m = _exec_flight_main("nba_backfill")
+        assert callable(m.main)
+        assert m.ENTRYPOINT_COMMAND == "backfill"
+
+
+class TestEntrypointDispatch:
+    """The package entrypoint module resolves all internal imports and
+    routes nightly/backfill — this is what the bootstrapper invokes."""
+
+    def test_commands_registered(self):
+        from nba_box_scores_pipeline import entrypoints
+
+        assert set(entrypoints._COMMANDS) == {"nightly", "backfill"}
+
+    def test_unknown_command_exits(self):
+        from nba_box_scores_pipeline import entrypoints
+
+        with pytest.raises(SystemExit):
+            entrypoints.main(["bogus"])
+
+    def test_no_command_exits(self):
+        from nba_box_scores_pipeline import entrypoints
+
+        with pytest.raises(SystemExit):
+            entrypoints.main([])
+
+    def test_backfill_requires_season_range(self, monkeypatch):
+        from nba_box_scores_pipeline import entrypoints
+
+        monkeypatch.setenv("MOTHERDUCK_TOKEN", "t")
+        monkeypatch.delenv("NBA_BACKFILL_START_SEASON", raising=False)
+        monkeypatch.delenv("NBA_BACKFILL_END_SEASON", raising=False)
+        with pytest.raises(RuntimeError, match="NBA_BACKFILL_START_SEASON"):
+            entrypoints.run_backfill()

--- a/projects/nba-box-scores-pipeline/tests/test_loader.py
+++ b/projects/nba-box-scores-pipeline/tests/test_loader.py
@@ -259,17 +259,3 @@ class TestViewsRebind:
             "SELECT DISTINCT team_abbreviation FROM main.team_stats ORDER BY team_abbreviation"
         ).fetchall()
         assert [t[0] for t in teams] == ["BOS", "NYK"]
-
-
-class TestViewsRebind:
-    """Cloned databases inherit view DDL pointing at the source DB; ensure_views fixes that."""
-
-    def test_views_compile_against_active_db(self, con, regulation_rows, loader):
-        loader.load_box_scores(regulation_rows)
-        # In-memory DuckDB names the database "memory"
-        ensure_views(con, db="memory")
-        # team_stats should aggregate the box_scores we loaded
-        teams = con.execute(
-            "SELECT DISTINCT team_abbreviation FROM main.team_stats ORDER BY team_abbreviation"
-        ).fetchall()
-        assert [t[0] for t in teams] == ["BOS", "NYK"]

--- a/projects/nba-box-scores-pipeline/tests/test_loader.py
+++ b/projects/nba-box-scores-pipeline/tests/test_loader.py
@@ -23,7 +23,11 @@ from nba_box_scores_pipeline.db.loader import (
     Loader,
     ScheduleRow,
 )
-from nba_box_scores_pipeline.db.schema import ensure_tables, ensure_views
+from nba_box_scores_pipeline.db.schema import (
+    ensure_tables,
+    ensure_tables_suffixed,
+    ensure_views,
+)
 from nba_box_scores_pipeline.parsers.nba_box_score import parse_box_score
 
 
@@ -183,32 +187,78 @@ class TestRawPbpstats:
         assert loader.get_raw_game_ids(2024, "Playoffs") == set()
 
 
-class TestSandboxTables:
-    """Validation path: write to box_scores_new, leave production box_scores alone."""
+class TestSandboxTableSet:
+    """Validation path: a sandbox run writes an isolated `_new` table set and
+    leaves the entire production set untouched — box scores AND skip/log state.
+    This is the P1 fix: a sandbox run must not mark success in the production
+    ingestion_log (else a later prod flip skips those games)."""
 
-    def test_sandbox_loader_targets_alternate_table(self, con, regulation_rows):
-        # CTAS doesn't preserve PKs, so spell the sandbox table out explicitly.
-        # Same constraint applies in v3: anyone provisioning a `box_scores_new`
-        # has to create it with the (game_id, entity_id, period) PK or the
-        # loader's INSERT OR REPLACE has no conflict target.
-        con.execute(
-            """
-            CREATE TABLE main.box_scores_new (
-              game_id VARCHAR, team_abbreviation VARCHAR, entity_id VARCHAR,
-              player_name VARCHAR, period VARCHAR, minutes VARCHAR,
-              points INTEGER, rebounds INTEGER, assists INTEGER,
-              steals INTEGER, blocks INTEGER, turnovers INTEGER,
-              fg_made INTEGER, fg_attempted INTEGER,
-              fg3_made INTEGER, fg3_attempted INTEGER,
-              ft_made INTEGER, ft_attempted INTEGER, starter INTEGER,
-              PRIMARY KEY (game_id, entity_id, period)
-            )
-            """
-        )
+    def test_ensure_tables_suffixed_creates_full_set(self, con):
+        ensure_tables_suffixed(con, "_new")
+        for name in ("box_scores_new", "schedule_new", "ingestion_log_new", "raw_game_data_pbpstats_new"):
+            assert _count(con, name) == 0  # exists and empty
+
+    def test_suffixed_box_scores_keeps_primary_key(self, con, regulation_rows):
+        # Reusing canonical DDL means the sandbox table keeps the PK, so
+        # INSERT OR REPLACE has a conflict target (reload is idempotent).
+        ensure_tables_suffixed(con, "_new")
         sandbox = Loader(con, box_scores_table="box_scores_new")
         sandbox.load_box_scores(regulation_rows)
+        sandbox.load_box_scores(regulation_rows)
         assert _count(con, "box_scores_new") == len(regulation_rows)
-        assert _count(con, "box_scores") == 0  # production table untouched
+        assert _count(con, "box_scores") == 0
+
+    def test_sandbox_log_isolated_from_production(self, con):
+        ensure_tables_suffixed(con, "_new")
+        sandbox = Loader(
+            con,
+            box_scores_table="box_scores_new",
+            schedule_table="schedule_new",
+            ingestion_log_table="ingestion_log_new",
+            raw_pbpstats_table="raw_game_data_pbpstats_new",
+        )
+        sandbox.mark_ingested(IngestionLogEntry(
+            game_id="0099999999", season_year=2024, season_type="Regular Season",
+        ))
+        # Sandbox run recorded success in its own log...
+        assert sandbox.is_game_ingested("0099999999")
+        # ...but the production loader must NOT see it (else prod flip skips it).
+        prod = Loader(con)
+        assert not prod.is_game_ingested("0099999999")
+        assert _count(con, "ingestion_log") == 0
+
+
+class TestSkipReadsTolerateMissingTables:
+    """A dry run performs no schema bootstrap; skip-reads against a not-yet-
+    created (sandbox) table set must return empty rather than raising."""
+
+    def test_reads_on_absent_tables_return_empty(self):
+        bare = duckdb.connect(":memory:")  # no tables at all
+        try:
+            loader = Loader(
+                bare,
+                ingestion_log_table="ingestion_log_new",
+                raw_pbpstats_table="raw_game_data_pbpstats_new",
+            )
+            assert loader.get_ingested_game_ids(2024, "Regular Season") == set()
+            assert loader.get_raw_game_ids(2024, "Regular Season") == set()
+            assert loader.is_game_ingested("0022400061") is False
+        finally:
+            bare.close()
+
+
+class TestViewsRebind:
+    """Cloned databases inherit view DDL pointing at the source DB; ensure_views fixes that."""
+
+    def test_views_compile_against_active_db(self, con, regulation_rows, loader):
+        loader.load_box_scores(regulation_rows)
+        # In-memory DuckDB names the database "memory"
+        ensure_views(con, db="memory")
+        # team_stats should aggregate the box_scores we loaded
+        teams = con.execute(
+            "SELECT DISTINCT team_abbreviation FROM main.team_stats ORDER BY team_abbreviation"
+        ).fetchall()
+        assert [t[0] for t in teams] == ["BOS", "NYK"]
 
 
 class TestViewsRebind:

--- a/projects/nba-box-scores-pipeline/uv.lock
+++ b/projects/nba-box-scores-pipeline/uv.lock
@@ -1,0 +1,312 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "controllog"
+version = "0.1.0"
+source = { git = "https://github.com/motherduckdb/labs?subdirectory=projects%2Fcontrollog#1db59e4d1bc9de95158e129714e5c8fcdbd36577" }
+
+[[package]]
+name = "duckdb"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/66/744b4931b799a42f8cb9bc7a6f169e7b8e51195b62b246db407fd90bf15f/duckdb-1.5.2.tar.gz", hash = "sha256:638da0d5102b6cb6f7d47f83d0600708ac1d3cb46c5e9aaabc845f9ba4d69246", size = 18017166, upload-time = "2026-04-13T11:30:09.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/de/ebe66bbe78125fc610f4fd415447a65349d94245950f3b3dfb31d028af02/duckdb-1.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e6495b00cad16888384119842797c49316a96ae1cb132bb03856d980d95afee1", size = 30064950, upload-time = "2026-04-13T11:29:11.468Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/8a/3e25b5d03bcf1fb99d189912f8ce92b1db4f9c8778e1b1f55745973a855a/duckdb-1.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d72b8856b1839d35648f38301b058f6232f4d36b463fe4dc8f4d3fdff2df1a2e", size = 15969113, upload-time = "2026-04-13T11:29:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/58001f0815002b1a93431bf907f77854085c7d049b83d521814a07b9db0b/duckdb-1.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2a1de4f4d454b8c97aec546c82003fc834d3422ce4bc6a19902f3462ef293bed", size = 14224774, upload-time = "2026-04-13T11:29:16.758Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2f/a7f0de9509d1cef35608aeb382919041cdd70f58c173865c3da6a0d87979/duckdb-1.5.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce0b8141a10d37ecef729c45bc41d334854013f4389f1488bd6035c5579aaac1", size = 19313510, upload-time = "2026-04-13T11:29:19.574Z" },
+    { url = "https://files.pythonhosted.org/packages/26/78/eb1e064ea8b9df3b87b167bfd7a407b2f615a4291e06cba756727adfa06c/duckdb-1.5.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99ef73a277c8921bc0a1f16dee38d924484251d9cfd20951748c20fcd5ed855", size = 21429692, upload-time = "2026-04-13T11:29:22.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/12/05b0c47d14839925c5e35b79081d918ca82e3f236bb724a6f58409dd5291/duckdb-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:8d599758b4e48bf12e18c9b960cf491d219f0c4972d19a45489c05cc5ab36f83", size = 13107594, upload-time = "2026-04-13T11:29:25.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2c/80558a82b236e044330e84a154b96aacddb343316b479f3d49be03ea11cb/duckdb-1.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:fc85a5dbcbe6eccac1113c72370d1d3aacfdd49198d63950bdf7d8638a307f00", size = 13927537, upload-time = "2026-04-13T11:29:27.842Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f2/e3d742808f138d374be4bb516fade3d1f33749b813650810ab7885cdc363/duckdb-1.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4420b3f47027a7849d0e1815532007f377fa95ee5810b47ea717d35525c12f79", size = 30064879, upload-time = "2026-04-13T11:29:30.763Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/f3dc1cf97e1267ca15e4307d456f96ce583961f0703fd75e62b2ad8d64fa/duckdb-1.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:bb42e6ed543902e14eae647850da24103a89f0bc2587dec5601b1c1f213bd2ed", size = 15969327, upload-time = "2026-04-13T11:29:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e0/d5418def53ae4e05a63075705ff44ed5af5a1a5932627eb2b600c5df1c93/duckdb-1.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98c0535cd6d901f61a5ea3c2e26a1fd28482953d794deb183daf568e3aa5dda6", size = 14225107, upload-time = "2026-04-13T11:29:35.882Z" },
+    { url = "https://files.pythonhosted.org/packages/16/a7/15aaa59dbecc35e9711980fcdbf525b32a52470b32d18ef678193a146213/duckdb-1.5.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:486c862bf7f163c0110b6d85b3e5c031d224a671cca468f12ebb1d3a348f6b39", size = 19313433, upload-time = "2026-04-13T11:29:38.367Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/21/d903cc63a5140c822b7b62b373a87dc557e60c29b321dfb435061c5e67cf/duckdb-1.5.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70631c847ca918ee710ec874241b00cf9d2e5be90762cbb2a0389f17823c08f7", size = 21429837, upload-time = "2026-04-13T11:29:41.135Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/0a/b770d1f60c70597302130d6247f418549b7094251a02348fbaf1c7e147ae/duckdb-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:52a21823f3fbb52f0f0e5425e20b07391ad882464b955879499b5ff0b45a376b", size = 13107699, upload-time = "2026-04-13T11:29:43.905Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cf/e200fe431d700962d1a908d2ce89f53ccee1cc8db260174ae663ba09686b/duckdb-1.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:411ad438bd4140f189a10e7f515781335962c5d18bd07837dc6d202e3985253d", size = 13927646, upload-time = "2026-04-13T11:29:46.598Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a1/f6286c67726cc1ea60a6e3c0d9fbc66527dde24ae089a51bbe298b13ca78/duckdb-1.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6b0fe75c148000f060aa1a27b293cacc0ea08cc1cad724fbf2143d56070a3785", size = 30078598, upload-time = "2026-04-13T11:29:49.828Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6a/59febb02f21a4a5c6b0b0099ef7c965fdd5e61e4904cf813809bb792e35f/duckdb-1.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:35579b8e3a064b5eaf15b0eafc558056a13f79a0a62e34cc4baf57119daecfec", size = 15975120, upload-time = "2026-04-13T11:29:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/09/70/ce750854d37bb5a45cccbb2c3cb04df4af56aea8fc30a2499bb643b4a9c0/duckdb-1.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea58ff5b0880593a280cf5511734b17711b32ee1f58b47d726e8600848358160", size = 14227762, upload-time = "2026-04-13T11:29:55.564Z" },
+    { url = "https://files.pythonhosted.org/packages/28/dc/ad45ac3c0b6c4687dc649e8f6cf01af1c8b0443932a39b2abb4ebcb3babd/duckdb-1.5.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef461bca07313412dc09961c4a4757a851f56b95ac01c58fac6007632b7b94f2", size = 19315668, upload-time = "2026-04-13T11:29:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b1/1464f468d2e5813f5808de95df9d3113a645a5bfa2ffcaecbc542ddae272/duckdb-1.5.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be37680ddb380015cb37318e378c53511c45c4f0d8fac5599d22b7d092b9217a", size = 21434056, upload-time = "2026-04-13T11:30:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/32/6673607e024722473fa7aafdd29c0e3dd231dd528f6cd8b5797fbeeb229d/duckdb-1.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:0b291786014df1133f8f18b9df4d004484613146e858d71a21791e0fcca16cf4", size = 13633667, upload-time = "2026-04-13T11:30:04.05Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e3/9d34173ec068631faea3ea6e73050700729363e7e33306a9a3218e5cdc61/duckdb-1.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:c9f3e0b71b8a50fccfb42794899285d9d318ce2503782b9dd54868e5ecd0ad31", size = 14402513, upload-time = "2026-04-13T11:30:06.609Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "nba-box-scores-pipeline"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "controllog" },
+    { name = "duckdb" },
+    { name = "httpx" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pydantic" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "controllog", git = "https://github.com/motherduckdb/labs?subdirectory=projects%2Fcontrollog" },
+    { name = "duckdb", specifier = ">=1.3.0,<1.5.3" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "pydantic", marker = "extra == 'dev'", specifier = ">=2.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]


### PR DESCRIPTION
## Summary

Pivots the flight entrypoints to a **"flight as CI runner"** pattern (inspired by a working dbt-runner flight), which **eliminates the `deploy.py` / Flights-SQL blocker** entirely. Validated end-to-end against the live flight runtime.

### The pattern

Each flight's registered `source_code` is now a thin, stable bootstrapper that:
1. `apt-get install git` (if needed)
2. shallow-clones `labs@<branch>` (default `nba-migration`; `NBA_FLIGHT_REPO_BRANCH` overrides)
3. `uv sync` the pipeline package
4. runs `python -m nba_box_scores_pipeline.entrypoints {nightly|backfill}` from the synced venv

Because code is fetched at run time, **pushing to the branch updates what the next run executes** — no flight re-registration, no `MD_CREATE_FLIGHT` SQL, no CI deploy step. We register each flight **once** via the MCP `create_flight`.

### Changes

- **`entrypoints.py`** (new): the real `run_nightly()` / `run_backfill()` logic, moved out of `flights/*/main.py` into the importable package so it's unit-testable and `python -m`-invokable.
- **`flights/nba_nightly/main.py`** + **`nba_backfill/main.py`**: rewritten as stdlib-only bootstrappers.
- **`pyproject.toml`**: pin `duckdb>=1.3.0,<1.5.3`. MotherDuck's server rejects client 1.5.3 (max supported 1.5.2); the harness test hit this on `md:` connect. Local tests use `:memory:` so were unaffected.
- **`schema.py`**: `ensure_box_scores_table()` reuses canonical DDL for the sandbox table (replaces DDL that was duplicated inline in the old `main.py`).
- **`entrypoints._run`**: `dry_run` now skips schema mutations (inspect-only).

### Validated on the runtime (throwaway flights, since deleted)

1. **Harness test** (read-only): apt-get git → clone → `uv sync` (builds our pkg + controllog-from-git, `duckdb==1.5.2`) → `import nba_box_scores_pipeline` → `duckdb.connect("md:")` → `SELECT COUNT(*) ... box_scores` = 3,049,526. Exit 0.
2. **Dry-run** of the real bootstrapper: → `entrypoints nightly` → env config (season 2024, dry_run) → real `get-games` API (200) for Regular Season + Playoffs → skip logic matched all **1,314** cloned games in `v3.ingestion_log` → `completed=0 skipped=1314 failed=0`. Exit 0.

### Tradeoffs (unchanged, acceptable for a nightly scrape)

- Clone-at-branch-HEAD → no SHA pinning / reproducibility, no per-PR preview flights. Recoverable via `deploy.py` if/when Flights SQL ships.

### Test plan

- [x] `pytest tests/` — 50/50 green
- [x] Harness + dry-run validated on the live runtime
- [ ] First real run: register `nba_nightly` once via MCP `create_flight` (`md_token_name=dives-loader-nba`, source = `flights/nba_nightly/main.py`, on-demand), run it, watch `box_scores_new` populate, diff vs the `box_scores` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)