### PR TITLE
nba-box-scores-dive: Phase 2 dive — schedule, box scores, GQ leaderboard, trends

### DIFF
--- a/projects/nba-box-scores-dive/.dive-preview/.gitignore
+++ b/projects/nba-box-scores-dive/.dive-preview/.gitignore
@@ -1,0 +1,2 @@
+.env
+node_modules/

--- a/projects/nba-box-scores-dive/.dive-preview/bundle.mjs
+++ b/projects/nba-box-scores-dive/.dive-preview/bundle.mjs
@@ -1,0 +1,54 @@
+// Bundle the multi-file dive source into a single self-contained .jsx that
+// save_dive accepts. Inlines our own ./components and ./lib imports; leaves the
+// runtime-provided libraries external (the dive runtime supplies them).
+//
+//   node bundle.mjs
+//
+// Output: ../dist/dive.jsx  (the string to pass to save_dive)
+import { build } from "esbuild";
+import { readFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const outfile = path.resolve(here, "../dist/dive.jsx");
+mkdirSync(path.dirname(outfile), { recursive: true });
+
+// These are externalized by the dive runtime — must NOT be inlined.
+const EXTERNAL = [
+  "react",
+  "react-dom",
+  "recharts",
+  "d3",
+  "lucide-react",
+  "@motherduck/react-sql-query",
+];
+
+await build({
+  entryPoints: [path.resolve(here, "src/dive.tsx")],
+  bundle: true,
+  format: "esm",
+  jsx: "preserve", // keep JSX; the dive runtime transpiles
+  target: "esnext",
+  charset: "utf8",
+  legalComments: "none",
+  external: EXTERNAL,
+  outfile,
+});
+
+const code = readFileSync(outfile, "utf8");
+const sizeKB = (Buffer.byteLength(code, "utf8") / 1024).toFixed(1);
+
+// Sanity checks.
+const problems = [];
+if (!/export\s*\{[^}]*\bas default\b|export default/.test(code))
+  problems.push("no default export found");
+if (/from\s*["']\.\.?\//.test(code))
+  problems.push("a relative import survived (local file not inlined)");
+for (const ext of EXTERNAL) {
+  // each used external should appear as a bare import
+}
+
+console.log(`bundled -> ${outfile}`);
+console.log(`size: ${sizeKB} KB`);
+console.log(problems.length ? `PROBLEMS: ${problems.join("; ")}` : "checks: OK");

--- a/projects/nba-box-scores-dive/.dive-preview/index.html
+++ b/projects/nba-box-scores-dive/.dive-preview/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dive Preview</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body style="background:#f8f8f8">
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/projects/nba-box-scores-dive/.dive-preview/package-lock.json
+++ b/projects/nba-box-scores-dive/.dive-preview/package-lock.json
@@ -1,0 +1,2498 @@
+{
+  "name": ".dive-preview",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@motherduck/wasm-client": "^0.8.0",
+        "apache-arrow": "^17.0.0",
+        "lucide-react": "^0.468.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "recharts": "~3.7.0"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-react": "^4.3.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@motherduck/wasm-client": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@motherduck/wasm-client/-/wasm-client-0.8.1.tgz",
+      "integrity": "sha512-/WSEwvk0YkzmsAnKSZtl9IF9fAyqkoavkmc55W3k6CP/fdVfXvW0zSyDhH6VQdFrMYLMbyPgFtfYC28bqHZsbA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "apache-arrow": "^17.0.0"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/apache-arrow": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz",
+      "integrity": "sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^24.3.25",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.cjs"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.364",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.364.tgz",
+      "integrity": "sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "24.12.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
+      "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.468.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
+      "integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/projects/nba-box-scores-dive/.dive-preview/package.json
+++ b/projects/nba-box-scores-dive/.dive-preview/package.json
@@ -1,0 +1,17 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": { "dev": "vite" },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "@motherduck/wasm-client": "^0.8.0",
+    "apache-arrow": "^17.0.0",
+    "recharts": "~3.7.0",
+    "lucide-react": "^0.468.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/projects/nba-box-scores-dive/.dive-preview/src/components/BoxScorePanel.tsx
+++ b/projects/nba-box-scores-dive/.dive-preview/src/components/BoxScorePanel.tsx
@@ -1,0 +1,141 @@
+import { useState } from "react";
+import { useSQLQuery } from "@motherduck/react-sql-query";
+import { Loader2, X } from "lucide-react";
+import BoxScoreTable, { PlayerRow } from "./BoxScoreTable";
+import PlayerGameLog from "./PlayerGameLog";
+import { DB } from "../lib/query";
+import { N, sqlStr, COLORS } from "../lib/format";
+import { getTeamName } from "../lib/teams";
+
+function formatLongDate(d: string): string {
+  const [y, m, day] = d.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, day)).toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export default function BoxScorePanel({
+  gameId,
+  onClose,
+}: {
+  gameId: string | null;
+  onClose: () => void;
+}) {
+  const enabled = !!gameId;
+  const id = gameId ?? "";
+  const [sel, setSel] = useState<{ id: string; name: string } | null>(null);
+
+  const gameQ = useSQLQuery(
+    `SELECT home_team_abbreviation AS home, away_team_abbreviation AS away,
+            home_team_score AS home_score, away_team_score AS away_score,
+            strftime(game_date, '%Y-%m-%d') AS d, season_type, season_year
+     FROM ${DB}."schedule" WHERE game_id = ${sqlStr(id)}`,
+    { enabled },
+  );
+
+  const playersQ = useSQLQuery(
+    `SELECT entity_id, player_name, team_abbreviation, minutes,
+            points, rebounds, assists, steals, blocks, turnovers,
+            fg_made, fg_attempted, fg3_made, fg3_attempted, ft_made, ft_attempted, starter
+     FROM ${DB}."box_scores"
+     WHERE game_id = ${sqlStr(id)} AND period = 'FullGame'
+     ORDER BY (coalesce(TRY_CAST(split_part(minutes, ':', 1) AS INTEGER), 0) * 60
+             + coalesce(TRY_CAST(split_part(minutes, ':', 2) AS INTEGER), 0)) DESC,
+              points DESC`,
+    { enabled },
+  );
+
+  if (!gameId) return null;
+
+  const game = gameQ.isSuccess ? (gameQ.data as any[])[0] : null;
+  const allPlayers = (Array.isArray(playersQ.data) ? playersQ.data : []) as any[];
+  const homeAbbr = game ? String(game.home) : "";
+  const awayAbbr = game ? String(game.away) : "";
+  const homePlayers = allPlayers.filter((p) => String(p.team_abbreviation) === homeAbbr) as PlayerRow[];
+  const awayPlayers = allPlayers.filter((p) => String(p.team_abbreviation) === awayAbbr) as PlayerRow[];
+
+  const loading = gameQ.isLoading || playersQ.isLoading;
+  const homeWins = game ? N(game.home_score) > N(game.away_score) : false;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex justify-end"
+      style={{ background: "rgba(0,0,0,0.5)" }}
+      onClick={onClose}
+    >
+      <div
+        className="h-full overflow-y-auto p-4"
+        style={{ width: "min(900px, 90%)", background: COLORS.card }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between mb-3">
+          <div>
+            {game && (
+              <>
+                <h2 className="text-xl text-center" style={{ color: COLORS.text }}>
+                  {homeWins ? (
+                    <>
+                      <span>{awayAbbr} {N(game.away_score)}</span>
+                      {" — "}
+                      <span className="font-bold">{homeAbbr} {N(game.home_score)} *</span>
+                    </>
+                  ) : (
+                    <>
+                      <span className="font-bold">* {awayAbbr} {N(game.away_score)}</span>
+                      {" — "}
+                      <span>{homeAbbr} {N(game.home_score)}</span>
+                    </>
+                  )}
+                </h2>
+                <p className="text-sm mt-0.5" style={{ color: COLORS.muted }}>
+                  {formatLongDate(String(game.d))}
+                  {String(game.season_type) === "Playoffs" ? " · Playoffs" : ""}
+                </p>
+              </>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="p-2 rounded-full hover:bg-gray-100"
+            style={{ color: COLORS.muted }}
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20 gap-2" style={{ color: COLORS.muted }}>
+            <Loader2 className="animate-spin" size={20} /> Loading box score…
+          </div>
+        ) : (
+          <div className="space-y-5">
+            <BoxScoreTable
+              teamName={getTeamName(awayAbbr)}
+              players={awayPlayers}
+              onPlayerClick={(eid, name) => setSel({ id: eid, name })}
+            />
+            <BoxScoreTable
+              teamName={getTeamName(homeAbbr)}
+              players={homePlayers}
+              onPlayerClick={(eid, name) => setSel({ id: eid, name })}
+            />
+          </div>
+        )}
+      </div>
+
+      {sel && (
+        <PlayerGameLog
+          entityId={sel.id}
+          playerName={sel.name}
+          season={game ? N(game.season_year) : null}
+          onClose={() => setSel(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/projects/nba-box-scores-dive/.dive-preview/src/components/BoxScoreTable.tsx
+++ b/projects/nba-box-scores-dive/.dive-preview/src/components/BoxScoreTable.tsx
@@ -1,0 +1,131 @@
+import { N, COLORS } from "../lib/format";
+
+export interface PlayerRow {
+  entity_id: string;
+  player_name: string;
+  minutes: string;
+  points: number;
+  rebounds: number;
+  assists: number;
+  steals: number;
+  blocks: number;
+  turnovers: number;
+  fg_made: number;
+  fg_attempted: number;
+  fg3_made: number;
+  fg3_attempted: number;
+  ft_made: number;
+  ft_attempted: number;
+  starter: number;
+}
+
+const COLS = ["MIN", "PTS", "REB", "AST", "STL", "BLK", "TO", "FG", "3P", "FT"];
+
+export default function BoxScoreTable({
+  teamName,
+  players,
+  onPlayerClick,
+}: {
+  teamName: string;
+  players: PlayerRow[];
+  onPlayerClick?: (entityId: string, playerName: string) => void;
+}) {
+  if (!players.length) {
+    return (
+      <div>
+        <h3 className="font-bold text-base mb-1" style={{ color: COLORS.text }}>
+          {teamName}
+        </h3>
+        <p className="text-sm" style={{ color: COLORS.muted }}>
+          No player stats available
+        </p>
+      </div>
+    );
+  }
+
+  const totals = players.reduce(
+    (a, p) => ({
+      points: a.points + N(p.points),
+      rebounds: a.rebounds + N(p.rebounds),
+      assists: a.assists + N(p.assists),
+      steals: a.steals + N(p.steals),
+      blocks: a.blocks + N(p.blocks),
+      turnovers: a.turnovers + N(p.turnovers),
+      fgM: a.fgM + N(p.fg_made),
+      fgA: a.fgA + N(p.fg_attempted),
+      tpM: a.tpM + N(p.fg3_made),
+      tpA: a.tpA + N(p.fg3_attempted),
+      ftM: a.ftM + N(p.ft_made),
+      ftA: a.ftA + N(p.ft_attempted),
+    }),
+    { points: 0, rebounds: 0, assists: 0, steals: 0, blocks: 0, turnovers: 0, fgM: 0, fgA: 0, tpM: 0, tpA: 0, ftM: 0, ftA: 0 },
+  );
+
+  const th = "px-2 py-0.5 text-right text-xs font-semibold";
+  const td = "px-2 py-0.5 text-right text-sm tabular-nums";
+
+  return (
+    <div>
+      <h3 className="font-bold text-base mb-1" style={{ color: COLORS.text }}>
+        {teamName}
+      </h3>
+      <table className="min-w-full table-fixed tabular-nums">
+        <thead>
+          <tr style={{ background: COLORS.headerBg }}>
+            <th className="px-2 py-0.5 text-left text-xs font-semibold" style={{ color: COLORS.text }}>
+              Player
+            </th>
+            {COLS.map((c) => (
+              <th key={c} className={th} style={{ color: COLORS.text }}>
+                {c}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {players.map((p, i) => (
+            <tr key={p.entity_id || p.player_name} style={{ background: i % 2 ? COLORS.altRow : COLORS.card }}>
+              <td className="px-2 py-0.5 text-left text-sm">
+                {onPlayerClick ? (
+                  <button
+                    className="hover:underline"
+                    style={{ color: COLORS.primary }}
+                    onClick={() => onPlayerClick(p.entity_id, p.player_name)}
+                  >
+                    {p.player_name}
+                  </button>
+                ) : (
+                  <span style={{ color: COLORS.text }}>{p.player_name}</span>
+                )}
+                {N(p.starter) === 1 ? <span style={{ color: COLORS.muted }}> *</span> : null}
+              </td>
+              <td className={td} style={{ color: COLORS.text }}>{p.minutes || "0:00"}</td>
+              <td className={td} style={{ color: COLORS.text }}>{N(p.points)}</td>
+              <td className={td} style={{ color: COLORS.text }}>{N(p.rebounds)}</td>
+              <td className={td} style={{ color: COLORS.text }}>{N(p.assists)}</td>
+              <td className={td} style={{ color: COLORS.text }}>{N(p.steals)}</td>
+              <td className={td} style={{ color: COLORS.text }}>{N(p.blocks)}</td>
+              <td className={td} style={{ color: COLORS.text }}>{N(p.turnovers)}</td>
+              <td className={td} style={{ color: COLORS.text }}>{N(p.fg_made)}-{N(p.fg_attempted)}</td>
+              <td className={td} style={{ color: COLORS.text }}>{N(p.fg3_made)}-{N(p.fg3_attempted)}</td>
+              <td className={td} style={{ color: COLORS.text }}>{N(p.ft_made)}-{N(p.ft_attempted)}</td>
+            </tr>
+          ))}
+          <tr className="font-bold" style={{ background: COLORS.totalBg }}>
+            <td className="px-2 py-0.5 text-left text-sm" style={{ color: COLORS.text }}>TOTAL</td>
+            <td className={td} style={{ color: COLORS.text }}>-</td>
+            <td className={td} style={{ color: COLORS.text }}>{totals.points}</td>
+            <td className={td} style={{ color: COLORS.text }}>{totals.rebounds}</td>
+            <td className={td} style={{ color: COLORS.text }}>{totals.assists}</td>
+            <td className={td} style={{ color: COLORS.text }}>{totals.steals}</td>
+            <td className={td} style={{ color: COLORS.text }}>{totals.blocks}</td>
+            <td className={td} style={{ color: COLORS.text }}>{totals.turnovers}</td>
+            <td className={td} style={{ color: COLORS.text }}>{totals.fgM}-{totals.fgA}</td>
+            <td className={td} style={{ color: COLORS.text }}>{totals.tpM}-{totals.tpA}</td>
+            <td className={td} style={{ color: COLORS.text }}>{totals.ftM}-{totals.ftA}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/projects/nba-box-scores-dive/.dive-preview/src/components/GameCard.tsx
+++ b/projects/nba-box-scores-dive/.dive-preview/src/components/GameCard.tsx
@@ -1,0 +1,84 @@
+import { periodLabel, COLORS } from "../lib/format";
+
+export interface GameCardData {
+  game_id: string;
+  home_abbr: string;
+  away_abbr: string;
+  home_score: number;
+  away_score: number;
+  isPlayoff: boolean;
+  game_status: string;
+  // period -> { [team_abbr]: points }
+  periodList: string[];
+  periodPoints: Record<string, Record<string, number>>;
+}
+
+export default function GameCard({
+  game,
+  onSelect,
+}: {
+  game: GameCardData;
+  onSelect: (id: string) => void;
+}) {
+  const cellPts = (period: string, team: string) =>
+    game.periodPoints[period]?.[team] ?? "";
+
+  const teamRow = (abbr: string, total: number, isWinner: boolean) => (
+    <tr>
+      <td
+        className="text-left py-0.5 pr-2 font-medium"
+        style={{ color: COLORS.text }}
+      >
+        {abbr}
+      </td>
+      {game.periodList.map((p) => (
+        <td
+          key={p}
+          className="text-center py-0.5 tabular-nums"
+          style={{ color: COLORS.muted, width: 26 }}
+        >
+          {cellPts(p, abbr)}
+        </td>
+      ))}
+      <td
+        className="text-center py-0.5 tabular-nums font-bold"
+        style={{ color: COLORS.text, width: 30 }}
+      >
+        {total}
+      </td>
+    </tr>
+  );
+
+  const homeWins = game.home_score > game.away_score;
+
+  return (
+    <div
+      onClick={() => onSelect(game.game_id)}
+      className="cursor-pointer rounded-lg p-4 shadow-md hover:shadow-lg transition-shadow"
+      style={{
+        background: COLORS.card,
+        borderLeft: game.isPlayoff ? `4px solid ${COLORS.playoff}` : undefined,
+      }}
+    >
+      <table className="w-full text-sm">
+        <thead>
+          <tr style={{ color: COLORS.muted }}>
+            <th className="text-left font-normal pb-1"> </th>
+            {game.periodList.map((p) => (
+              <th key={p} className="text-center font-normal pb-1" style={{ width: 26 }}>
+                {periodLabel(p)}
+              </th>
+            ))}
+            <th className="text-center font-normal pb-1" style={{ width: 30 }}>
+              T
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {teamRow(game.away_abbr, game.away_score, !homeWins)}
+          {teamRow(game.home_abbr, game.home_score, homeWins)}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/projects/nba-box-scores-dive/.dive-preview/src/components/GameQualityExplorer.tsx
+++ b/projects/nba-box-scores-dive/.dive-preview/src/components/GameQualityExplorer.tsx
@@ -1,0 +1,188 @@
+import { useState } from "react";
+import { useSQLQuery } from "@motherduck/react-sql-query";
+import { Loader2 } from "lucide-react";
+import PlayerGameLog from "./PlayerGameLog";
+import { DB, Filters, seasonTypeWhere, playerEntityIds } from "../lib/query";
+import { N, sqlStr, COLORS } from "../lib/format";
+
+interface Col {
+  key: string;
+  label: string;
+  fmt: (v: number) => string;
+  num: boolean;
+}
+
+const PCT = (v: number) => (v * 100).toFixed(1) + "%";
+const D1 = (v: number) => v.toFixed(1);
+const SIGNED = (v: number) => (v >= 0 ? "+" : "") + v.toFixed(2);
+const INT = (v: number) => String(Math.round(v));
+
+const COLS: Col[] = [
+  { key: "avg_gq", label: "GQ", fmt: PCT, num: true },
+  { key: "gp", label: "GP", fmt: INT, num: true },
+  { key: "ppg", label: "PTS", fmt: D1, num: true },
+  { key: "rpg", label: "REB", fmt: D1, num: true },
+  { key: "apg", label: "AST", fmt: D1, num: true },
+  { key: "spg", label: "STL", fmt: D1, num: true },
+  { key: "bpg", label: "BLK", fmt: D1, num: true },
+  { key: "topg", label: "TO", fmt: D1, num: true },
+  { key: "fg_v", label: "FGv", fmt: SIGNED, num: true },
+  { key: "ft_v", label: "FTv", fmt: SIGNED, num: true },
+  { key: "tpm", label: "3PM", fmt: D1, num: true },
+];
+
+export default function GameQualityExplorer({ filters }: { filters: Filters }) {
+  const [minGames, setMinGames] = useState(10);
+  const [sortKey, setSortKey] = useState("avg_gq");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+  const [sel, setSel] = useState<{ id: string; name: string } | null>(null);
+
+  const teamJoin = filters.team
+    ? `JOIN ${DB}."box_scores" bt ON bt.game_id = gq.game_id AND bt.entity_id = gq.entity_id
+        AND bt.period = 'FullGame' AND bt.team_abbreviation = ${sqlStr(filters.team)}`
+    : "";
+  const playerCond = filters.player ? `AND gq.entity_id IN ${playerEntityIds(filters.player)}` : "";
+
+  // game_quality = -1 is the sentinel for sub-15-min games (don't qualify for
+  // the GQ calc); exclude them so they don't drag the average down. Group by the
+  // stable entity_id and show the most recent name to defeat name drift.
+  const q = useSQLQuery(`
+    SELECT gq.entity_id,
+           arg_max(gq.player_name, s.game_date) AS player_name,
+           COUNT(*) AS gp,
+           AVG(gq.game_quality) AS avg_gq,
+           AVG(gq.points) AS ppg, AVG(gq.rebounds) AS rpg, AVG(gq.assists) AS apg,
+           AVG(gq.steals) AS spg, AVG(gq.blocks) AS bpg, AVG(gq.turnovers) AS topg,
+           AVG(gq.fg_v) AS fg_v, AVG(gq.ft_v) AS ft_v, AVG(gq.fg3_made) AS tpm
+    FROM ${DB}."game_quality" gq
+    JOIN ${DB}."schedule" s ON gq.game_id = s.game_id
+    ${teamJoin}
+    WHERE ${seasonTypeWhere(filters)} AND gq.game_quality >= 0 ${playerCond}
+    GROUP BY gq.entity_id
+    HAVING COUNT(*) >= ${Number(minGames)}
+    ORDER BY avg_gq DESC
+    LIMIT 200
+  `);
+
+  const rows = (Array.isArray(q.data) ? q.data : []).map((r) => {
+    const o: Record<string, number | string> = {
+      entity_id: String(r.entity_id),
+      player_name: String(r.player_name),
+    };
+    for (const c of COLS) o[c.key] = N(r[c.key]);
+    return o;
+  });
+
+  const sorted = [...rows].sort((a, b) => {
+    const av = a[sortKey] as number;
+    const bv = b[sortKey] as number;
+    return sortDir === "desc" ? bv - av : av - bv;
+  });
+
+  const clickSort = (key: string) => {
+    if (sortKey === key) setSortDir((d) => (d === "desc" ? "asc" : "desc"));
+    else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+  };
+
+  const arrow = (key: string) => (sortKey === key ? (sortDir === "desc" ? " ▾" : " ▴") : "");
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-3">
+        <label className="text-sm" style={{ color: COLORS.muted }}>
+          Min games
+        </label>
+        <input
+          type="range"
+          min={1}
+          max={50}
+          value={minGames}
+          onChange={(e) => setMinGames(Number(e.target.value))}
+          className="w-40"
+        />
+        <span className="text-sm font-medium tabular-nums" style={{ color: COLORS.text }}>
+          {minGames}
+        </span>
+        <span className="text-sm ml-auto" style={{ color: COLORS.muted }}>
+          {q.isSuccess ? `${sorted.length} players` : ""}
+        </span>
+      </div>
+      <p className="text-xs mb-3" style={{ color: COLORS.muted }}>
+        Game Quality averages only games with 15+ minutes played; GP counts those qualifying games.
+      </p>
+
+      {q.isError ? (
+        <div className="py-8 text-sm" style={{ color: "#bc1200" }}>
+          Error: {q.error?.message}
+        </div>
+      ) : q.isLoading && rows.length === 0 ? (
+        <div className="flex items-center justify-center py-16 gap-2" style={{ color: COLORS.muted }}>
+          <Loader2 className="animate-spin" size={18} /> Loading…
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full tabular-nums">
+            <thead>
+              <tr style={{ background: COLORS.headerBg }}>
+                <th
+                  className="px-2 py-1 text-left text-xs font-semibold cursor-pointer"
+                  style={{ color: COLORS.text }}
+                  onClick={() => clickSort("player_name")}
+                >
+                  Player
+                </th>
+                {COLS.map((c) => (
+                  <th
+                    key={c.key}
+                    className="px-2 py-1 text-right text-xs font-semibold cursor-pointer whitespace-nowrap"
+                    style={{ color: COLORS.text }}
+                    onClick={() => clickSort(c.key)}
+                  >
+                    {c.label}
+                    {arrow(c.key)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((r, i) => (
+                <tr key={String(r.entity_id)} style={{ background: i % 2 ? COLORS.altRow : COLORS.card }}>
+                  <td className="px-2 py-0.5 text-left text-sm whitespace-nowrap">
+                    <button
+                      className="hover:underline"
+                      style={{ color: COLORS.primary }}
+                      onClick={() => setSel({ id: String(r.entity_id), name: String(r.player_name) })}
+                    >
+                      {String(r.player_name)}
+                    </button>
+                  </td>
+                  {COLS.map((c) => (
+                    <td
+                      key={c.key}
+                      className="px-2 py-0.5 text-right text-sm"
+                      style={{ color: c.key === "avg_gq" ? COLORS.primary : COLORS.text }}
+                    >
+                      {c.fmt(r[c.key] as number)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {sel && (
+        <PlayerGameLog
+          entityId={sel.id}
+          playerName={sel.name}
+          season={filters.season}
+          onClose={() => setSel(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/projects/nba-box-scores-dive/.dive-preview/src/components/PlayerGameLog.tsx
+++ b/projects/nba-box-scores-dive/.dive-preview/src/components/PlayerGameLog.tsx
@@ -40,7 +40,11 @@ export default function PlayerGameLog({
   const td = "px-2 py-0.5 text-right text-sm tabular-nums";
 
   return (
-    <div className="fixed inset-0 z-[60] flex justify-end" style={{ background: "rgba(0,0,0,0.5)" }} onClick={onClose}>
+    <div
+      className="fixed inset-0 flex justify-end"
+      style={{ background: "rgba(0,0,0,0.5)", zIndex: 60 }}
+      onClick={onClose}
+    >
       <div
         className="h-full overflow-y-auto p-4"
         style={{ width: "min(820px, 92%)", background: COLORS.card }}

--- a/projects/nba-box-scores-dive/.dive-preview/src/components/PlayerGameLog.tsx
+++ b/projects/nba-box-scores-dive/.dive-preview/src/components/PlayerGameLog.tsx
@@ -1,0 +1,131 @@
+import { useSQLQuery } from "@motherduck/react-sql-query";
+import { Loader2, X } from "lucide-react";
+import { DB } from "../lib/query";
+import { N, sqlStr, seasonLabel, COLORS } from "../lib/format";
+
+export default function PlayerGameLog({
+  entityId,
+  playerName,
+  season,
+  onClose,
+}: {
+  entityId: string;
+  playerName: string;
+  season: number | null;
+  onClose: () => void;
+}) {
+  const seasonCond = season != null ? `AND s.season_year = ${Number(season)}` : "";
+
+  const q = useSQLQuery(`
+    SELECT strftime(s.game_date, '%Y-%m-%d') AS d, s.season_type,
+           b.team_abbreviation AS team,
+           CASE WHEN s.home_team_abbreviation = b.team_abbreviation
+                THEN s.away_team_abbreviation ELSE s.home_team_abbreviation END AS opp,
+           CASE WHEN s.home_team_abbreviation = b.team_abbreviation THEN 'vs' ELSE '@' END AS loc,
+           CASE WHEN (s.home_team_abbreviation = b.team_abbreviation AND s.home_team_score > s.away_team_score)
+                  OR (s.away_team_abbreviation = b.team_abbreviation AND s.away_team_score > s.home_team_score)
+                THEN 'W' ELSE 'L' END AS result,
+           greatest(s.home_team_score, s.away_team_score) AS win_score,
+           least(s.home_team_score, s.away_team_score) AS lose_score,
+           b.minutes, b.points, b.rebounds, b.assists, b.steals, b.blocks, b.turnovers,
+           b.fg_made, b.fg_attempted, b.fg3_made, b.fg3_attempted, b.ft_made, b.ft_attempted
+    FROM ${DB}."box_scores" b
+    JOIN ${DB}."schedule" s ON b.game_id = s.game_id
+    WHERE b.period = 'FullGame' AND b.entity_id = ${sqlStr(entityId)} ${seasonCond}
+    ORDER BY s.game_date DESC
+  `);
+
+  const rows = Array.isArray(q.data) ? q.data : [];
+  const cols = ["Date", "", "Opp", "W/L", "MIN", "PTS", "REB", "AST", "STL", "BLK", "TO", "FG", "3P", "FT"];
+  const td = "px-2 py-0.5 text-right text-sm tabular-nums";
+
+  return (
+    <div className="fixed inset-0 z-[60] flex justify-end" style={{ background: "rgba(0,0,0,0.5)" }} onClick={onClose}>
+      <div
+        className="h-full overflow-y-auto p-4"
+        style={{ width: "min(820px, 92%)", background: COLORS.card }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between mb-3">
+          <div>
+            <h2 className="text-xl font-bold" style={{ color: COLORS.text }}>
+              {playerName}
+            </h2>
+            <p className="text-sm" style={{ color: COLORS.muted }}>
+              Game log{season != null ? ` · ${seasonLabel(season)}` : " · all seasons"}
+              {rows.length ? ` · ${rows.length} games` : ""}
+            </p>
+          </div>
+          <button onClick={onClose} aria-label="Close" className="p-2 rounded-full hover:bg-gray-100" style={{ color: COLORS.muted }}>
+            <X size={20} />
+          </button>
+        </div>
+
+        {q.isLoading && rows.length === 0 ? (
+          <div className="flex items-center justify-center py-20 gap-2" style={{ color: COLORS.muted }}>
+            <Loader2 className="animate-spin" size={20} /> Loading…
+          </div>
+        ) : rows.length === 0 ? (
+          <p className="text-sm py-10 text-center" style={{ color: COLORS.muted }}>
+            No games found.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full tabular-nums">
+              <thead>
+                <tr style={{ background: COLORS.headerBg }}>
+                  {cols.map((c, i) => (
+                    <th
+                      key={i}
+                      className={`px-2 py-1 text-xs font-semibold whitespace-nowrap ${i <= 3 ? "text-left" : "text-right"}`}
+                      style={{ color: COLORS.text }}
+                    >
+                      {c}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r, i) => {
+                  const win = String(r.result) === "W";
+                  return (
+                    <tr key={i} style={{ background: i % 2 ? COLORS.altRow : COLORS.card }}>
+                      <td className="px-2 py-0.5 text-left text-sm whitespace-nowrap" style={{ color: COLORS.text }}>
+                        {String(r.d)}
+                        {String(r.season_type) === "Playoffs" ? (
+                          <span style={{ color: COLORS.playoff }}> ●</span>
+                        ) : null}
+                      </td>
+                      <td className="px-2 py-0.5 text-left text-sm" style={{ color: COLORS.muted }}>
+                        {String(r.loc)}
+                      </td>
+                      <td className="px-2 py-0.5 text-left text-sm" style={{ color: COLORS.text }}>
+                        {String(r.opp)}
+                      </td>
+                      <td
+                        className="px-2 py-0.5 text-left text-sm font-medium whitespace-nowrap"
+                        style={{ color: win ? "#2d7a00" : "#bc1200" }}
+                      >
+                        {String(r.result)} {N(r.win_score)}-{N(r.lose_score)}
+                      </td>
+                      <td className={td} style={{ color: COLORS.text }}>{String(r.minutes || "0:00")}</td>
+                      <td className={td} style={{ color: COLORS.text }}>{N(r.points)}</td>
+                      <td className={td} style={{ color: COLORS.text }}>{N(r.rebounds)}</td>
+                      <td className={td} style={{ color: COLORS.text }}>{N(r.assists)}</td>
+                      <td className={td} style={{ color: COLORS.text }}>{N(r.steals)}</td>
+                      <td className={td} style={{ color: COLORS.text }}>{N(r.blocks)}</td>
+                      <td className={td} style={{ color: COLORS.text }}>{N(r.turnovers)}</td>
+                      <td className={td} style={{ color: COLORS.text }}>{N(r.fg_made)}-{N(r.fg_attempted)}</td>
+                      <td className={td} style={{ color: COLORS.text }}>{N(r.fg3_made)}-{N(r.fg3_attempted)}</td>
+                      <td className={td} style={{ color: COLORS.text }}>{N(r.ft_made)}-{N(r.ft_attempted)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/projects/nba-box-scores-dive/.dive-preview/src/components/ScheduleGrid.tsx
+++ b/projects/nba-box-scores-dive/.dive-preview/src/components/ScheduleGrid.tsx
@@ -142,7 +142,15 @@ export default function ScheduleGrid({
           <h2 className="text-lg font-bold mb-3" style={{ color: COLORS.text }}>
             {formatDateHeading(g.date)}
           </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+          {/* Inline auto-fill grid (responsive Tailwind prefixes like md:/lg: don't
+              apply in the MotherDuck dive renderer — this flows columns by width). */}
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))",
+              gap: 12,
+            }}
+          >
             {g.games.map((game) => (
               <GameCard key={game.game_id} game={game} onSelect={onSelectGame} />
             ))}

--- a/projects/nba-box-scores-dive/.dive-preview/src/components/ScheduleGrid.tsx
+++ b/projects/nba-box-scores-dive/.dive-preview/src/components/ScheduleGrid.tsx
@@ -1,0 +1,178 @@
+import { useSQLQuery } from "@motherduck/react-sql-query";
+import { Loader2 } from "lucide-react";
+import GameCard, { GameCardData } from "./GameCard";
+import { DB, Filters, scheduleWhere } from "../lib/query";
+import { N, COLORS } from "../lib/format";
+
+const DATES_PER_PAGE = 4;
+
+function formatDateHeading(d: string): string {
+  // d is 'YYYY-MM-DD' — format without JS Date timezone surprises.
+  const [y, m, day] = d.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, day));
+  return dt.toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export default function ScheduleGrid({
+  filters,
+  page,
+  setPage,
+  onSelectGame,
+}: {
+  filters: Filters;
+  page: number;
+  setPage: (fn: (p: number) => number) => void;
+  onSelectGame: (id: string) => void;
+}) {
+  const where = scheduleWhere(filters);
+  const lo = page * DATES_PER_PAGE;
+
+  const gamesQ = useSQLQuery(`
+    WITH filtered AS (
+      SELECT s.game_id, s.game_date,
+             strftime(s.game_date, '%Y-%m-%d') AS d,
+             s.season_type,
+             s.home_team_abbreviation AS home_abbr,
+             s.away_team_abbreviation AS away_abbr,
+             s.home_team_score AS home_score,
+             s.away_team_score AS away_score,
+             s.game_status
+      FROM ${DB}."schedule" s
+      WHERE ${where}
+    ),
+    ranked AS (
+      SELECT d, ROW_NUMBER() OVER (ORDER BY d DESC) - 1 AS rn
+      FROM (SELECT DISTINCT d FROM filtered)
+    ),
+    page_dates AS (
+      SELECT d FROM ranked WHERE rn >= ${lo} AND rn < ${lo + DATES_PER_PAGE}
+    )
+    SELECT f.game_id, f.d, f.season_type, f.home_abbr, f.away_abbr,
+           f.home_score, f.away_score, f.game_status,
+           (SELECT string_agg(ts.period || '|' || ts.team_abbreviation || '|' || ts.points, ','
+                              ORDER BY ts.period)
+            FROM ${DB}."team_stats" ts
+            WHERE ts.game_id = f.game_id AND ts.period <> 'FullGame') AS period_scores
+    FROM filtered f
+    JOIN page_dates pd ON f.d = pd.d
+    ORDER BY f.game_date DESC, f.game_id
+  `);
+
+  const countQ = useSQLQuery(`
+    SELECT COUNT(*) AS n FROM (
+      SELECT DISTINCT strftime(s.game_date, '%Y-%m-%d') AS d
+      FROM ${DB}."schedule" s WHERE ${where}
+    )
+  `);
+
+  const totalDates = countQ.isSuccess ? N((countQ.data as any[])[0]?.n) : 0;
+  const totalPages = Math.max(1, Math.ceil(totalDates / DATES_PER_PAGE));
+
+  const rows = Array.isArray(gamesQ.data) ? gamesQ.data : [];
+
+  // Group games by date, building GameCardData (parsing the period_scores string).
+  const groups: { date: string; games: GameCardData[] }[] = [];
+  const byDate = new Map<string, GameCardData[]>();
+  for (const r of rows) {
+    const d = String(r.d);
+    const periodPoints: Record<string, Record<string, number>> = {};
+    const periodSet = new Set<string>();
+    const raw = r.period_scores ? String(r.period_scores) : "";
+    if (raw) {
+      for (const part of raw.split(",")) {
+        const [p, team, pts] = part.split("|");
+        if (!p) continue;
+        periodSet.add(p);
+        (periodPoints[p] ||= {})[team] = N(pts);
+      }
+    }
+    const periodList = [...periodSet].sort((a, b) => Number(a) - Number(b));
+    const game: GameCardData = {
+      game_id: String(r.game_id),
+      home_abbr: String(r.home_abbr),
+      away_abbr: String(r.away_abbr),
+      home_score: N(r.home_score),
+      away_score: N(r.away_score),
+      isPlayoff: String(r.season_type) === "Playoffs",
+      game_status: String(r.game_status ?? ""),
+      periodList,
+      periodPoints,
+    };
+    if (!byDate.has(d)) {
+      byDate.set(d, []);
+      groups.push({ date: d, games: byDate.get(d)! });
+    }
+    byDate.get(d)!.push(game);
+  }
+
+  if (gamesQ.isError) {
+    return (
+      <div className="py-8 text-sm" style={{ color: "#bc1200" }}>
+        Error loading games: {gamesQ.error?.message}
+      </div>
+    );
+  }
+
+  if (gamesQ.isLoading && rows.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-16 gap-2" style={{ color: COLORS.muted }}>
+        <Loader2 className="animate-spin" size={18} /> Loading games…
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="py-16 text-center text-sm" style={{ color: COLORS.muted }}>
+        No games match these filters.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {groups.map((g) => (
+        <div key={g.date} className="mb-8">
+          <h2 className="text-lg font-bold mb-3" style={{ color: COLORS.text }}>
+            {formatDateHeading(g.date)}
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+            {g.games.map((game) => (
+              <GameCard key={game.game_id} game={game} onSelect={onSelectGame} />
+            ))}
+          </div>
+        </div>
+      ))}
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-4 py-4">
+          <button
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={page === 0}
+            className="px-4 py-1.5 rounded border text-sm disabled:opacity-40"
+            style={{ borderColor: COLORS.border, background: "#fff", color: COLORS.text }}
+          >
+            Previous
+          </button>
+          <span className="text-sm" style={{ color: COLORS.muted }}>
+            Page {page + 1} of {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            disabled={page >= totalPages - 1}
+            className="px-4 py-1.5 rounded border text-sm disabled:opacity-40"
+            style={{ borderColor: COLORS.border, background: "#fff", color: COLORS.text }}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/projects/nba-box-scores-dive/.dive-preview/src/components/SeasonFilter.tsx
+++ b/projects/nba-box-scores-dive/.dive-preview/src/components/SeasonFilter.tsx
@@ -1,0 +1,165 @@
+import { useState } from "react";
+import { useSQLQuery } from "@motherduck/react-sql-query";
+import { Search } from "lucide-react";
+import { DB, Filters, SeasonTypeFilter } from "../lib/query";
+import { N, seasonLabel, sqlStr, COLORS } from "../lib/format";
+
+const SEASON_TYPES: { value: SeasonTypeFilter; label: string }[] = [
+  { value: "all", label: "All Games" },
+  { value: "regular", label: "Regular Season" },
+  { value: "playoffs", label: "Playoffs" },
+];
+
+const selectCls = "px-2 py-1 rounded border text-sm";
+const selectStyle = { borderColor: COLORS.border, background: "#fff", color: COLORS.text };
+
+export default function SeasonFilter({
+  filters,
+  onChange,
+}: {
+  filters: Filters;
+  onChange: (patch: Partial<Filters>) => void;
+}) {
+  const [term, setTerm] = useState(filters.player);
+  const [open, setOpen] = useState(false);
+
+  const seasonsQ = useSQLQuery(
+    `SELECT DISTINCT season_year FROM ${DB}."schedule" ORDER BY season_year DESC`,
+  );
+  const teamsQ = useSQLQuery(
+    `SELECT abbr FROM (
+       SELECT home_team_abbreviation AS abbr FROM ${DB}."schedule"
+       UNION SELECT away_team_abbreviation FROM ${DB}."schedule"
+     ) WHERE abbr IS NOT NULL ORDER BY abbr`,
+  );
+
+  const trimmed = term.trim();
+  const suggestQ = useSQLQuery(
+    `SELECT arg_max(b.player_name, s.game_date) AS player_name,
+            arg_max(b.team_abbreviation, s.game_date) AS team
+     FROM ${DB}."box_scores" b JOIN ${DB}."schedule" s ON b.game_id = s.game_id
+     WHERE b.period = 'FullGame' AND b.player_name ILIKE ${sqlStr("%" + trimmed + "%")}
+     ${filters.season != null ? `AND s.season_year = ${Number(filters.season)}` : ""}
+     GROUP BY b.entity_id ORDER BY player_name LIMIT 8`,
+    { enabled: open && trimmed.length >= 2 },
+  );
+
+  const seasons = (Array.isArray(seasonsQ.data) ? seasonsQ.data : []).map((r) => N(r.season_year));
+  const teams = (Array.isArray(teamsQ.data) ? teamsQ.data : []).map((r) => String(r.abbr));
+  const suggestions = Array.isArray(suggestQ.data) ? suggestQ.data : [];
+
+  const hasFilters =
+    filters.season != null || filters.seasonType !== "all" || !!filters.team || !!filters.player;
+
+  const clearAll = () => {
+    setTerm("");
+    onChange({ season: null, seasonType: "all", team: "", player: "" });
+  };
+
+  return (
+    <div
+      className="sticky top-0 z-20 pt-3 pb-3 mb-5"
+      style={{ background: COLORS.bg, borderBottom: `1px solid ${COLORS.border}` }}
+    >
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-2 flex-wrap">
+          <select
+            className={selectCls}
+            style={selectStyle}
+            value={filters.season ?? ""}
+            onChange={(e) => onChange({ season: e.target.value ? Number(e.target.value) : null })}
+          >
+            <option value="">All Seasons</option>
+            {seasons.map((y) => (
+              <option key={y} value={y}>
+                {seasonLabel(y)}
+              </option>
+            ))}
+          </select>
+
+          <select
+            className={selectCls}
+            style={selectStyle}
+            value={filters.seasonType}
+            onChange={(e) => onChange({ seasonType: e.target.value as SeasonTypeFilter })}
+          >
+            {SEASON_TYPES.map((t) => (
+              <option key={t.value} value={t.value}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+
+          <select
+            className={selectCls}
+            style={selectStyle}
+            value={filters.team}
+            onChange={(e) => onChange({ team: e.target.value })}
+          >
+            <option value="">All Teams</option>
+            {teams.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+
+          <div className="relative">
+            <Search
+              size={15}
+              style={{ color: COLORS.muted, position: "absolute", left: 8, top: 8 }}
+            />
+            <input
+              type="text"
+              value={term}
+              placeholder="Search player…"
+              autoComplete="off"
+              className="pl-7 pr-2 py-1 rounded border text-sm w-44"
+              style={selectStyle}
+              onFocus={() => setOpen(true)}
+              onChange={(e) => {
+                setTerm(e.target.value);
+                setOpen(true);
+                if (e.target.value === "") onChange({ player: "" });
+              }}
+            />
+            {open && suggestions.length > 0 && (
+              <div
+                className="absolute top-full left-0 mt-1 w-64 rounded shadow-lg z-30 max-h-60 overflow-y-auto"
+                style={{ background: "#fff", border: `1px solid ${COLORS.border}` }}
+              >
+                {suggestions.map((s) => (
+                  <button
+                    key={String(s.player_name)}
+                    className="w-full text-left px-3 py-1.5 text-sm flex items-center justify-between hover:bg-gray-100"
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      setTerm(String(s.player_name));
+                      onChange({ player: String(s.player_name) });
+                      setOpen(false);
+                    }}
+                  >
+                    <span style={{ color: COLORS.text }}>{String(s.player_name)}</span>
+                    <span className="text-xs ml-2" style={{ color: COLORS.muted }}>
+                      {String(s.team ?? "")}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {hasFilters && (
+          <button
+            onClick={clearAll}
+            className="text-sm"
+            style={{ color: COLORS.primary }}
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/projects/nba-box-scores-dive/.dive-preview/src/components/TrendsScatter.tsx
+++ b/projects/nba-box-scores-dive/.dive-preview/src/components/TrendsScatter.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import { useSQLQuery } from "@motherduck/react-sql-query";
+import {
+  ScatterChart, Scatter, XAxis, YAxis, ZAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+} from "recharts";
+import { Loader2 } from "lucide-react";
+import { DB, Filters, seasonTypeWhere } from "../lib/query";
+import { N, seasonLabel, COLORS } from "../lib/format";
+
+function PointTooltip({ active, payload }: any) {
+  if (!active || !payload?.length) return null;
+  const p = payload[0].payload;
+  return (
+    <div className="rounded px-2 py-1 text-xs" style={{ background: "#fff", border: `1px solid ${COLORS.border}` }}>
+      <div className="font-semibold" style={{ color: COLORS.text }}>{p.player_name}</div>
+      <div style={{ color: COLORS.muted }}>
+        {p.ppg.toFixed(1)} PPG · GQ {(p.avg_gq * 100).toFixed(1)}% · {p.gp} GP
+      </div>
+    </div>
+  );
+}
+
+export default function TrendsScatter({ filters }: { filters: Filters }) {
+  const [minGames, setMinGames] = useState(20);
+
+  // Exclude the -1 (sub-15-min) GQ sentinel; group by stable entity_id, latest name.
+  const q = useSQLQuery(`
+    SELECT gq.entity_id,
+           arg_max(gq.player_name, s.game_date) AS player_name,
+           COUNT(*) AS gp,
+           AVG(gq.points) AS ppg,
+           AVG(gq.game_quality) AS avg_gq
+    FROM ${DB}."game_quality" gq
+    JOIN ${DB}."schedule" s ON gq.game_id = s.game_id
+    WHERE ${seasonTypeWhere(filters)} AND gq.game_quality >= 0
+    GROUP BY gq.entity_id
+    HAVING COUNT(*) >= ${Number(minGames)}
+    LIMIT 800
+  `);
+
+  const data = (Array.isArray(q.data) ? q.data : []).map((r) => ({
+    player_name: String(r.player_name),
+    gp: N(r.gp),
+    ppg: N(r.ppg),
+    avg_gq: N(r.avg_gq),
+  }));
+
+  const seasonTxt = filters.season != null ? seasonLabel(filters.season) : "all seasons";
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-1">
+        <label className="text-sm" style={{ color: COLORS.muted }}>Min games</label>
+        <input type="range" min={1} max={60} value={minGames}
+          onChange={(e) => setMinGames(Number(e.target.value))} className="w-40" />
+        <span className="text-sm font-medium tabular-nums" style={{ color: COLORS.text }}>{minGames}</span>
+        <span className="text-sm ml-auto" style={{ color: COLORS.muted }}>
+          {q.isSuccess ? `${data.length} players` : ""}
+        </span>
+      </div>
+      <p className="text-sm mb-3" style={{ color: COLORS.muted }}>
+        Scoring vs. Game Quality — {seasonTxt}. Each dot is a player.
+      </p>
+
+      {q.isError ? (
+        <div className="py-8 text-sm" style={{ color: "#bc1200" }}>Error: {q.error?.message}</div>
+      ) : q.isLoading && data.length === 0 ? (
+        <div className="flex items-center justify-center gap-2" style={{ color: COLORS.muted, height: 420 }}>
+          <Loader2 className="animate-spin" size={18} /> Loading…
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={460}>
+          <ScatterChart margin={{ top: 10, right: 20, bottom: 30, left: 10 }}>
+            <CartesianGrid stroke="#eee" />
+            <XAxis
+              type="number" dataKey="ppg" name="PPG" fontSize={11}
+              label={{ value: "Points per game", position: "insideBottom", offset: -15, fontSize: 12 }}
+            />
+            <YAxis
+              type="number" dataKey="avg_gq" name="GQ" fontSize={11}
+              tickFormatter={(v) => `${(v * 100).toFixed(0)}%`}
+              label={{ value: "Avg Game Quality", angle: -90, position: "insideLeft", fontSize: 12 }}
+            />
+            <ZAxis type="number" dataKey="gp" range={[20, 200]} name="GP" />
+            <Tooltip content={<PointTooltip />} cursor={{ strokeDasharray: "3 3" }} />
+            <Scatter data={data} fill={COLORS.primary} fillOpacity={0.55} />
+          </ScatterChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+}

--- a/projects/nba-box-scores-dive/.dive-preview/src/dive.tsx
+++ b/projects/nba-box-scores-dive/.dive-preview/src/dive.tsx
@@ -1,0 +1,93 @@
+import { useDiveState } from "@motherduck/react-sql-query";
+import SeasonFilter from "./components/SeasonFilter";
+import ScheduleGrid from "./components/ScheduleGrid";
+import BoxScorePanel from "./components/BoxScorePanel";
+import GameQualityExplorer from "./components/GameQualityExplorer";
+import TrendsScatter from "./components/TrendsScatter";
+import { Filters, SeasonTypeFilter } from "./lib/query";
+import { COLORS, MONO } from "./lib/format";
+
+// Current season: season_year = 2025 is the 2025-26 season.
+const DEFAULT_SEASON = 2025;
+
+type Tab = "schedule" | "gq" | "trends";
+const TABS: { key: Tab; label: string }[] = [
+  { key: "schedule", label: "Schedule" },
+  { key: "gq", label: "Game Quality" },
+  { key: "trends", label: "Trends" },
+];
+
+export default function NBABoxScores() {
+  const [tab, setTab] = useDiveState<Tab>("tab", "schedule");
+  const [season, setSeason] = useDiveState<number | null>("season", DEFAULT_SEASON);
+  const [seasonType, setSeasonType] = useDiveState<SeasonTypeFilter>("type", "all");
+  const [team, setTeam] = useDiveState<string>("team", "");
+  const [player, setPlayer] = useDiveState<string>("player", "");
+  const [page, setPage] = useDiveState<number>("page", 0);
+  const [gameId, setGameId] = useDiveState<string | null>("game", null);
+
+  // Fall back to Schedule if a stale/unknown tab is in the URL state.
+  const activeTab: Tab = TABS.some((t) => t.key === tab) ? tab : "schedule";
+
+  const filters: Filters = { season, seasonType, team, player };
+
+  const onFilterChange = (patch: Partial<Filters>) => {
+    if ("season" in patch) setSeason(patch.season ?? null);
+    if ("seasonType" in patch) setSeasonType(patch.seasonType!);
+    if ("team" in patch) setTeam(patch.team!);
+    if ("player" in patch) setPlayer(patch.player!);
+    setPage(0); // any filter change returns to the first page
+  };
+
+  return (
+    <div
+      className="p-6"
+      style={{ background: COLORS.bg, minHeight: "100vh", color: COLORS.text, fontFamily: MONO }}
+    >
+      <header className="mb-3">
+        <h1 className="text-2xl font-bold" style={{ color: COLORS.text }}>
+          NBA Box Scores
+        </h1>
+        <p className="text-sm" style={{ color: COLORS.muted }}>
+          Schedule, box scores, and player analytics — 2000-01 through 2025-26.
+        </p>
+      </header>
+
+      {/* Tab navigation */}
+      <div className="flex gap-1 mb-4" style={{ borderBottom: `1px solid ${COLORS.border}` }}>
+        {TABS.map((t) => {
+          const active = activeTab ===t.key;
+          return (
+            <button
+              key={t.key}
+              onClick={() => setTab(t.key)}
+              className="px-4 py-2 text-sm font-medium"
+              style={{
+                color: active ? COLORS.primary : COLORS.muted,
+                borderBottom: active ? `2px solid ${COLORS.primary}` : "2px solid transparent",
+                marginBottom: -1,
+              }}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <SeasonFilter filters={filters} onChange={onFilterChange} />
+
+      {activeTab ==="schedule" && (
+        <ScheduleGrid
+          filters={filters}
+          page={page}
+          setPage={(fn) => setPage(fn)}
+          onSelectGame={(id) => setGameId(id)}
+        />
+      )}
+      {activeTab ==="gq" && <GameQualityExplorer filters={filters} />}
+      {activeTab ==="trends" && <TrendsScatter filters={filters} />}
+
+      <BoxScorePanel gameId={gameId} onClose={() => setGameId(null)} />
+    </div>
+  );
+}

--- a/projects/nba-box-scores-dive/.dive-preview/src/lib/format.ts
+++ b/projects/nba-box-scores-dive/.dive-preview/src/lib/format.ts
@@ -1,0 +1,45 @@
+// Shared formatting + SQL helpers for the NBA Box Scores dive.
+
+// DuckDB returns BIGINT/HUGEINT/DECIMAL as BigInt or special objects — coerce everything.
+export const N = (v: unknown): number => (v != null ? Number(v) : 0);
+
+// Single-quote a string literal for inline SQL (doubles embedded quotes).
+export const sqlStr = (s: string): string => `'${String(s).replace(/'/g, "''")}'`;
+
+// season_year = 2025 means the 2025-26 season.
+export const seasonLabel = (year: number): string =>
+  `${year}-${String((year + 1) % 100).padStart(2, "0")}`;
+
+// period values are '1'..'8' (regulation 1-4, then OT) plus 'FullGame'.
+export const periodLabel = (p: string): string => {
+  const n = Number(p);
+  if (n >= 1 && n <= 4) return `Q${n}`;
+  if (n === 5) return "OT";
+  if (n > 5) return `${n - 4}OT`;
+  return p;
+};
+
+// "MM:SS" -> total seconds (for client-side sorting / fallbacks).
+export const minutesToSeconds = (min: string | null | undefined): number => {
+  if (!min) return 0;
+  const [m, s] = String(min).split(":").map(Number);
+  return (m || 0) * 60 + (s || 0);
+};
+
+// Matches the legacy nba-box-scores look: monospace, white background, gray
+// palette, blue-600 links/accents, amber-500 playoff marker.
+export const MONO =
+  'ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Code", "Roboto Mono", Consolas, "Courier New", monospace';
+
+export const COLORS = {
+  bg: "#ffffff",
+  card: "#ffffff",
+  text: "#171717", // gray-900
+  muted: "#6b7280", // gray-500
+  border: "#e5e7eb", // gray-200
+  primary: "#2563eb", // blue-600
+  playoff: "#f59e0b", // amber-500
+  headerBg: "#f3f4f6", // gray-100
+  altRow: "#f9fafb", // gray-50
+  totalBg: "#eff6ff", // blue-50
+};

--- a/projects/nba-box-scores-dive/.dive-preview/src/lib/query.ts
+++ b/projects/nba-box-scores-dive/.dive-preview/src/lib/query.ts
@@ -1,0 +1,53 @@
+import { sqlStr } from "./format";
+
+export const DB = `"nba_box_scores_v3"."main"`;
+
+export type SeasonTypeFilter = "all" | "regular" | "playoffs";
+
+export interface Filters {
+  season: number | null; // null = all seasons
+  seasonType: SeasonTypeFilter;
+  team: string; // "" = all teams
+  player: string; // "" = no player filter
+}
+
+const SEASON_TYPE_SQL: Record<SeasonTypeFilter, string | null> = {
+  all: null,
+  regular: "Regular Season",
+  playoffs: "Playoffs",
+};
+
+// Player names drift over time (diacritics / nicknames: "Nikola Jokić" vs
+// "Nikola Jokic", "Alex" vs "Alexandre"). entity_id is the stable key. Given a
+// (selected) display name, resolve to the entity_id(s) so a filter catches ALL
+// of that player's rows regardless of how the name was spelled in a given game.
+export const playerEntityIds = (player: string): string =>
+  `(SELECT entity_id FROM ${DB}."box_scores" WHERE player_name = ${sqlStr(player)})`;
+
+// Season + season_type conditions only (on schedule alias `s`), for aggregate
+// queries (GQ leaderboard, player index, scatter) that handle team/player
+// against their own columns. Returns "1=1" when neither is set.
+export function seasonTypeWhere(f: Filters): string {
+  const conds: string[] = ["1=1"];
+  if (f.season != null) conds.push(`s.season_year = ${Number(f.season)}`);
+  const st = SEASON_TYPE_SQL[f.seasonType];
+  if (st) conds.push(`s.season_type = ${sqlStr(st)}`);
+  return conds.join(" AND ");
+}
+
+// Build the WHERE conditions for the schedule table (aliased `s`).
+// Returns a string beginning with the conditions, joined by AND, or "1=1".
+export function scheduleWhere(f: Filters): string {
+  const conds: string[] = ["1=1"];
+  if (f.season != null) conds.push(`s.season_year = ${Number(f.season)}`);
+  const st = SEASON_TYPE_SQL[f.seasonType];
+  if (st) conds.push(`s.season_type = ${sqlStr(st)}`);
+  if (f.team) conds.push(`(s.home_team_abbreviation = ${sqlStr(f.team)} OR s.away_team_abbreviation = ${sqlStr(f.team)})`);
+  if (f.player) {
+    conds.push(
+      `s.game_id IN (SELECT bs.game_id FROM ${DB}."box_scores" bs ` +
+        `WHERE bs.period = 'FullGame' AND bs.entity_id IN ${playerEntityIds(f.player)})`,
+    );
+  }
+  return conds.join(" AND ");
+}

--- a/projects/nba-box-scores-dive/.dive-preview/src/lib/teams.ts
+++ b/projects/nba-box-scores-dive/.dive-preview/src/lib/teams.ts
@@ -1,0 +1,43 @@
+// NBA team abbreviation -> full name. Includes historical abbreviations that
+// appear in the 2000-2025 schedule (relocations / renames).
+const ABBR_TO_NAME: Record<string, string> = {
+  ATL: "Atlanta Hawks",
+  BOS: "Boston Celtics",
+  BKN: "Brooklyn Nets",
+  NJN: "New Jersey Nets",
+  CHA: "Charlotte Hornets",
+  CHH: "Charlotte Hornets",
+  CHI: "Chicago Bulls",
+  CLE: "Cleveland Cavaliers",
+  DAL: "Dallas Mavericks",
+  DEN: "Denver Nuggets",
+  DET: "Detroit Pistons",
+  GSW: "Golden State Warriors",
+  HOU: "Houston Rockets",
+  IND: "Indiana Pacers",
+  LAC: "LA Clippers",
+  LAL: "Los Angeles Lakers",
+  MEM: "Memphis Grizzlies",
+  VAN: "Vancouver Grizzlies",
+  MIA: "Miami Heat",
+  MIL: "Milwaukee Bucks",
+  MIN: "Minnesota Timberwolves",
+  NOP: "New Orleans Pelicans",
+  NOH: "New Orleans Hornets",
+  NOK: "New Orleans/Oklahoma City Hornets",
+  NYK: "New York Knicks",
+  OKC: "Oklahoma City Thunder",
+  SEA: "Seattle SuperSonics",
+  ORL: "Orlando Magic",
+  PHI: "Philadelphia 76ers",
+  PHX: "Phoenix Suns",
+  POR: "Portland Trail Blazers",
+  SAC: "Sacramento Kings",
+  SAS: "San Antonio Spurs",
+  TOR: "Toronto Raptors",
+  UTA: "Utah Jazz",
+  WAS: "Washington Wizards",
+};
+
+export const getTeamName = (abbr: string): string =>
+  ABBR_TO_NAME[abbr] ?? abbr;

--- a/projects/nba-box-scores-dive/.dive-preview/src/main.tsx
+++ b/projects/nba-box-scores-dive/.dive-preview/src/main.tsx
@@ -1,0 +1,36 @@
+import { createRoot } from "react-dom/client";
+import { MotherDuckSDKProvider, useConnectionStatus } from "./md-sdk";
+import { Loader2, AlertCircle } from "lucide-react";
+import Dive from "./dive";
+
+function ConnectionGate({ children }: { children: React.ReactNode }) {
+  const { isConnected, isConnecting, error } = useConnectionStatus();
+  if (isConnecting) return (
+    <div className="flex items-center justify-center h-screen gap-2 text-[#6a6a6a]">
+      <Loader2 className="animate-spin" size={20} />
+      Connecting to MotherDuck…
+    </div>
+  );
+  if (error) return (
+    <div className="flex items-center justify-center h-screen gap-2 text-red-600">
+      <AlertCircle size={20} />
+      Connection failed: {error.message}
+    </div>
+  );
+  if (!isConnected) return null;
+  return <>{children}</>;
+}
+
+const token = import.meta.env.VITE_MOTHERDUCK_TOKEN;
+if (!token) {
+  document.getElementById("root")!.innerHTML =
+    '<p style="padding:2rem;color:red">Missing VITE_MOTHERDUCK_TOKEN in .env</p>';
+} else {
+  createRoot(document.getElementById("root")!).render(
+    <MotherDuckSDKProvider token={token}>
+      <ConnectionGate>
+        <Dive />
+      </ConnectionGate>
+    </MotherDuckSDKProvider>
+  );
+}

--- a/projects/nba-box-scores-dive/.dive-preview/src/md-sdk.tsx
+++ b/projects/nba-box-scores-dive/.dive-preview/src/md-sdk.tsx
@@ -1,0 +1,365 @@
+/**
+ * Simplified @motherduck/react-sql-query shim for local Vite preview.
+ * Same API as the production dive runtime — useSQLQuery, useConnection,
+ * useConnectionStatus, and MotherDuckSDKProvider.
+ */
+import { MDConnection } from "@motherduck/wasm-client";
+import type { DuckDBRow } from "@motherduck/wasm-client";
+import {
+  createContext, useContext, useEffect, useMemo, useRef, useState,
+  useCallback, useSyncExternalStore,
+} from "react";
+import type { ReactNode } from "react";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+type QueryStatus = "idle" | "loading" | "success" | "error";
+
+type ExportFormat = "csv" | "json" | "parquet" | "xlsx";
+type ExportCompression = "none" | "gzip" | "zstd";
+
+export type ExportQueryOptions = {
+  format: ExportFormat;
+  title?: string;
+  filename?: string;
+  sheetName?: string;
+  copy?: { preserveOrder?: boolean };
+  csv?: {
+    compression?: ExportCompression;
+    dateformat?: string;
+    delim?: string;
+    escape?: string;
+    forceQuote?: readonly string[] | "*";
+    header?: boolean;
+    nullstr?: string;
+    prefix?: string;
+    quote?: string;
+    suffix?: string;
+    timestampformat?: string;
+  };
+  json?: {
+    array?: boolean;
+    compression?: ExportCompression;
+    dateformat?: string;
+    timestampformat?: string;
+  };
+  parquet?: {
+    compression?:
+      | "uncompressed"
+      | "snappy"
+      | "gzip"
+      | "zstd"
+      | "brotli"
+      | "lz4"
+      | "lz4_raw";
+    compressionLevel?: number;
+    fieldIds?: "auto" | Record<string, number | Record<string, number>>;
+    kvMetadata?: Record<string, string>;
+    parquetVersion?: "v1" | "v2" | "V1" | "V2";
+    rowGroupSize?: number;
+    rowGroupSizeBytes?: number | string;
+    stringDictionaryPageSizeLimit?: number | string;
+  };
+  xlsx?: {
+    header?: boolean;
+    sheet?: string;
+    sheetRowLimit?: number;
+  };
+};
+
+type ExportQueryRequest = { sql: string } & ExportQueryOptions;
+
+type ConnectionState =
+  | { status: "idle" }
+  | { status: "connecting" }
+  | { status: "connected"; connection: MDConnection }
+  | { status: "error"; error: Error };
+
+export type UseSQLQueryResult<TData = readonly DuckDBRow[]> = {
+  data: TData | undefined;
+  isLoading: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+  isPlaceholderData: boolean;
+  error: Error | null;
+  refetch: () => void;
+  exportAs: (options: ExportQueryOptions) => Promise<void>;
+  status: QueryStatus;
+};
+
+type UseSQLQueryOptions<TData = readonly DuckDBRow[]> = {
+  enabled?: boolean;
+  select?: (data: readonly DuckDBRow[]) => TData;
+  initialData?: TData;
+  placeholderData?: TData | ((prev: TData | undefined) => TData | undefined);
+};
+
+async function simulateLocalExport(sql: string, options: ExportQueryOptions) {
+  const filename = options.filename || options.title || "export";
+  console.info("Dive export requested in local preview", { sql, options });
+  window.alert?.(
+    `Export requested: ${filename}.${options.format}. Saved MotherDuck dives generate and download the real file.`,
+  );
+}
+
+// ── QueryObserver (external store for useSyncExternalStore) ────────
+
+interface QueryObserverState {
+  status: QueryStatus;
+  data: readonly DuckDBRow[] | undefined;
+  error: Error | undefined;
+  hasHadData: boolean;
+  lastData: readonly DuckDBRow[] | undefined;
+}
+
+class QueryObserver {
+  private state: QueryObserverState = {
+    status: "idle", data: undefined, error: undefined,
+    hasHadData: false, lastData: undefined,
+  };
+  private listeners = new Set<() => void>();
+  private abortController: AbortController | null = null;
+
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => { this.listeners.delete(listener); };
+  };
+  getSnapshot = () => this.state;
+  getStatus() { return this.state.status; }
+
+  private setState(updates: Partial<QueryObserverState>) {
+    this.state = { ...this.state, ...updates };
+    this.listeners.forEach((l) => l());
+  }
+
+  async execute(connection: MDConnection, sql: string) {
+    this.abortController?.abort();
+    this.abortController = new AbortController();
+    const { signal } = this.abortController;
+    this.setState({ status: "loading", data: undefined, error: undefined });
+    try {
+      const result = await connection.safeEvaluateQuery(sql);
+      if (signal.aborted) return;
+      if (result.status === "error") {
+        this.setState({ status: "error", error: result.err, data: undefined });
+        return;
+      }
+      const data = result.result.data.toRows();
+      this.setState({
+        status: "success", data, error: undefined,
+        hasHadData: true, lastData: data,
+      });
+    } catch (err) {
+      if (signal.aborted) return;
+      this.setState({
+        status: "error",
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: undefined,
+      });
+    }
+  }
+
+  reset() {
+    this.abortController?.abort();
+    this.abortController = null;
+    this.setState({ status: "idle", data: undefined, error: undefined });
+  }
+  cancel() {
+    this.abortController?.abort();
+    this.abortController = null;
+  }
+}
+
+// ── Provider ───────────────────────────────────────────────────────
+
+type ContextValue = { state: ConnectionState };
+const SDKContext = createContext<ContextValue | null>(null);
+
+function useSDKContext() {
+  const ctx = useContext(SDKContext);
+  if (!ctx) throw new Error("Must be used within MotherDuckSDKProvider");
+  return ctx;
+}
+
+export function MotherDuckSDKProvider(
+  { token, children }: { token: string; children: ReactNode },
+) {
+  const [state, setState] = useState<ConnectionState>({ status: "idle" });
+
+  useEffect(() => {
+    if (!token) { setState({ status: "idle" }); return; }
+    let cancelled = false;
+    let conn: MDConnection | null = null;
+    (async () => {
+      setState({ status: "connecting" });
+      try {
+        conn = MDConnection.create({ mdToken: token, useDuckDBWasmCOI: false });
+        await conn.isInitialized();
+        if (!cancelled) setState({ status: "connected", connection: conn });
+      } catch (err) {
+        if (!cancelled) setState({
+          status: "error",
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
+      }
+    })();
+    return () => { cancelled = true; conn?.close(); };
+  }, [token]);
+
+  const value = useMemo(() => ({ state }), [state]);
+  return <SDKContext.Provider value={value}>{children}</SDKContext.Provider>;
+}
+
+// ── useSQLQuery ────────────────────────────────────────────────────
+
+export function useSQLQuery<TData = readonly DuckDBRow[]>(
+  sql: string,
+  options?: UseSQLQueryOptions<TData>,
+): UseSQLQueryResult<TData> {
+  const { state: connState } = useSDKContext();
+  const observerRef = useRef<QueryObserver | null>(null);
+  if (!observerRef.current) observerRef.current = new QueryObserver();
+  const observer = observerRef.current;
+
+  const snap = useSyncExternalStore(
+    observer.subscribe, observer.getSnapshot, observer.getSnapshot,
+  );
+  const enabled = options?.enabled !== false;
+
+  useEffect(() => {
+    if (!enabled || connState.status !== "connected") {
+      if (observer.getStatus() !== "idle") observer.reset();
+      return;
+    }
+    observer.execute(connState.connection, sql);
+    return () => observer.cancel();
+  }, [sql, enabled, connState, observer]);
+
+  const refetch = useCallback(() => {
+    if (connState.status === "connected" && enabled) {
+      observer.execute(connState.connection, sql);
+    }
+  }, [observer, connState, enabled, sql]);
+
+  const exportAs = useCallback(async (exportOptions: ExportQueryOptions) => {
+    if (connState.status !== "connected") {
+      throw new Error("Cannot export before the MotherDuck connection is ready.");
+    }
+    await simulateLocalExport(sql, exportOptions);
+  }, [connState.status, sql]);
+
+  const isLoading = snap.status === "loading" || connState.status === "connecting";
+  const rawData = snap.data ?? snap.lastData;
+
+  const transformed = useMemo(() => {
+    if (rawData === undefined) return undefined;
+    return options?.select
+      ? options.select(rawData)
+      : (rawData as unknown as TData);
+  }, [rawData, options?.select]);
+
+  const { data, isPlaceholderData } = useMemo(() => {
+    if (transformed !== undefined)
+      return { data: transformed, isPlaceholderData: false };
+    if (!snap.hasHadData && options?.initialData !== undefined)
+      return { data: options.initialData, isPlaceholderData: false };
+    if (isLoading && options?.placeholderData !== undefined) {
+      const ph = typeof options.placeholderData === "function"
+        ? (options.placeholderData as (p: TData | undefined) => TData | undefined)(transformed)
+        : options.placeholderData;
+      if (ph !== undefined) return { data: ph, isPlaceholderData: true };
+    }
+    return { data: undefined, isPlaceholderData: false };
+  }, [transformed, snap.hasHadData, options?.initialData, options?.placeholderData, isLoading]);
+
+  return {
+    data, isLoading,
+    isSuccess: snap.status === "success",
+    isError: snap.status === "error",
+    isPlaceholderData,
+    error: snap.error ?? null,
+    refetch, exportAs, status: snap.status,
+  };
+}
+
+// ── useDiveState ───────────────────────────────────────────────────
+
+function readBag(): Record<string, unknown> {
+  if (typeof window === "undefined") return {};
+  const m = window.location.hash.match(/state=([^&]+)/);
+  if (!m) return {};
+  try {
+    const json = atob(m[1].replace(/-/g, "+").replace(/_/g, "/"));
+    const parsed = JSON.parse(json);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch { return {}; }
+}
+
+function writeBag(bag: Record<string, unknown>) {
+  const json = JSON.stringify(bag);
+  const b64 = btoa(json).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  const newHash = `#state=${b64}`;
+  if (window.location.hash !== newHash) {
+    window.history.replaceState(null, "", newHash);
+  }
+  window.dispatchEvent(new Event("divestatechange"));
+}
+
+export function useDiveState<T>(key: string, initialValue: T): [T, (v: T | ((prev: T) => T)) => void] {
+  const subscribe = useCallback((cb: () => void) => {
+    window.addEventListener("divestatechange", cb);
+    window.addEventListener("hashchange", cb);
+    return () => {
+      window.removeEventListener("divestatechange", cb);
+      window.removeEventListener("hashchange", cb);
+    };
+  }, []);
+  const getSnapshot = useCallback(() => {
+    const bag = readBag();
+    return key in bag ? JSON.stringify(bag[key]) : undefined;
+  }, [key]);
+  const raw = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const value = useMemo<T>(() => {
+    if (raw === undefined) return initialValue;
+    try { return JSON.parse(raw) as T; } catch { return initialValue; }
+  }, [raw, initialValue]);
+
+  const setValue = useCallback((next: T | ((prev: T) => T)) => {
+    const bag = readBag();
+    const prev = key in bag ? (bag[key] as T) : initialValue;
+    const resolved = typeof next === "function" ? (next as (p: T) => T)(prev) : next;
+    if (resolved === undefined) delete bag[key];
+    else bag[key] = resolved;
+    writeBag(bag);
+  }, [key, initialValue]);
+
+  return [value, setValue];
+}
+
+// ── useConnection / useConnectionStatus ────────────────────────────
+
+export function useConnection(): MDConnection | null {
+  const { state } = useSDKContext();
+  return state.status === "connected" ? state.connection : null;
+}
+
+export function useConnectionStatus() {
+  const { state } = useSDKContext();
+  return {
+    isConnected: state.status === "connected",
+    isConnecting: state.status === "connecting",
+    error: state.status === "error" ? state.error : null,
+  };
+}
+
+export function useExport() {
+  const { state } = useSDKContext();
+  const exportQuery = useCallback(async ({ sql, ...options }: ExportQueryRequest) => {
+    if (state.status !== "connected") {
+      throw new Error("Cannot export before the MotherDuck connection is ready.");
+    }
+    await simulateLocalExport(sql, options);
+  }, [state.status]);
+
+  return { exportQuery };
+}

--- a/projects/nba-box-scores-dive/.dive-preview/vite.config.ts
+++ b/projects/nba-box-scores-dive/.dive-preview/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@motherduck/react-sql-query": path.resolve(__dirname, "src/md-sdk.tsx"),
+    },
+  },
+  server: {
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "credentialless",
+    },
+  },
+});

--- a/projects/nba-box-scores-pipeline/PHASE2_HANDOFF.md
+++ b/projects/nba-box-scores-pipeline/PHASE2_HANDOFF.md
@@ -1,0 +1,119 @@
+# Phase 2 hand-off — nba-box-scores migration (Dive / frontend)
+
+This doc lets a fresh Claude Code session pick up **Phase 2** (the Dive UI) without re-deriving
+everything. Phase 0 (clone) and Phase 1 (Python ingest → Flights) are **done and live**.
+
+Read this, then read [`plan.md`](./plan.md) §2 for the full Phase 2 design.
+
+---
+
+## TL;DR — where things stand (2026-05-29)
+
+- **Phase 1 is LIVE.** A scheduled MotherDuck **Flight** (`nba_nightly`) ingests NBA box scores
+  into `nba_box_scores_v3` nightly. It's self-maintaining.
+- **Phase 2 has NOT started.** No migration Dive exists yet. That's this branch's job.
+- Branch: you are on **`nba-box-scores-dive`**, cut from `nba-migration` (the long-lived
+  integration branch, 5 commits ahead of `main`). Keep targeting `nba-migration`, not `main`.
+
+## The data you're building a UI on
+
+- **Database:** `nba_box_scores_v3` on the **live/production** MotherDuck account (user `matson`,
+  reachable via the `mcp__claude_ai_MotherDuck__*` MCP tools — NOT the `_Staging` ones).
+- v3 is currently byte-identical to `nba_box_scores_v2` (the DB serving the legacy Vercel app),
+  and the nightly Flight keeps it current. v3 is isolated — nothing user-facing reads it yet.
+- Everything lives in the **`main` schema**. No raw/hydrated schema split.
+
+### Tables (`nba_box_scores_v3.main.*`)
+
+| Object | Kind | Notes |
+|---|---|---|
+| `schedule` | table | one row/game. Cols: `game_id, game_date (TIMESTAMP), home_team_id, away_team_id, home_team_abbreviation, away_team_abbreviation, home_team_score, away_team_score, game_status, season_year, season_type, created_at`. ~33.4k rows. |
+| `box_scores` | table | one row per **player × period**. PK `(game_id, entity_id, period)`. `period` ∈ `'1'..'6'`, `'FullGame'`. Cols: `team_abbreviation, player_name, minutes (VARCHAR 'MM:SS'), points, rebounds, assists, steals, blocks, turnovers, fg_made, fg_attempted, fg3_made, fg3_attempted, ft_made, ft_attempted, starter (1/0, only set on FullGame rows)`. ~3.05M rows. |
+| `players` | view | `entity_id, player_name` (distinct, from FullGame rows). |
+| `team_stats` | view | team aggregates per period + FullGame. |
+| `game_quality` | view | the "GQ" metric per player-game: `fg_pct, ft_pct, fg_v, ft_v, ..., week_id, wins, gm_count, game_quality`. |
+| `ingestion_log`, `raw_game_data_pbpstats` | tables | operational/raw — **not for the UI.** |
+
+**Gotchas that bite query writers:**
+- `box_scores` has **no `season_year`** — to filter by season, join `schedule` on `game_id`.
+- `season_year = 2024` means the **2024-25** season. Current season today is `2025` (2025-26).
+- For per-game player lines use `period = 'FullGame'`; for quarter/OT splits use `'1'..'6'`.
+- The 3 views were just repointed from v2 → v3; they read v3 now.
+
+## Decisions already made (don't re-litigate)
+
+- **NBA only.** NHL is out of scope (legacy app had it; we dropped it). No sport switcher.
+- **Prod, not staging.** Pipeline and Dive both live on the live account. Staging has a
+  *separate, unrelated* `nba_box_scores` DB — ignore it.
+- **Dive reads `nba_box_scores_v3.main.*`** directly.
+- Nightly Flight stays live (cron `0 16 * * *` UTC). Flight id
+  `ebeaf1ba-cb2a-4702-b8b7-252063a12f9b` — inspect via `mcp__claude_ai_MotherDuck__list_flights`
+  / `get_flight` / `get_flight_run_logs` (the web UI doesn't show Flights yet — preview feature).
+
+## Open decision for Phase 2 kickoff
+
+**Repo home.** `plan.md` §2.3 says the Dive should be its **own repo** (modeled on
+[`motherduckdb/blessed-dives`](https://github.com/motherduckdb/blessed-dives), local clone at
+`~/code/blessed-dives`), because the dives-as-code deploy tooling is repo-scoped. But this branch
+was cut in the labs monorepo per the user's request. **Resolve first:** separate repo (per plan)
+vs. a `projects/nba-box-scores-dive/` dir in labs. The user leans toward iterating here; confirm.
+
+## First steps for Phase 2
+
+1. **Call `mcp__claude_ai_MotherDuck__get_dive_guide` immediately.** It returns the live Dive API:
+   component shape, allowed/externalized libs, `useSQLQuery` usage, how `requiredResources` are
+   declared, styling rules. This is authoritative and may have changed — trust it over this doc.
+2. Skim the user's **32 existing prod dives** (`list_dives`) — they're ad-hoc NBA dashboards
+   (PPG leaders, standings, GQ explorer, playoff bracket, etc.) and are excellent pattern/styling
+   references. The migration Dive consolidates the legacy Vercel app's surfaces into one Dive.
+3. Read the **old frontend** for the surfaces to port:
+   `~/code/nba-box-scores/nba-box-scores/app/` + `components/` (Next.js 16 / React 19).
+4. Decide the repo question above, scaffold accordingly.
+
+## Component → Dive section map (from plan §2.4)
+
+One Dive, several sections. Drop the NBA/NHL switcher.
+
+| Legacy surface | Dive section |
+|---|---|
+| `app/page.tsx` schedule grid | `<ScheduleGrid />` |
+| `LiveGamesSection` | `<LiveGames />` |
+| `BoxScorePanel` | `<BoxScorePanel />` (click-through from grid) |
+| `SeasonFilter` | `<SeasonFilter />` |
+| scatter plot | `<ScatterPlot />` (recharts) |
+| dynamic stats explorer | `<DynamicStatsExplorer />` (biggest port) |
+| player index | `<PlayerIndex />` |
+
+- Data layer: `useSQLQuery` from `@motherduck/react-sql-query` (runtime-provided, externalized).
+- Externalized (do NOT bundle): `react`, `react-dom`, `@motherduck/react-sql-query`, `recharts`,
+  `d3`, `lucide-react`. Everything else (e.g. `date-fns`) gets inlined by esbuild — confirm via
+  the dive guide.
+- `requiredResources` / `REQUIRED_DATABASES`: `md:nba_box_scores_v3` (alias `nba_box_scores_v3`).
+- Known v1 regressions to accept: no URL deep links (single-component state), no `next/image`.
+
+## Optional: purpose-shaped views (plan §2.7)
+
+Rather than join raw tables in `useSQLQuery`, consider adding views to v3 that match the Dive's
+queries 1:1 (`schedule_with_scores`, `box_score_player_rows`, `player_index`, `season_scatter`,
+`dynamic_stats_facts`). These **do not exist yet** — only `players`/`team_stats`/`game_quality` do.
+If added, check them into the pipeline repo (`src/.../db/`) and apply them in the nightly's
+post-load step so they stay maintained.
+
+## Environment gotchas
+
+- MCP is the **live** account (`matson`). Dives created via MCP are owned by `matson`.
+- **Flights** preview: no web UI, no `MD_CREATE_FLIGHT` SQL on this workspace (API/MCP only).
+  **Dives** are fully supported in the UI (32 exist) and via MCP (`save_dive`, `update_dive`,
+  `edit_dive_content`, `read_dive`, `view_dive`, `list_dives`).
+- If doing dives-as-code deploy (blessed-dives style), confirm whether `MD_CREATE_DIVE` SQL is
+  available on the workspace or whether to deploy via the MCP tools.
+
+## Pointers
+
+- Migration plan: [`plan.md`](./plan.md) (esp. §2).
+- Pipeline (Phase 1, done): `projects/nba-box-scores-pipeline/` — `src/nba_box_scores_pipeline/`,
+  flights in `flights/`, entrypoints in `entrypoints.py`.
+- blessed-dives reference: `~/code/blessed-dives` (build.ts / deploy.ts / schema.ts / workflows).
+- Legacy frontend: `~/code/nba-box-scores/nba-box-scores/app/` + `components/`.
+- Auto-memory: `nba-box-scores-v3-migration` (has flight id, decisions, sync method, gotchas).
+- `get_dive_guide` MCP tool — **call it first.**


### PR DESCRIPTION
Phase 2 of the nba-box-scores migration: the consolidated MotherDuck **Dive** that replaces the legacy Next.js/Vercel frontend. Reads `nba_box_scores_v3` on prod via `useSQLQuery`.

## What's here
Multi-file preview source under `projects/nba-box-scores-dive/.dive-preview/` (Vite harness from the dive guide + the dive's own components/lib).

**Tabs:**
- **Schedule** — games grouped by date, paginated, period line-scores per card; click-through to a full box-score modal (both teams, sorted by minutes, totals). Box-score player names drill into a per-player game log.
- **Game Quality** — player GQ leaderboard from the `game_quality` view (avg GQ + box stats + FGv/FTv value-adds), min-games slider, sortable columns, drill to game log.
- **Trends** — recharts scatter, points/game vs avg Game Quality (dot size = games played).

Shared `SeasonFilter` (season / type / team / player-search) on top; all state (tab, filters, page, selected game) persists via `useDiveState`.

## Data handling (flagged during review)
- **Name drift:** player names drift across seasons (e.g. "Nikola Jokić" ↔ "Nikola Jokic"). Aggregates group by stable `entity_id` and display the latest name via `arg_max(player_name, game_date)`; player filters resolve a selected name → `entity_id` so every spelling is caught.
- **GQ sub-15-min sentinel:** `game_quality = -1` marks games with <15 min played (176k rows). Excluded (`>= 0`) from all GQ averages.

## Aesthetic
Matches the legacy app: monospace, white background, gray palette, blue-600 links, amber-500 playoff strip, shadowed cards.

## Not in this PR (next steps)
- **esbuild bundle step** — collapse the multi-file source into the single self-contained `.tsx` that `save_dive` requires (externalizing react/recharts/lucide-react/@motherduck/react-sql-query).
- **Deploy** via `save_dive` (creates the dive on prod).
- **LiveGames dropped** — dives are CSP-locked to `*.motherduck.com`, so the legacy `fetch()`-based live scores can't port.

The token `.env` and `node_modules/` are git-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)