### PR TITLE
dive-viewer: storage shim, d3, clearer expired-session error

### DIFF
--- a/projects/motherduck-dive-viewer/lib/dive-viewer.ts
+++ b/projects/motherduck-dive-viewer/lib/dive-viewer.ts
@@ -235,6 +235,10 @@ export function buildDiveViewerHtml(params: {
   <script crossorigin="anonymous" src="https://unpkg.com/@babel/standalone@7.26.4/babel.min.js"><\/script>
   <script crossorigin="anonymous" src="https://unpkg.com/recharts@2.15.4/umd/Recharts.js"><\/script>
 
+  <!-- d3 (full v7 bundle: includes d3-geo/scale/shape/etc.). Some Dives import
+       or use a global \`d3\` (e.g. d3.geoOrthographic). -->
+  <script crossorigin="anonymous" src="https://unpkg.com/d3@7/dist/d3.min.js"><\/script>
+
   <style>
     html, body, #root { height: 100%; }
     body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
@@ -263,6 +267,28 @@ export function buildDiveViewerHtml(params: {
   <\/script>
 
   <script>
+    // In a sandboxed (opaque-origin) iframe, reading window.localStorage /
+    // sessionStorage throws a SecurityError. Dives (or their libs) that touch
+    // storage would crash on load. Install in-memory shims BEFORE any dive code
+    // runs — per-session, not persisted, like the useDiveState preview stub.
+    (function () {
+      function makeStorage() {
+        var m = Object.create(null);
+        return {
+          getItem: function (k) { k = String(k); return k in m ? m[k] : null; },
+          setItem: function (k, v) { m[String(k)] = String(v); },
+          removeItem: function (k) { delete m[String(k)]; },
+          clear: function () { for (var k in m) delete m[k]; },
+          key: function (i) { var ks = Object.keys(m); return i >= 0 && i < ks.length ? ks[i] : null; },
+          get length() { return Object.keys(m).length; },
+        };
+      }
+      ['localStorage', 'sessionStorage'].forEach(function (name) {
+        try { Object.defineProperty(window, name, { value: makeStorage(), configurable: true }); }
+        catch (e) { /* leave native (throwing) accessor if it can't be shadowed */ }
+      });
+    })();
+
     var __CAPABILITY = ${JSON.stringify(capability)};
     var __QUERY_ENDPOINT = ${JSON.stringify(queryEndpoint)};
     var __DIVE_ID = ${JSON.stringify(diveId)};
@@ -309,7 +335,12 @@ export function buildDiveViewerHtml(params: {
         }).then(function(res) {
           if (!res.ok) {
             return res.json().catch(function() { return {}; }).then(function(b) {
-              return { status: 'error', err: new Error(b && b.error ? b.error : ('Query failed (' + res.status + ')')) };
+              // 401 means the capability/session expired — the actionable fix
+              // is reloading the page (which re-mints with a refreshed token).
+              var msg = res.status === 401
+                ? 'Session expired — reload this page to continue.'
+                : (b && b.error ? b.error : ('Query failed (' + res.status + ')'));
+              return { status: 'error', err: new Error(msg) };
             });
           }
           return res.json().then(function(j) {
@@ -468,6 +499,7 @@ export function buildDiveViewerHtml(params: {
         var Fragment = React.Fragment;
         var useSQLQuery = MDSDK.useSQLQuery;
         var Lucide = window.__Lucide || {};
+        var d3 = window.d3 || {};
 
         var rechartsPrelude = Object.keys(RechartsComponents)
           .filter(function(n) { return /^[A-Z][A-Za-z0-9_$]*$/.test(n); })
@@ -493,6 +525,7 @@ export function buildDiveViewerHtml(params: {
           'react/jsx-dev-runtime': React,
           'recharts': RechartsComponents,
           'lucide-react': Lucide,
+          'd3': d3,
           '@motherduck/react-sql-query': MDSDK,
         };
         var moduleCache = {};

--- a/projects/motherduck-dive-viewer/package-lock.json
+++ b/projects/motherduck-dive-viewer/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "motherduck-oauth-nextjs",
+  "name": "motherduck-dive-viewer",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "motherduck-oauth-nextjs",
+      "name": "motherduck-dive-viewer",
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
Follow-up fixes for render-fidelity gaps surfaced by real Dives in the viewer:

- **localStorage/sessionStorage shim** — installed before dive code runs, so dives that touch storage don't crash in the opaque-origin sandbox (`Failed to read the 'localStorage' property … lacks the 'allow-same-origin' flag`). In-memory, per-session (matches the preview-only `useDiveState` stub).
- **d3** — load the full d3 v7 bundle (includes d3-geo/scale/shape/…) and expose it as a bare global + a `d3` import, so dives using d3 (e.g. `d3.geoOrthographic`) render.
- **Clearer expired-session error** — proxy 401s now surface "Session expired — reload this page to continue." instead of a bare `auth_expired` (the short-lived capability / OAuth token aged out; a reload re-mints with a refreshed token).

Known remaining gap (not in this PR): **theming**. Dives that rely on MotherDuck's injected theme CSS/fonts won't match exactly — that's the inherent limit of rendering with our own SDK port instead of MotherDuck's hosted renderer (documented in the README's Known Limitations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)