### PR TITLE
dive-viewer: recharts v3 + wider dive view

### DIFF
--- a/projects/motherduck-dive-viewer/app/dives/[id]/dive-frame.tsx
+++ b/projects/motherduck-dive-viewer/app/dives/[id]/dive-frame.tsx
@@ -15,7 +15,7 @@ export function DiveFrame({ src, title }: { src: string; title: string }) {
   return (
     <div
       className="relative border-2 border-foreground rounded-sm shadow-[3px_3px_0_#171717] overflow-hidden bg-white"
-      style={{ height: '760px' }}
+      style={{ height: '82vh', minHeight: '640px' }}
     >
       {!loaded && (
         <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-white text-brutal-muted">

--- a/projects/motherduck-dive-viewer/app/dives/[id]/page.tsx
+++ b/projects/motherduck-dive-viewer/app/dives/[id]/page.tsx
@@ -19,7 +19,7 @@ export default async function DivePage({
   const title = typeof sp.title === 'string' && sp.title.length > 0 ? sp.title : 'Dive';
 
   return (
-    <main className="mx-auto w-full max-w-5xl px-6 py-10">
+    <main className="mx-auto w-full max-w-[1600px] px-6 py-10">
       <header className="flex items-center justify-between mb-6">
         <Link
           href="/"

--- a/projects/motherduck-dive-viewer/lib/dive-viewer.ts
+++ b/projects/motherduck-dive-viewer/lib/dive-viewer.ts
@@ -238,7 +238,12 @@ export function buildDiveViewerHtml(params: {
   <script crossorigin="anonymous" src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"><\/script>
   <script crossorigin="anonymous" src="https://unpkg.com/prop-types@15.8.1/prop-types.min.js"><\/script>
   <script crossorigin="anonymous" src="https://unpkg.com/@babel/standalone@7.26.4/babel.min.js"><\/script>
-  <script crossorigin="anonymous" src="https://unpkg.com/recharts@2.15.4/umd/Recharts.js"><\/script>
+  <!-- react-is is an external of the Recharts v3 UMD (it reads window.ReactIs);
+       must load before Recharts. -->
+  <script crossorigin="anonymous" src="https://unpkg.com/react-is@18.3.1/umd/react-is.production.min.js"><\/script>
+  <!-- Recharts v3 to match the version Dives are authored against (the
+       dive-preview harness pins ~3.7). v2 caused render mismatches. -->
+  <script crossorigin="anonymous" src="https://unpkg.com/recharts@3.7.0/umd/Recharts.js"><\/script>
 
   <!-- d3 (full v7 bundle: includes d3-geo/scale/shape/etc.). Some Dives import
        or use a global \`d3\` (e.g. d3.geoOrthographic). -->


### PR DESCRIPTION
- **Recharts v3** — bump 2.15.4 → 3.7.0 to match what Dives are authored against (the local dive-preview harness pins ~3.7); v2 was causing chart render mismatches ("weird issues"). Recharts 3's UMD externalizes `react-is`, so load `react-is@18.3.1` UMD before it.
- **Wider dive view** — the dive page was capped at `max-w-5xl` (~1024px) while MotherDuck renders Dives near full-width, so wide side-by-side layouts (e.g. Night Sky Atlas) collapsed/stacked. Widen to `max-w-[1600px]` and grow the iframe to `82vh` (min 640px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)