### PR TITLE
[workshop] data-chat-mini step 02: MCP query

### DIFF
--- a/projects/data-chat-mini/app/api/query/route.ts
+++ b/projects/data-chat-mini/app/api/query/route.ts
@@ -1,0 +1,43 @@
+import { createMCPClient, executeQuery, listQueryTool } from '@/lib/mcp-client';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+export async function GET() {
+  let client: Client | null = null;
+  try {
+    client = await createMCPClient();
+    const tool = await listQueryTool(client);
+    if (!tool) {
+      return Response.json({ error: 'The MotherDuck MCP server did not expose query.' }, { status: 500 });
+    }
+    return Response.json({ tool });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return Response.json({ error: message }, { status: 500 });
+  } finally {
+    if (client) {
+      try { await client.close(); } catch { /* ignore */ }
+    }
+  }
+}
+
+export async function POST(request: Request) {
+  let client: Client | null = null;
+  try {
+    const body = await request.json();
+    const sql = typeof body.query === 'string' ? body.query : '';
+    if (!sql.trim()) {
+      return Response.json({ error: 'Provide a SQL string as { "query": "select ..." }.' }, { status: 400 });
+    }
+
+    client = await createMCPClient();
+    const result = await executeQuery(client, sql);
+    return Response.json({ result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return Response.json({ error: message }, { status: 500 });
+  } finally {
+    if (client) {
+      try { await client.close(); } catch { /* ignore */ }
+    }
+  }
+}

--- a/projects/data-chat-mini/app/page.tsx
+++ b/projects/data-chat-mini/app/page.tsx
@@ -2,27 +2,19 @@ export default function Home() {
   return (
     <main>
       <section className="workshop-page">
-        <div className="eyebrow">Step 01 · Data</div>
-        <h1>Start with the ground truth.</h1>
+        <div className="eyebrow">Step 02 · MCP query</div>
+        <h1>Give the app one read-only tool.</h1>
         <p>
-          The workshop agent starts from a MotherDuck database named
-          <strong> nba_box_scores_v2</strong>. Before there is a model or a
-          loop, the first checkpoint proves the data shape with a plain SQL
-          query.
+          The workshop agent still has no model and no loop. This checkpoint
+          wires the MotherDuck MCP server and exposes only the <code>query</code>
+          tool so you can call it by hand.
         </p>
 
         <div className="check">
-          <p>Quick check: run a plain SELECT and show the grain.</p>
-          <pre>{`select
-  game_id,
-  player_name,
-  period,
-  points
-from nba_box_scores_v2.main.box_scores
-where season_year = 2025
-  and season_type = 'Playoffs'
-order by game_date desc, game_id, player_name, period
-limit 12;`}</pre>
+          <p>Quick check: POST this SQL to <code>/api/query</code> and get rows back.</p>
+          <pre>{`curl -s http://localhost:3000/api/query \\
+  -H 'content-type: application/json' \\
+  -d '{"query":"select count(*) as games from nba_box_scores_v2.main.schedule"}'`}</pre>
           <p>
             The important rule: <code>box_scores</code> is one row per player
             per period. A game total is the <code>FullGame</code> row, not the

--- a/projects/data-chat-mini/lib/mcp-client.ts
+++ b/projects/data-chat-mini/lib/mcp-client.ts
@@ -1,0 +1,60 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { getMotherDuckMcpUrl } from './motherduck-env';
+
+export interface MCPTool {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export async function createMCPClient(): Promise<Client> {
+  const token = process.env.MOTHERDUCK_TOKEN;
+  if (!token) {
+    throw new Error('No MOTHERDUCK_TOKEN configured. Set it in .env.local.');
+  }
+
+  const client = new Client({ name: 'data-chat-mini', version: '1.0.0' });
+  const transport = new StreamableHTTPClientTransport(new URL(getMotherDuckMcpUrl()), {
+    requestInit: {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  });
+
+  try {
+    await client.connect(transport);
+    return client;
+  } catch (error) {
+    try { await client.close(); } catch { /* ignore */ }
+    throw error;
+  }
+}
+
+export async function listQueryTool(client: Client): Promise<MCPTool | null> {
+  const result = await client.listTools();
+  const query = (result.tools || []).find(tool => tool.name === 'query');
+  if (!query) return null;
+  return {
+    name: query.name,
+    description: query.description || '',
+    inputSchema: query.inputSchema as Record<string, unknown>,
+  };
+}
+
+export async function executeQuery(client: Client, sql: string): Promise<string> {
+  const result = await client.callTool({
+    name: 'query',
+    arguments: { query: sql },
+  });
+
+  if (result.structuredContent != null) {
+    return JSON.stringify(result.structuredContent, null, 2);
+  }
+  return Array.isArray(result.content)
+    ? result.content
+        .map((block: { type: string; text?: string }) =>
+          block.type === 'text' ? block.text : JSON.stringify(block)
+        )
+        .join('\n')
+    : JSON.stringify(result.content);
+}


### PR DESCRIPTION
Adds the MotherDuck MCP query checkpoint.\n\nQuick check: POST SQL to /api/query and get rows back.\n\nValidation: npm run typecheck for data-chat-mini-step-02.