### PR TITLE
[workshop] data-chat-mini step 03: read-scaling token

### DIFF
--- a/projects/data-chat-mini/app/api/query/route.ts
+++ b/projects/data-chat-mini/app/api/query/route.ts
@@ -1,10 +1,15 @@
+import { NextRequest } from 'next/server';
 import { createMCPClient, executeQuery, listQueryTool } from '@/lib/mcp-client';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 
-export async function GET() {
+function getSessionHint(request: NextRequest): string | undefined {
+  return request.headers.get('x-session-id') || request.nextUrl.searchParams.get('session') || undefined;
+}
+
+export async function GET(request: NextRequest) {
   let client: Client | null = null;
   try {
-    client = await createMCPClient();
+    client = await createMCPClient(getSessionHint(request));
     const tool = await listQueryTool(client);
     if (!tool) {
       return Response.json({ error: 'The MotherDuck MCP server did not expose query.' }, { status: 500 });
@@ -20,7 +25,7 @@ export async function GET() {
   }
 }
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
   let client: Client | null = null;
   try {
     const body = await request.json();
@@ -29,7 +34,7 @@ export async function POST(request: Request) {
       return Response.json({ error: 'Provide a SQL string as { "query": "select ..." }.' }, { status: 400 });
     }
 
-    client = await createMCPClient();
+    client = await createMCPClient(getSessionHint(request));
     const result = await executeQuery(client, sql);
     return Response.json({ result });
   } catch (error) {

--- a/projects/data-chat-mini/app/page.tsx
+++ b/projects/data-chat-mini/app/page.tsx
@@ -2,18 +2,20 @@ export default function Home() {
   return (
     <main>
       <section className="workshop-page">
-        <div className="eyebrow">Step 02 · MCP query</div>
-        <h1>Give the app one read-only tool.</h1>
+        <div className="eyebrow">Step 03 · Read-scaling token</div>
+        <h1>Make the credential room-sized.</h1>
         <p>
-          The workshop agent still has no model and no loop. This checkpoint
-          wires the MotherDuck MCP server and exposes only the <code>query</code>
-          tool so you can call it by hand.
+          The MCP client now connects with <code>MOTHERDUCK_TOKEN</code>, a
+          read-scaling token. The browser keeps a random session id and passes
+          it as a hint so repeat requests can stay warm while the token fans the
+          room out across read replicas.
         </p>
 
         <div className="check">
-          <p>Quick check: POST this SQL to <code>/api/query</code> and get rows back.</p>
+          <p>Quick check: POST with a session id and get rows back.</p>
           <pre>{`curl -s http://localhost:3000/api/query \\
   -H 'content-type: application/json' \\
+  -H 'x-session-id: workshop-demo' \\
   -d '{"query":"select count(*) as games from nba_box_scores_v2.main.schedule"}'`}</pre>
           <p>
             The important rule: <code>box_scores</code> is one row per player

--- a/projects/data-chat-mini/lib/mcp-client.ts
+++ b/projects/data-chat-mini/lib/mcp-client.ts
@@ -8,14 +8,26 @@ export interface MCPTool {
   inputSchema: Record<string, unknown>;
 }
 
-export async function createMCPClient(): Promise<Client> {
+/**
+ * Create an MCP client authenticated with the MotherDuck read scaling token.
+ *
+ * The token fans read-only connections across replicas. The browser session id
+ * is passed as `session_name` so a user's repeat requests can stay warm when
+ * the MCP transport forwards the hint.
+ */
+export async function createMCPClient(sessionHint?: string): Promise<Client> {
   const token = process.env.MOTHERDUCK_TOKEN;
   if (!token) {
     throw new Error('No MOTHERDUCK_TOKEN configured. Set it in .env.local.');
   }
 
+  const url = new URL(getMotherDuckMcpUrl());
+  if (sessionHint) {
+    url.searchParams.set('session_name', sessionHint);
+  }
+
   const client = new Client({ name: 'data-chat-mini', version: '1.0.0' });
-  const transport = new StreamableHTTPClientTransport(new URL(getMotherDuckMcpUrl()), {
+  const transport = new StreamableHTTPClientTransport(url, {
     requestInit: {
       headers: { Authorization: `Bearer ${token}` },
     },

--- a/projects/data-chat-mini/lib/session-id.ts
+++ b/projects/data-chat-mini/lib/session-id.ts
@@ -1,0 +1,24 @@
+import { uuid7 } from './uuid7';
+
+/**
+ * Stable per-browser-session id, used as the MotherDuck read-scaling session
+ * hint so concurrent users fan out across read replicas. Persisted in
+ * localStorage so a reload keeps the same replica affinity; regenerated only
+ * when storage is cleared. Client-only.
+ */
+const KEY = 'data-chat-mini:session-id';
+
+export function getSessionId(): string {
+  if (typeof window === 'undefined') return '';
+  try {
+    let id = window.localStorage.getItem(KEY);
+    if (!id) {
+      id = uuid7();
+      window.localStorage.setItem(KEY, id);
+    }
+    return id;
+  } catch {
+    // Private mode / storage disabled — fall back to a per-load id.
+    return uuid7();
+  }
+}

--- a/projects/data-chat-mini/lib/uuid7.ts
+++ b/projects/data-chat-mini/lib/uuid7.ts
@@ -1,0 +1,38 @@
+/**
+ * Generate a UUIDv7 (time-sortable) string.
+ * 48-bit timestamp in high bytes, version 7, random fill.
+ * Avoids BigInt for ES2017 compatibility.
+ */
+export function uuid7(): string {
+  const now = Date.now();
+  const randBytes = new Uint8Array(10);
+  crypto.getRandomValues(randBytes);
+
+  const b = new Uint8Array(16);
+
+  // Bytes 0-5: 48-bit timestamp (big-endian)
+  // JS Date.now() fits in 48 bits until year 10889
+  b[0] = (now / 0x10000000000) & 0xFF;
+  b[1] = (now / 0x100000000) & 0xFF;
+  b[2] = (now / 0x1000000) & 0xFF;
+  b[3] = (now / 0x10000) & 0xFF;
+  b[4] = (now / 0x100) & 0xFF;
+  b[5] = now & 0xFF;
+
+  // Byte 6: version 7 (0x7_) | high 4 bits of rand_a
+  b[6] = 0x70 | (randBytes[0] & 0x0F);
+  // Byte 7: low 8 bits of rand_a
+  b[7] = randBytes[1];
+
+  // Byte 8: variant 10 (0x80) | 6 bits of random
+  b[8] = 0x80 | (randBytes[2] & 0x3F);
+
+  // Bytes 9-15: remaining random
+  for (let i = 3; i < 10; i++) {
+    b[6 + i] = randBytes[i];
+  }
+
+  // Format as UUID string
+  const hex = Array.from(b).map(x => x.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}


### PR DESCRIPTION
Adds the read-scaling token/session checkpoint.\n\nQuick check: call the MCP query route with a session id header.\n\nValidation: npm run typecheck for data-chat-mini-step-03.