### PR TITLE
[workshop] data-chat-mini step 04: tool allowlist

### DIFF
--- a/projects/data-chat-mini/app/api/query/route.ts
+++ b/projects/data-chat-mini/app/api/query/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { createMCPClient, executeQuery, listQueryTool } from '@/lib/mcp-client';
+import { createMCPClient, executeQuery, executeTool, listQueryTool } from '@/lib/mcp-client';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 
 function getSessionHint(request: NextRequest): string | undefined {
@@ -40,6 +40,25 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     return Response.json({ error: message }, { status: 500 });
+  } finally {
+    if (client) {
+      try { await client.close(); } catch { /* ignore */ }
+    }
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  let client: Client | null = null;
+  try {
+    const body = await request.json();
+    const tool = typeof body.tool === 'string' ? body.tool : 'query_rw';
+    const args = body.args && typeof body.args === 'object' ? body.args as Record<string, unknown> : {};
+    client = await createMCPClient(getSessionHint(request));
+    const result = await executeTool(client, tool, args);
+    return Response.json({ result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return Response.json({ error: message }, { status: 400 });
   } finally {
     if (client) {
       try { await client.close(); } catch { /* ignore */ }

--- a/projects/data-chat-mini/app/page.tsx
+++ b/projects/data-chat-mini/app/page.tsx
@@ -2,21 +2,20 @@ export default function Home() {
   return (
     <main>
       <section className="workshop-page">
-        <div className="eyebrow">Step 03 · Read-scaling token</div>
-        <h1>Make the credential room-sized.</h1>
+        <div className="eyebrow">Step 04 · Guardrails</div>
+        <h1>Reject writes before they run.</h1>
         <p>
-          The MCP client now connects with <code>MOTHERDUCK_TOKEN</code>, a
-          read-scaling token. The browser keeps a random session id and passes
-          it as a hint so repeat requests can stay warm while the token fans the
-          room out across read replicas.
+          The MCP client now has an explicit allowlist. Only <code>query</code>
+          can run; mutating tools like <code>query_rw</code> are classified but
+          absent from the allowlist, so they fail in code before MotherDuck sees
+          the request.
         </p>
 
         <div className="check">
-          <p>Quick check: POST with a session id and get rows back.</p>
-          <pre>{`curl -s http://localhost:3000/api/query \\
+          <p>Quick check: try the write-shaped tool and see it rejected.</p>
+          <pre>{`curl -X PUT -s http://localhost:3000/api/query \\
   -H 'content-type: application/json' \\
-  -H 'x-session-id: workshop-demo' \\
-  -d '{"query":"select count(*) as games from nba_box_scores_v2.main.schedule"}'`}</pre>
+  -d '{"tool":"query_rw","args":{"query":"create table nope as select 1"}}'`}</pre>
           <p>
             The important rule: <code>box_scores</code> is one row per player
             per period. A game total is the <code>FullGame</code> row, not the

--- a/projects/data-chat-mini/lib/mcp-client.ts
+++ b/projects/data-chat-mini/lib/mcp-client.ts
@@ -8,6 +8,36 @@ export interface MCPTool {
   inputSchema: Record<string, unknown>;
 }
 
+export const ALLOWED_TOOLS = new Set([
+  'query',
+]);
+
+export const READONLY_TOOLS = new Set([
+  'query',
+]);
+
+export const MUTATING_TOOLS = new Set([
+  'query_rw',
+  'update_context_layer',
+]);
+
+export const DESTRUCTIVE_TOOLS = new Set([
+  'delete_dive',
+]);
+
+export function requiresConfirmation(
+  toolName: string,
+  toolArgs: Record<string, unknown> | undefined,
+): boolean {
+  if (DESTRUCTIVE_TOOLS.has(toolName)) return true;
+  if (!MUTATING_TOOLS.has(toolName)) return false;
+  if (toolName === 'update_context_layer') {
+    const action = toolArgs && typeof toolArgs.action === 'string' ? toolArgs.action : undefined;
+    return action !== 'create';
+  }
+  return true;
+}
+
 /**
  * Create an MCP client authenticated with the MotherDuck read scaling token.
  *
@@ -53,20 +83,66 @@ export async function listQueryTool(client: Client): Promise<MCPTool | null> {
   };
 }
 
-export async function executeQuery(client: Client, sql: string): Promise<string> {
+export async function getFilteredTools(client: Client): Promise<MCPTool[]> {
+  const result = await client.listTools();
+  return (result.tools || [])
+    .filter(tool => ALLOWED_TOOLS.has(tool.name))
+    .map(tool => ({
+      name: tool.name,
+      description: tool.description || '',
+      inputSchema: tool.inputSchema as Record<string, unknown>,
+    }));
+}
+
+export function mcpToolsToAnthropicFormat(tools: MCPTool[]): Array<{
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}> {
+  return tools.map(tool => ({
+    name: tool.name,
+    description: tool.description || '',
+    input_schema: tool.inputSchema,
+  }));
+}
+
+export async function executeToolWithStatus(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>,
+  internal?: boolean,
+): Promise<{ text: string; isError: boolean }> {
+  if (!internal && !ALLOWED_TOOLS.has(name)) {
+    throw new Error(`Tool "${name}" is not in the allowed (read-only) tool set`);
+  }
   const result = await client.callTool({
-    name: 'query',
-    arguments: { query: sql },
+    name,
+    arguments: args,
   });
 
   if (result.structuredContent != null) {
-    return JSON.stringify(result.structuredContent, null, 2);
+    return { text: JSON.stringify(result.structuredContent, null, 2), isError: result.isError === true };
   }
-  return Array.isArray(result.content)
+  const text = Array.isArray(result.content)
     ? result.content
         .map((block: { type: string; text?: string }) =>
           block.type === 'text' ? block.text : JSON.stringify(block)
         )
         .join('\n')
     : JSON.stringify(result.content);
+  return { text, isError: result.isError === true };
+}
+
+export async function executeTool(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>,
+  internal?: boolean,
+): Promise<string> {
+  const { text } = await executeToolWithStatus(client, name, args, internal);
+  return text;
+}
+
+export async function executeQuery(client: Client, sql: string): Promise<string> {
+  return executeTool(client, 'query', { query: sql });
 }


### PR DESCRIPTION
Adds the read-only MCP tool allowlist and guardrail classification checkpoint.\n\nQuick check: attempt query_rw and see it rejected before dispatch.\n\nValidation: npm run typecheck for data-chat-mini-step-04.