### PR TITLE
[workshop] data-chat-mini step 06: agentic loop

### DIFF
--- a/projects/data-chat-mini/app/api/chat/route.ts
+++ b/projects/data-chat-mini/app/api/chat/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest } from 'next/server';
+import { getModelProfile } from '@/lib/llm-client';
+import { createMCPClient, getFilteredTools, mcpToolsToAnthropicFormat } from '@/lib/mcp-client';
+import { runAgenticLoop } from '@/lib/agentic-loop';
+import { sseDone, sseError } from '@/lib/sse-encoder';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+export const maxDuration = 300;
+
+export async function POST(request: NextRequest) {
+  let mcpClient: Client | null = null;
+  try {
+    const body = await request.json();
+    const message = typeof body.message === 'string' ? body.message : '';
+    const sessionId = typeof body.sessionId === 'string' ? body.sessionId : undefined;
+    if (!message.trim()) {
+      return Response.json({ error: 'No message provided' }, { status: 400 });
+    }
+    if (!process.env.MOTHERDUCK_TOKEN) {
+      return Response.json({ error: 'Server is missing MOTHERDUCK_TOKEN' }, { status: 500 });
+    }
+    if (!process.env.OPENROUTER_API_KEY) {
+      return Response.json({ error: 'Server is missing OPENROUTER_API_KEY' }, { status: 500 });
+    }
+
+    mcpClient = await createMCPClient(sessionId);
+    const tools = mcpToolsToAnthropicFormat(await getFilteredTools(mcpClient));
+    const profile = getModelProfile();
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        const emit = (chunk: Uint8Array) => controller.enqueue(chunk);
+        try {
+          await runAgenticLoop({
+            messages: [{ role: 'user', content: message }],
+            profile,
+            thinkingLevel: 'none',
+            client: mcpClient!,
+            tools,
+            systemPrompt: 'You are a read-only data assistant. Use tools when needed, then answer concisely.',
+            emit,
+          });
+          emit(sseDone());
+        } catch (error) {
+          console.error('[Chat] Stream error:', error);
+          emit(sseError('An error occurred processing your request'));
+        } finally {
+          try { controller.close(); } catch { /* already closed */ }
+          if (mcpClient) {
+            try { await mcpClient.close(); } catch { /* ignore */ }
+          }
+        }
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+      },
+    });
+  } catch (error) {
+    if (mcpClient) {
+      try { await mcpClient.close(); } catch { /* ignore */ }
+    }
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/projects/data-chat-mini/app/page.tsx
+++ b/projects/data-chat-mini/app/page.tsx
@@ -2,19 +2,18 @@ export default function Home() {
   return (
     <main>
       <section className="workshop-page">
-        <div className="eyebrow">Step 05 · Model</div>
-        <h1>Point at the engine.</h1>
+        <div className="eyebrow">Step 06 · Loop</div>
+        <h1>Let the model take steps.</h1>
         <p>
-          The app now speaks OpenRouter's OpenAI-compatible streaming API. The
-          default model is <code>google/gemini-3-flash-preview</code>, with
-          <code>OPENROUTER_MODEL</code> available for swaps.
+          The app now has the agentic loop: ask the model, run any tool calls it
+          requests, append the results, and ask again until it answers.
         </p>
 
         <div className="check">
-          <p>Quick check: call the model without tools and see a response.</p>
-          <pre>{`curl -s http://localhost:3000/api/model \\
+          <p>Quick check: ask a question that requires a query.</p>
+          <pre>{`curl -N http://localhost:3000/api/chat \\
   -H 'content-type: application/json' \\
-  -d '{"message":"Say hello to the workshop in one sentence."}'`}</pre>
+  -d '{"message":"How many games are in the schedule table?"}'`}</pre>
           <p>
             The important rule: <code>box_scores</code> is one row per player
             per period. A game total is the <code>FullGame</code> row, not the

--- a/projects/data-chat-mini/lib/agentic-loop.ts
+++ b/projects/data-chat-mini/lib/agentic-loop.ts
@@ -1,0 +1,144 @@
+import { streamChatCompletion } from '@/lib/llm-client';
+import type { ModelProfile } from '@/lib/llm-client';
+import { dispatchTool } from '@/lib/tool-dispatch';
+import { sseError, sseText, sseToolEnd, sseToolStart, sseUsage } from '@/lib/sse-encoder';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { ThinkingLevel } from '@/types/chat';
+
+export interface RunAgenticLoopOpts {
+  messages: Array<{ role: string; content: unknown }>;
+  profile: ModelProfile;
+  thinkingLevel: ThinkingLevel;
+  client: Client;
+  tools: Array<{ name: string; description: string; input_schema: Record<string, unknown> }>;
+  systemPrompt: string;
+  emit: (chunk: Uint8Array) => void;
+}
+
+const MAX_ITERATIONS = 8;
+
+export async function runAgenticLoop(opts: RunAgenticLoopOpts) {
+  const messages = opts.messages;
+
+  for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+    const llmStream = await streamChatCompletion({
+      model: opts.profile.id,
+      messages,
+      tools: opts.tools,
+      systemPrompt: opts.systemPrompt,
+      temperature: 0.2,
+      maxTokens: opts.profile.maxTokens,
+      thinkingLevel: opts.thinkingLevel,
+      provider: opts.profile.provider,
+    });
+
+    const assistantBlocks: Array<Record<string, unknown>> = [];
+    const pendingToolCalls = new Map<number, { id: string; name: string; args: string }>();
+    let fullResponseText = '';
+    const usage = { promptTokens: 0, completionTokens: 0 };
+
+    const reader = llmStream.getReader();
+    const decoder = new TextDecoder();
+    let sseBuffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      sseBuffer += decoder.decode(value, { stream: true });
+      const lines = sseBuffer.split('\n');
+      sseBuffer = lines.pop() || '';
+
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        const data = line.slice(6).trim();
+        if (!data || data === '[DONE]') continue;
+
+        let chunk;
+        try { chunk = JSON.parse(data); } catch { continue; }
+
+        if (chunk.usage) {
+          usage.promptTokens = chunk.usage.prompt_tokens || 0;
+          usage.completionTokens = chunk.usage.completion_tokens || 0;
+        }
+
+        const choice = chunk.choices?.[0];
+        if (!choice) continue;
+        const delta = choice.delta || {};
+
+        if (delta.content) {
+          fullResponseText += delta.content;
+          opts.emit(sseText(delta.content));
+        }
+
+        if (delta.tool_calls) {
+          for (const tc of delta.tool_calls) {
+            const idx = tc.index ?? 0;
+            if (!pendingToolCalls.has(idx)) {
+              pendingToolCalls.set(idx, { id: tc.id || `tool_${idx}`, name: tc.function?.name || '', args: '' });
+            }
+            const pending = pendingToolCalls.get(idx)!;
+            if (tc.id) pending.id = tc.id;
+            if (tc.function?.name) pending.name = tc.function.name;
+            if (tc.function?.arguments) pending.args += tc.function.arguments;
+          }
+        }
+      }
+    }
+
+    if (fullResponseText) {
+      assistantBlocks.push({ type: 'text', text: fullResponseText });
+    }
+    for (const [, tc] of pendingToolCalls) {
+      let parsedArgs: Record<string, unknown> = {};
+      try { parsedArgs = JSON.parse(tc.args || '{}'); } catch { /* keep empty */ }
+      assistantBlocks.push({ type: 'tool_use', id: tc.id, name: tc.name, input: parsedArgs });
+    }
+
+    opts.emit(sseUsage({
+      promptTokens: usage.promptTokens,
+      completionTokens: usage.completionTokens,
+      model: opts.profile.id,
+      contextWindow: opts.profile.contextWindow,
+    }));
+
+    if (pendingToolCalls.size === 0) {
+      if (assistantBlocks.length > 0) {
+        messages.push({ role: 'assistant', content: assistantBlocks });
+      }
+      return { messages };
+    }
+
+    const toolResults: Array<{ type: 'tool_result'; tool_use_id: string; content: string; is_error?: boolean }> = [];
+    for (const tc of pendingToolCalls.values()) {
+      let parsedArgs: Record<string, unknown> = {};
+      try { parsedArgs = JSON.parse(tc.args || '{}'); } catch { /* keep empty */ }
+
+      opts.emit(sseToolStart({ id: tc.id, name: tc.name, args: parsedArgs }));
+      try {
+        const result = await dispatchTool({ client: opts.client, name: tc.name, args: parsedArgs });
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: tc.id,
+          content: result.content,
+          ...(result.isError && { is_error: true }),
+        });
+        opts.emit(sseToolEnd({
+          id: tc.id,
+          name: tc.name,
+          result: result.content.slice(0, 500),
+          ...(result.isError && { error: true }),
+        }));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        toolResults.push({ type: 'tool_result', tool_use_id: tc.id, content: `Error: ${message}`, is_error: true });
+        opts.emit(sseToolEnd({ id: tc.id, name: tc.name, result: `Error: ${message}`, error: true }));
+      }
+    }
+
+    messages.push({ role: 'assistant', content: assistantBlocks });
+    messages.push({ role: 'user', content: toolResults });
+  }
+
+  opts.emit(sseError(`Iteration limit reached (${MAX_ITERATIONS}).`));
+  return { messages };
+}

--- a/projects/data-chat-mini/lib/sse-encoder.ts
+++ b/projects/data-chat-mini/lib/sse-encoder.ts
@@ -1,0 +1,16 @@
+import type { TurnUsage } from '@/types/chat';
+
+const encoder = new TextEncoder();
+
+function event(data: Record<string, unknown>): Uint8Array {
+  return encoder.encode(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+export const sseText = (content: string) => event({ type: 'text', content });
+export const sseDone = () => event({ type: 'done' });
+export const sseError = (content: string) => event({ type: 'error', content });
+export const sseToolStart = (toolCall: { id: string; name: string; args?: Record<string, unknown> }) =>
+  event({ type: 'tool_start', toolCall });
+export const sseToolEnd = (toolCall: { id: string; name: string; result?: string; error?: boolean }) =>
+  event({ type: 'tool_end', toolCall });
+export const sseUsage = (usage: TurnUsage) => event({ type: 'usage', usage });

--- a/projects/data-chat-mini/lib/tool-dispatch.ts
+++ b/projects/data-chat-mini/lib/tool-dispatch.ts
@@ -1,0 +1,22 @@
+import { executeToolWithStatus } from '@/lib/mcp-client';
+import { applyToolArgDefaults, detectPayloadFailure } from '@/lib/tool-invocation';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+export async function dispatchTool({
+  client,
+  name,
+  args,
+}: {
+  client: Client;
+  name: string;
+  args: Record<string, unknown>;
+}): Promise<{ content: string; isError: boolean; errorMessage?: string }> {
+  const normalizedArgs = applyToolArgDefaults(name, args);
+  const { text, isError } = await executeToolWithStatus(client, name, normalizedArgs);
+  const payloadFailure = detectPayloadFailure(text);
+  return {
+    content: text,
+    isError: isError || payloadFailure !== null,
+    ...(payloadFailure && { errorMessage: payloadFailure }),
+  };
+}

--- a/projects/data-chat-mini/lib/tool-invocation.ts
+++ b/projects/data-chat-mini/lib/tool-invocation.ts
@@ -1,0 +1,13 @@
+export function applyToolArgDefaults(
+  name: string,
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  if (name === 'query' && typeof args.query === 'string') {
+    return { ...args, database: args.database || 'nba_box_scores_v2' };
+  }
+  return args;
+}
+
+export function detectPayloadFailure(content: string): string | null {
+  return /error|failed|unauthorized|forbidden/i.test(content) ? content.slice(0, 300) : null;
+}

--- a/projects/data-chat-mini/types/chat.ts
+++ b/projects/data-chat-mini/types/chat.ts
@@ -1,0 +1,24 @@
+export type ThinkingLevel = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
+export interface TurnUsage {
+  promptTokens: number;
+  completionTokens: number;
+  cachedPromptTokens?: number;
+  reasoningTokens?: number;
+  cost?: number;
+  model: string;
+  contextWindow: number;
+}
+
+export interface StreamEvent {
+  type: 'text' | 'tool_start' | 'tool_end' | 'usage' | 'error' | 'done';
+  content?: string;
+  toolCall?: {
+    id: string;
+    name: string;
+    args?: Record<string, unknown>;
+    result?: string;
+    error?: boolean;
+  };
+  usage?: TurnUsage;
+}


### PR DESCRIPTION
Adds the first agentic loop checkpoint.\n\nQuick check: ask how many games are in the schedule and watch query run.\n\nValidation: npm run typecheck for data-chat-mini-step-06.