### PR TITLE
[workshop] data-chat-mini step 08: schema tools

### DIFF
--- a/projects/data-chat-mini/app/api/schema/route.ts
+++ b/projects/data-chat-mini/app/api/schema/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest } from 'next/server';
+import { createMCPClient, executeTool } from '@/lib/mcp-client';
+import { parseTables, parseColumns } from '@/lib/mcp-parsers';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+function getSessionHint(request: NextRequest): string | undefined {
+  return request.headers.get('x-session-id') || request.nextUrl.searchParams.get('session') || undefined;
+}
+
+export async function GET(request: NextRequest) {
+  let client: Client | null = null;
+  try {
+    const database = request.nextUrl.searchParams.get('database') || 'nba_box_scores_v2';
+    const table = request.nextUrl.searchParams.get('table');
+    client = await createMCPClient(getSessionHint(request));
+
+    if (table) {
+      const raw = await executeTool(client, 'list_columns', { database, table });
+      return Response.json({ columns: parseColumns(raw) });
+    }
+
+    const raw = await executeTool(client, 'list_tables', { database });
+    return Response.json({ tables: parseTables(raw) });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return Response.json({ error: message }, { status: 500 });
+  } finally {
+    if (client) {
+      try { await client.close(); } catch { /* ignore */ }
+    }
+  }
+}

--- a/projects/data-chat-mini/app/chat/SchemaExplorerSidebar.tsx
+++ b/projects/data-chat-mini/app/chat/SchemaExplorerSidebar.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { getSessionId } from '@/lib/session-id';
+import type { SchemaTable, SchemaColumn } from '@/lib/mcp-parsers';
+
+export function SchemaExplorerSidebar({ database }: { database: string }) {
+  const [tables, setTables] = useState<SchemaTable[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [columns, setColumns] = useState<SchemaColumn[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/schema?database=${encodeURIComponent(database)}`, {
+      headers: { 'x-session-id': getSessionId() },
+    })
+      .then(async (r) => {
+        const data = await r.json();
+        if (!r.ok) throw new Error(data.error || 'Failed to load schema');
+        setTables(data.tables || []);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load schema'));
+  }, [database]);
+
+  const loadColumns = useCallback((table: string) => {
+    setSelected(table);
+    fetch(`/api/schema?database=${encodeURIComponent(database)}&table=${encodeURIComponent(table)}`, {
+      headers: { 'x-session-id': getSessionId() },
+    })
+      .then(async (r) => {
+        const data = await r.json();
+        if (!r.ok) throw new Error(data.error || 'Failed to load columns');
+        setColumns(data.columns || []);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load columns'));
+  }, [database]);
+
+  return (
+    <aside className="schema-panel">
+      <h2>Schema</h2>
+      <p>{database}</p>
+      {error && <p className="error">{error}</p>}
+      <div className="schema-grid">
+        <div>
+          {tables.map((table) => (
+            <button
+              className={selected === table.name ? 'table-row selected' : 'table-row'}
+              key={`${table.schema}.${table.name}`}
+              onClick={() => loadColumns(table.name)}
+            >
+              {table.schema}.{table.name}
+            </button>
+          ))}
+        </div>
+        <div>
+          {selected ? (
+            columns.map((column) => (
+              <div className="column-row" key={column.name}>
+                <strong>{column.name}</strong>
+                <span>{column.type}</span>
+                {column.comment && <p>{column.comment}</p>}
+              </div>
+            ))
+          ) : (
+            <p>Pick a table to inspect columns.</p>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/projects/data-chat-mini/app/chat/page.tsx
+++ b/projects/data-chat-mini/app/chat/page.tsx
@@ -1,0 +1,17 @@
+import { SchemaExplorerSidebar } from './SchemaExplorerSidebar';
+
+export default function ChatPage() {
+  return (
+    <main>
+      <section className="workshop-page">
+        <div className="eyebrow">Step 08 · Schema explore</div>
+        <h1>Give the agent a map.</h1>
+        <p>
+          The model can now call the schema tools, and the room can inspect the
+          same tables and columns in the sidebar.
+        </p>
+      </section>
+      <SchemaExplorerSidebar database="nba_box_scores_v2" />
+    </main>
+  );
+}

--- a/projects/data-chat-mini/app/globals.css
+++ b/projects/data-chat-mini/app/globals.css
@@ -54,3 +54,48 @@ pre {
   gap: 12px;
   margin-top: 24px;
 }
+
+.schema-panel {
+  max-width: 1180px;
+  border-top: 1px solid #d1d5db;
+  margin-top: 32px;
+  padding-top: 24px;
+}
+
+.schema-grid {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.schema-grid > div {
+  flex: 1;
+}
+
+.table-row {
+  display: block;
+  width: 100%;
+  border: 1px solid #d1d5db;
+  background: white;
+  padding: 10px 12px;
+  text-align: left;
+}
+
+.table-row.selected {
+  border-color: #2563eb;
+}
+
+.column-row {
+  border: 1px solid #d1d5db;
+  background: white;
+  padding: 10px 12px;
+}
+
+.column-row span {
+  display: block;
+  color: #6b7280;
+}
+
+.error {
+  color: #b91c1c;
+}

--- a/projects/data-chat-mini/app/page.tsx
+++ b/projects/data-chat-mini/app/page.tsx
@@ -2,18 +2,21 @@ export default function Home() {
   return (
     <main>
       <section className="workshop-page">
-        <div className="eyebrow">Step 07 · System prompt</div>
-        <h1>Give the loop habits.</h1>
+        <div className="eyebrow">Step 08 · Schema tools</div>
+        <h1>Let it find its way.</h1>
         <p>
-          The app now has a system prompt that teaches the model how to behave:
-          explore first, stay read-only, and respect the NBA box-score grain.
+          The MCP allowlist now includes the read-only catalog tools. Open the
+          schema page to inspect tables and columns while the model uses the
+          same tools.
         </p>
 
         <div className="check">
-          <p>Quick check: ask the same kind of question and watch it answer with the caveat in mind.</p>
-          <pre>{`curl -N http://localhost:3000/api/chat \\
+          <p>Quick check: ask a question that needs exploration.</p>
+          <pre>{`open http://localhost:3000/chat
+
+curl -N http://localhost:3000/api/chat \\
   -H 'content-type: application/json' \\
-  -d '{"message":"How many games are in the schedule table?"}'`}</pre>
+  -d '{"message":"Most points by one player in a single 2026 playoff game?"}'`}</pre>
           <p>
             The important rule: <code>box_scores</code> is one row per player
             per period. A game total is the <code>FullGame</code> row, not the

--- a/projects/data-chat-mini/lib/mcp-client.ts
+++ b/projects/data-chat-mini/lib/mcp-client.ts
@@ -10,10 +10,20 @@ export interface MCPTool {
 
 export const ALLOWED_TOOLS = new Set([
   'query',
+  'list_tables',
+  'list_columns',
+  'list_databases',
+  'search_catalog',
+  'ask_docs_question',
 ]);
 
 export const READONLY_TOOLS = new Set([
   'query',
+  'list_tables',
+  'list_columns',
+  'list_databases',
+  'search_catalog',
+  'ask_docs_question',
 ]);
 
 export const MUTATING_TOOLS = new Set([

--- a/projects/data-chat-mini/lib/mcp-parsers.ts
+++ b/projects/data-chat-mini/lib/mcp-parsers.ts
@@ -1,0 +1,219 @@
+/**
+ * Shared parsers for MCP tool responses (#98).
+ *
+ * MotherDuck's MCP tools return text content that can come back in several
+ * shapes: a JSON object with a `databases` field, a top-level array, an
+ * array of objects with `alias`/`name`, a JSON wrapper around a markdown
+ * `context` blob, or just plain markdown. Each consumer was open-coding
+ * their own parser and the duplicates were drifting — a fix in one route
+ * could miss a sibling. This module consolidates the parsers so MCP
+ * response-shape changes have one obvious place to update.
+ */
+
+/**
+ * Pull a flat list of database names from the `list_databases` MCP
+ * response. Tolerates: top-level JSON array, `{ databases: [...] }`,
+ * objects with `alias`/`name`, and a plain-text fallback (`#`/`-`-prefixed
+ * comment lines stripped).
+ *
+ * Returns an empty array on unrecognised shapes — the caller is
+ * responsible for surfacing that as an error if it's not load-bearing.
+ */
+export function parseDatabaseNames(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw);
+    const list: unknown = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray(parsed?.databases)
+        ? parsed.databases
+        : null;
+    if (!list) {
+      // `databases` field but not an array — pass through as-is when it
+      // contains strings; preserves old behavior in app/api/databases/route.ts.
+      if (parsed && Array.isArray(parsed.databases)) return parsed.databases;
+      return [];
+    }
+    const names = (list as Array<unknown>).map((db) => {
+      if (typeof db === 'string') return db;
+      if (db && typeof db === 'object') {
+        const d = db as { alias?: unknown; name?: unknown };
+        if (typeof d.alias === 'string') return d.alias;
+        if (typeof d.name === 'string') return d.name;
+      }
+      return '';
+    });
+    return names.filter((s): s is string => typeof s === 'string' && s.length > 0);
+  } catch {
+    return raw
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('#') && !l.startsWith('-'));
+  }
+}
+
+/**
+ * Return the raw object array from `list_databases` when callers need
+ * the full per-row metadata (alias, name, type, …). Returns `[]` on
+ * non-array shapes or non-JSON responses.
+ */
+export function parseRawDatabases(raw: string): Array<Record<string, unknown>> {
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed.filter((row): row is Record<string, unknown> => !!row && typeof row === 'object');
+    if (parsed && Array.isArray(parsed.databases)) {
+      return parsed.databases.filter((row: unknown): row is Record<string, unknown> => !!row && typeof row === 'object');
+    }
+  } catch {
+    /* fall through */
+  }
+  return [];
+}
+
+export interface SchemaTable {
+  schema: string;
+  name: string;
+  type: string;
+  comment?: string;
+  fragmentCount?: number;
+}
+
+export interface SchemaColumn {
+  name: string;
+  type: string;
+  nullable: boolean;
+  comment?: string;
+  fragmentCount?: number;
+}
+
+/**
+ * Parse `list_tables` MCP response. Tolerates both the JSON wrapper
+ * (`{ success, tables: [...] }`) and a bare JSON array. Returns an empty
+ * list on unparseable input — the caller should treat that as "no tables
+ * loaded yet" rather than an error.
+ */
+export function parseTables(raw: string): SchemaTable[] {
+  try {
+    const parsed = JSON.parse(raw);
+    const list: unknown = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray(parsed?.tables)
+        ? parsed.tables
+        : null;
+    if (!list) return [];
+    return (list as Array<Record<string, unknown>>)
+      .filter((row): row is Record<string, unknown> => !!row && typeof row === 'object')
+      .map(row => ({
+        schema: typeof row.schema === 'string' ? row.schema : 'main',
+        name: typeof row.name === 'string' ? row.name : '',
+        type: typeof row.type === 'string' ? row.type : 'table',
+        comment: typeof row.comment === 'string' ? row.comment : undefined,
+        fragmentCount: extractFragmentCount(row.context),
+      }))
+      .filter(t => t.name);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Parse `list_columns` MCP response into a list of columns.
+ */
+export function parseColumns(raw: string): SchemaColumn[] {
+  try {
+    const parsed = JSON.parse(raw);
+    const list: unknown = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray(parsed?.columns)
+        ? parsed.columns
+        : null;
+    if (!list) return [];
+    return (list as Array<Record<string, unknown>>)
+      .filter((row): row is Record<string, unknown> => !!row && typeof row === 'object')
+      .map(row => ({
+        name: typeof row.name === 'string' ? row.name : '',
+        type: typeof row.type === 'string' ? row.type : '',
+        nullable: row.nullable !== false,
+        comment: typeof row.comment === 'string' ? row.comment : undefined,
+        fragmentCount: extractFragmentCount(row.context),
+      }))
+      .filter(c => c.name);
+  } catch {
+    return [];
+  }
+}
+
+export interface DiveSummary {
+  /** UUID — matches the `dive:UUID` reference format on fragments. */
+  id: string;
+  /** Human title; falls back to a short UUID slice when missing. */
+  title: string;
+  /** Database the dive lives in, when reported. */
+  database?: string;
+}
+
+/**
+ * Parse `list_dives` MCP response into a flat list. Tolerates the JSON
+ * wrapper (`{ success, dives: [...] }`), a bare array, or an `items` key.
+ * Used by `/api/dives` to surface dive metadata in the schema browser so
+ * `dive:UUID` refs can render their human title instead of the bare UUID.
+ */
+export function parseDives(raw: string): DiveSummary[] {
+  try {
+    const parsed = JSON.parse(raw);
+    const list: unknown = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray(parsed?.dives)
+        ? parsed.dives
+        : Array.isArray(parsed?.items)
+          ? parsed.items
+          : null;
+    if (!list) return [];
+    return (list as Array<Record<string, unknown>>)
+      .filter((row): row is Record<string, unknown> => !!row && typeof row === 'object')
+      .map(row => {
+        const id = typeof row.id === 'string'
+          ? row.id
+          : typeof row.dive_id === 'string'
+            ? row.dive_id
+            : typeof row.uuid === 'string'
+              ? row.uuid
+              : '';
+        const title = typeof row.title === 'string' && row.title.length > 0
+          ? row.title
+          : typeof row.name === 'string' && row.name.length > 0
+            ? row.name
+            : '';
+        const database = typeof row.database === 'string' ? row.database : undefined;
+        return { id, title, database };
+      })
+      .filter(d => d.id);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The MCP `context` field is a freeform string like `"3 context fragments"`
+ * or `"0 context fragments"`. Pull the leading integer out so we can use it
+ * as a hint without trusting the exact phrasing.
+ */
+function extractFragmentCount(value: unknown): number | undefined {
+  if (typeof value !== 'string') return undefined;
+  const m = value.match(/^(\d+)/);
+  return m ? Number(m[1]) : undefined;
+}
+
+/**
+ * MCP `query_context_layer` returns either a JSON wrapper `{ context: "<md>" }`
+ * or the markdown body directly. Normalise to the markdown so downstream
+ * parsers can do their job without each one re-implementing the unwrap.
+ */
+export function unwrapContextString(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.context === 'string') return parsed.context;
+  } catch {
+    /* not JSON — the response is already markdown */
+  }
+  return raw;
+}

--- a/projects/data-chat-mini/lib/system-prompt.ts
+++ b/projects/data-chat-mini/lib/system-prompt.ts
@@ -6,6 +6,7 @@ Available databases: ${dbList}
 
 Habits:
 - Explore schema before guessing table or column names.
+- Use list_tables, list_columns, and search_catalog to find your way around the database.
 - Use only read-only tools.
 - Prefer concise prose answers with the SQL-relevant caveats.
 - For nba_box_scores_v2.main.box_scores, remember that player/game totals live in period = 'FullGame'. Do not sum all period rows for a game total.


### PR DESCRIPTION
Adds schema exploration tools and sidebar checkpoint.\n\nQuick check: ask for most points in a 2026 playoff game and inspect schema in the sidebar.\n\nValidation: npm run typecheck for data-chat-mini-step-08.