### PR TITLE
[workshop] data-chat-mini step 10: charts

### DIFF
--- a/projects/data-chat-mini/app/chat/ChatPanel.tsx
+++ b/projects/data-chat-mini/app/chat/ChatPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRef, useState } from 'react';
+import { MvizFrame } from '@/app/components/MvizFrame';
 import { getSessionId } from '@/lib/session-id';
 import type { StreamEvent } from '@/types/chat';
 
@@ -16,6 +17,7 @@ type Message = {
   id: string;
   role: 'user' | 'assistant';
   content: string;
+  segments?: Array<{ type: 'text'; text: string } | { type: 'mviz_pending'; id: string } | { type: 'mviz'; id?: string; html: string }>;
   steps?: ToolStep[];
   error?: string;
 };
@@ -62,7 +64,11 @@ export function ChatPanel({ database }: { database: string }) {
 
       const handle = (event: StreamEvent) => {
         if (event.type === 'text') {
-          updateAssistant(assistant.id, (message) => ({ ...message, content: message.content + (event.content || '') }));
+          updateAssistant(assistant.id, (message) => ({
+            ...message,
+            content: message.content + (event.content || ''),
+            segments: [...(message.segments || []), { type: 'text', text: event.content || '' }],
+          }));
         } else if (event.type === 'tool_start' && event.toolCall) {
           const tool = event.toolCall;
           updateAssistant(assistant.id, (message) => ({
@@ -84,6 +90,31 @@ export function ChatPanel({ database }: { database: string }) {
           }));
         } else if (event.type === 'error') {
           updateAssistant(assistant.id, (message) => ({ ...message, error: event.content }));
+        } else if (event.type === 'mviz_pending' && event.id) {
+          updateAssistant(assistant.id, (message) => ({
+            ...message,
+            segments: [...(message.segments || []), { type: 'mviz_pending', id: event.id! }],
+            steps: [...(message.steps || []), {
+              id: `mviz:${event.id}`,
+              name: 'mviz_render',
+              status: 'running',
+              args: { output: 'inline visualization' },
+            }],
+          }));
+        } else if (event.type === 'mviz_html') {
+          updateAssistant(assistant.id, (message) => ({
+            ...message,
+            segments: (message.segments || []).map((segment) =>
+              segment.type === 'mviz_pending' && (!event.id || segment.id === event.id)
+                ? { type: 'mviz', id: event.id, html: event.content || '' }
+                : segment,
+            ),
+            steps: (message.steps || []).map((step) =>
+              step.id === `mviz:${event.id}`
+                ? { ...step, status: 'complete', result: 'Rendered inline visualization.' }
+                : step,
+            ),
+          }));
         }
       };
 
@@ -122,7 +153,17 @@ export function ChatPanel({ database }: { database: string }) {
                 ))}
               </div>
             )}
-            <p>{message.content}</p>
+            {message.segments && message.segments.length > 0 ? (
+              <div className="segments">
+                {message.segments.map((segment, index) => {
+                  if (segment.type === 'text') return <p key={index}>{segment.text}</p>;
+                  if (segment.type === 'mviz_pending') return <p key={segment.id}>Rendering chart...</p>;
+                  return <MvizFrame html={segment.html} key={segment.id || index} />;
+                })}
+              </div>
+            ) : (
+              <p>{message.content}</p>
+            )}
             {message.error && <p className="error">{message.error}</p>}
           </article>
         ))}

--- a/projects/data-chat-mini/app/components/MvizFrame.tsx
+++ b/projects/data-chat-mini/app/components/MvizFrame.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * MvizFrame — sandboxed iframe that renders an mviz table/chart.
+ *
+ * Auto-sizes from `postMessage({type:'mviz-height', height})`
+ * notifications emitted by mviz's bundled height-reporter script.
+ *
+ * The page chrome (top accent bar, title row, theme toggle, etc.) is
+ * stripped upstream at render time — `processMvizMarkdown` renders with
+ * mviz's `embedOverride` (^1.7.0), which omits the chrome and prunes the
+ * output for iframe embedding. This used to require a local CSS strip
+ * (matsonj/mviz#11); embed mode delivered it, so the strip is gone.
+ *
+ * Shared between chat and prism so both surfaces render identical frames.
+ */
+export function MvizFrame({ html }: { html: string }) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState(180);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+    const handler = (e: MessageEvent) => {
+      if (e.source !== iframe.contentWindow) return;
+      if (
+        e.data?.type === 'mviz-height' &&
+        typeof e.data.height === 'number' &&
+        e.data.height > 0
+      ) {
+        // Clamp to avoid runaway-tall frames from a misbehaving inner doc.
+        setHeight(Math.min(e.data.height + 16, 1200));
+      }
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, [html]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      srcDoc={html}
+      className="mviz-frame"
+      style={{ height, pointerEvents: 'auto' }}
+      sandbox="allow-scripts"
+      title="Visualization"
+    />
+  );
+}

--- a/projects/data-chat-mini/app/page.tsx
+++ b/projects/data-chat-mini/app/page.tsx
@@ -2,15 +2,15 @@ export default function Home() {
   return (
     <main>
       <section className="workshop-page">
-        <div className="eyebrow">Step 09 · Streaming UI</div>
-        <h1>Watch the loop work.</h1>
+        <div className="eyebrow">Step 10 · Charts</div>
+        <h1>Make answers legible.</h1>
         <p>
-          The app now has a streaming chat surface. Tool calls appear as they
-          start and finish, and the final answer streams in as text.
+          The loop now recognizes mviz chart fences, renders them, and streams
+          inline visualizations into the chat.
         </p>
 
         <div className="check">
-          <p>Quick check: open the chat and ask a question that needs exploration.</p>
+          <p>Quick check: ask for top scorers by points per game as a bar chart.</p>
           <pre>{`open http://localhost:3000/chat`}</pre>
           <p>
             The important rule: <code>box_scores</code> is one row per player

--- a/projects/data-chat-mini/lib/agentic-loop.ts
+++ b/projects/data-chat-mini/lib/agentic-loop.ts
@@ -1,7 +1,22 @@
 import { streamChatCompletion } from '@/lib/llm-client';
 import type { ModelProfile } from '@/lib/llm-client';
 import { dispatchTool } from '@/lib/tool-dispatch';
-import { sseError, sseText, sseToolEnd, sseToolStart, sseUsage } from '@/lib/sse-encoder';
+import {
+  sseError,
+  sseMvizHtml,
+  sseMvizPending,
+  sseText,
+  sseToolEnd,
+  sseToolStart,
+  sseUsage,
+} from '@/lib/sse-encoder';
+import {
+  buildMvizFallbackHtml,
+  createMvizFenceState,
+  flushMvizFence,
+  stepMvizFence,
+} from '@/lib/mviz-fence';
+import { processMvizMarkdown } from '@/lib/mviz-processor';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { ThinkingLevel } from '@/types/chat';
 
@@ -35,6 +50,7 @@ export async function runAgenticLoop(opts: RunAgenticLoopOpts) {
     const assistantBlocks: Array<Record<string, unknown>> = [];
     const pendingToolCalls = new Map<number, { id: string; name: string; args: string }>();
     let fullResponseText = '';
+    let mvizState = createMvizFenceState();
     const usage = { promptTokens: 0, completionTokens: 0 };
 
     const reader = llmStream.getReader();
@@ -67,7 +83,21 @@ export async function runAgenticLoop(opts: RunAgenticLoopOpts) {
 
         if (delta.content) {
           fullResponseText += delta.content;
-          opts.emit(sseText(delta.content));
+          const { events, newState } = stepMvizFence(fullResponseText, mvizState);
+          mvizState = newState;
+          for (const event of events) {
+            if (event.kind === 'text') {
+              opts.emit(sseText(event.content));
+            } else if (event.kind === 'mviz_pending') {
+              opts.emit(sseMvizPending(event.id));
+            } else if (event.kind === 'mviz_block') {
+              const rendered = processMvizMarkdown(event.source);
+              opts.emit(sseMvizHtml(
+                rendered || buildMvizFallbackHtml('The chart block failed to render.'),
+                { source: event.source, ...(event.id && { id: event.id }) },
+              ));
+            }
+          }
         }
 
         if (delta.tool_calls) {
@@ -82,6 +112,19 @@ export async function runAgenticLoop(opts: RunAgenticLoopOpts) {
             if (tc.function?.arguments) pending.args += tc.function.arguments;
           }
         }
+      }
+    }
+
+    const flushed = flushMvizFence(fullResponseText, mvizState);
+    mvizState = flushed.newState;
+    for (const event of flushed.events) {
+      if (event.kind === 'text') {
+        opts.emit(sseText(event.content));
+      } else if (event.kind === 'mviz_fallback') {
+        opts.emit(sseMvizHtml(
+          buildMvizFallbackHtml('The chart block was cut off before it finished streaming.'),
+          { id: event.id },
+        ));
       }
     }
 

--- a/projects/data-chat-mini/lib/mviz-fence.ts
+++ b/projects/data-chat-mini/lib/mviz-fence.ts
@@ -1,0 +1,206 @@
+import { randomUUID } from 'node:crypto';
+import {
+  ENABLED_MVIZ_TYPES_PATTERN,
+  MAX_MVIZ_OPENER_LEN,
+} from '@/lib/mviz-types';
+
+/**
+ * Streaming mviz-fence state machine.
+ *
+ * The model emits assistant text that may contain one or more mviz blocks
+ * (```table / ```bar / ```line / ```dumbbell — see `ENABLED_MVIZ_TYPES`).
+ * Three concerns interleave:
+ *
+ *   1. Outside-fence text must forward to the client as `text` events.
+ *   2. Inside-fence markdown must be suppressed — the client already shows
+ *      a "Visualizing…" placeholder via `mviz_pending`. We never stream the
+ *      raw JSON body as text.
+ *   3. Each completed mviz block (`\`\`\`<type> ... \`\`\``) is extracted and
+ *      handed back to the caller (via an `mviz_block` event) for rendering
+ *      into final HTML. The pending placeholder id is paired with the block
+ *      via a FIFO — openers produce placeholders in text order, closers
+ *      produce blocks in the same order, so the pairing is stable.
+ *
+ * `stepMvizFence` is called after each delta arrives (with the growing
+ * `fullText`) and returns any events that accumulated plus the new state.
+ * `flushMvizFence` is called once at end-of-stream to release trailing text
+ * held back by the opener lookahead and to emit fallback events for any
+ * `mviz_pending` placeholders that never received a matching block (stream
+ * cut off mid-fence, or malformed markdown).
+ */
+
+export type MvizFenceState = {
+  /** How far we've scanned for complete `\`\`\`<type>...\`\`\`` blocks. */
+  mvizScanCursor: number;
+  /** How far we've decided what to forward as text vs suppress as fence body. */
+  textEmitEnd: number;
+  /** Start index of the current open fence (null while outside a fence). */
+  openFenceStart: number | null;
+  /** FIFO of placeholder ids awaiting an `mviz_block` pairing. */
+  pendingFenceIds: string[];
+};
+
+export type MvizFenceEvent =
+  | { kind: 'text'; content: string }
+  | { kind: 'mviz_pending'; id: string }
+  | { kind: 'mviz_block'; source: string; id?: string }
+  | { kind: 'mviz_fallback'; id: string };
+
+export function createMvizFenceState(): MvizFenceState {
+  return { mvizScanCursor: 0, textEmitEnd: 0, openFenceStart: null, pendingFenceIds: [] };
+}
+
+/**
+ * Regex source for an mviz fence opener: ```` ```<enabled-type> ```` immediately
+ * followed by header whitespace. mviz headers are always `\`\`\`<type>\n` or
+ * `\`\`\`<type> size=[…]\n`, so the type is always followed by whitespace — we
+ * require a *present* whitespace char (`(?=\s)`) rather than merely "not an
+ * identifier char". This matters in two ways:
+ *   - Look-alikes don't match: ` ```barchart ` (next char `c`) and
+ *     ` ```bar-chart ` (next char `-`) are both rejected, not read as `bar`.
+ *   - End-of-buffer is NOT a boundary: a streamed ` ```bar ` whose `chart`
+ *     hasn't arrived yet fails to match (no whitespace present), so the opener
+ *     scan holds it back instead of emitting a premature `mviz_pending` that
+ *     would later orphan into a fallback iframe when `barchart` completes.
+ * Shared by `findFenceOpener` and `findNextMvizBlock` so the opener scan and
+ * the completed-block matcher can never disagree on what's an enabled type.
+ */
+const FENCE_OPENER_SRC = '```(?:' + ENABLED_MVIZ_TYPES_PATTERN + ')(?=\\s)';
+
+/**
+ * Find the next mviz fence opener at or after `from`. Returns the opener
+ * position and its byte length (variable: ` ```bar ` is 6, ` ```dumbbell ` 11).
+ */
+export function findFenceOpener(
+  text: string,
+  from: number,
+): { index: number; length: number } | null {
+  const re = new RegExp(FENCE_OPENER_SRC, 'g');
+  re.lastIndex = from;
+  const match = re.exec(text);
+  if (!match) return null;
+  return { index: match.index, length: match[0].length };
+}
+
+export function findNextMvizBlock(text: string, from: number): { source: string; end: number } | null {
+  const re = new RegExp(FENCE_OPENER_SRC + '[^\\n]*\\n[\\s\\S]*?\\n```', 'g');
+  re.lastIndex = from;
+  const match = re.exec(text);
+  if (!match) return null;
+  return { source: match[0], end: match.index + match[0].length };
+}
+
+/**
+ * Minimal HTML payload rendered into the mviz iframe when a placeholder
+ * can't be paired with real mviz output. Plain inline styles; no network
+ * dependencies. AutoSizeIframe's default 200 px height is fine — we skip
+ * the height reporter on purpose so the error box stays compact.
+ */
+export function buildMvizFallbackHtml(reason: string): string {
+  const safe = reason.replace(/[<>&]/g, c => (c === '<' ? '&lt;' : c === '>' ? '&gt;' : '&amp;'));
+  return `<!DOCTYPE html><html><body style="margin:0;padding:10px;font:13px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#7c1d0d;background:#fef2f0;border:1px solid #fbd5cc;border-radius:4px;line-height:1.4"><strong>Table render failed.</strong> ${safe}</body></html>`;
+}
+
+export function stepMvizFence(
+  fullText: string,
+  state: MvizFenceState,
+  makeId: () => string = randomUUID,
+): { events: MvizFenceEvent[]; newState: MvizFenceState } {
+  const events: MvizFenceEvent[] = [];
+  const s: MvizFenceState = {
+    mvizScanCursor: state.mvizScanCursor,
+    textEmitEnd: state.textEmitEnd,
+    openFenceStart: state.openFenceStart,
+    pendingFenceIds: [...state.pendingFenceIds],
+  };
+
+  // Walk forward through any newly-arrived bytes, splitting them into
+  // outside-fence text and inside-fence markdown (suppressed).
+  while (s.textEmitEnd < fullText.length) {
+    if (s.openFenceStart === null) {
+      const opener = findFenceOpener(fullText, s.textEmitEnd);
+      if (opener === null) {
+        // No unopened fence in the remaining bytes — but the last few bytes
+        // might be a partial `\`\`\`dumbbel` waiting on the next chunk. Hold
+        // back up to MAX_MVIZ_OPENER_LEN trailing chars so we don't leak the
+        // opener as plain text before recognizing it.
+        const safeEnd = Math.max(s.textEmitEnd, fullText.length - MAX_MVIZ_OPENER_LEN);
+        if (safeEnd > s.textEmitEnd) {
+          events.push({ kind: 'text', content: fullText.slice(s.textEmitEnd, safeEnd) });
+          s.textEmitEnd = safeEnd;
+        }
+        break;
+      }
+      if (opener.index > s.textEmitEnd) {
+        events.push({ kind: 'text', content: fullText.slice(s.textEmitEnd, opener.index) });
+      }
+      const id = makeId();
+      s.pendingFenceIds.push(id);
+      events.push({ kind: 'mviz_pending', id });
+      s.openFenceStart = opener.index;
+      s.textEmitEnd = opener.index + opener.length;
+    } else {
+      // Inside a fence — look for the closing `\n\`\`\`` at line start.
+      const closer = fullText.indexOf('\n```', s.textEmitEnd);
+      if (closer < 0) {
+        // Still streaming fence body — silently consume what's here, but
+        // hold back the last 3 bytes so a `\n\`\`\`` straddling a chunk
+        // boundary can complete on the next call. Without this, the closer-
+        // find can miss a `\n` that arrived in the previous chunk because
+        // `textEmitEnd` already advanced past it. The downstream symptom:
+        // when the model emits two adjacent mviz blocks and a chunk
+        // boundary lands mid-closer, the second opener is swallowed
+        // silently, only one mviz_pending fires, and the second mviz_block
+        // emits with no id — the placeholder for the missed second fence
+        // never gets swapped (#65).
+        s.textEmitEnd = Math.max(s.textEmitEnd, fullText.length - 3);
+        break;
+      }
+      s.textEmitEnd = closer + '\n```'.length;
+      s.openFenceStart = null;
+    }
+  }
+
+  // Detect each newly-completed ```<type>...``` block and hand it to the
+  // caller for rendering. Pair with the oldest pending placeholder id so
+  // text-order = block-order.
+  while (true) {
+    const match = findNextMvizBlock(fullText, s.mvizScanCursor);
+    if (!match) break;
+    const id = s.pendingFenceIds.shift();
+    events.push({ kind: 'mviz_block', source: match.source, ...(id ? { id } : {}) });
+    s.mvizScanCursor = match.end;
+  }
+
+  return { events, newState: s };
+}
+
+/**
+ * End-of-stream cleanup. Emits any text held back by the opener lookahead
+ * and fires `mviz_fallback` for placeholders never paired with a block
+ * (stream cut off mid-fence, or block source was malformed so
+ * `findNextMvizBlock` never matched).
+ */
+export function flushMvizFence(
+  fullText: string,
+  state: MvizFenceState,
+): { events: MvizFenceEvent[]; newState: MvizFenceState } {
+  const events: MvizFenceEvent[] = [];
+  const s: MvizFenceState = {
+    mvizScanCursor: state.mvizScanCursor,
+    textEmitEnd: state.textEmitEnd,
+    openFenceStart: state.openFenceStart,
+    pendingFenceIds: [...state.pendingFenceIds],
+  };
+
+  if (s.openFenceStart === null && s.textEmitEnd < fullText.length) {
+    events.push({ kind: 'text', content: fullText.slice(s.textEmitEnd) });
+    s.textEmitEnd = fullText.length;
+  }
+  while (s.pendingFenceIds.length > 0) {
+    const id = s.pendingFenceIds.shift()!;
+    events.push({ kind: 'mviz_fallback', id });
+  }
+  s.openFenceStart = null;
+  return { events, newState: s };
+}

--- a/projects/data-chat-mini/lib/mviz-processor.ts
+++ b/projects/data-chat-mini/lib/mviz-processor.ts
@@ -1,0 +1,349 @@
+import { parseMarkdownToDashboard, lintSpec, SpecValidationError } from 'mviz';
+import { MVIZ_CUSTOM_THEME, MVIZ_FONT_IMPORT_URL } from './mviz-theme';
+
+// mviz embed mode (parseMarkdownToDashboard's embedOverride, see below) already
+// strips the page chrome — the red accent bar (.red-line), the "Dashboard"
+// title row (.page-title), and the theme toggle — so we no longer hand-hide
+// them here. Native customTheme now owns colors, fonts, and series palettes.
+// This remaining CSS is a small sizing/radius/spacing layer.
+const CUSTOM_CSS_OVERRIDES = `
+<style>
+  @import url('${MVIZ_FONT_IMPORT_URL}');
+  /* Kill the browser default body margin so the frame hugs its host card. */
+  html, body {
+    margin: 0 !important;
+  }
+  .dashboard {
+    max-width: 100% !important;
+    padding: 20px !important;
+  }
+  .dashboard-section:last-child {
+    margin-bottom: 0 !important;
+    padding-bottom: 0 !important;
+  }
+  .row:last-child {
+    margin-bottom: 0 !important;
+  }
+  html, body { font-size: 14px !important; }
+  .section-title { font-size: 16px !important; font-weight: 600 !important; }
+  .chart-title { font-size: 16px !important; }
+  .big-value { font-size: 30px !important; font-weight: 700 !important; }
+  .label { font-size: 13px !important; }
+  .delta { font-size: 24px !important; }
+  .delta .value { font-size: 24px !important; }
+  .delta .arrow { font-size: 24px !important; }
+  .delta .label { font-size: 13px !important; }
+  .row { gap: 12px !important; margin-bottom: 12px !important; }
+  .alert .message { font-size: 13px !important; }
+  .data-table {
+    border-radius: 10px !important;
+    overflow: hidden !important;
+  }
+  .data-table th {
+    border-bottom-color: var(--grid) !important;
+    font-size: 12px !important;
+    font-weight: 600 !important;
+    padding: 8px 12px !important;
+  }
+  .data-table td {
+    font-size: 12px !important;
+    padding: 8px 12px !important;
+  }
+  .note-content, .text-content { font-size: 13px !important; line-height: 1.5 !important; }
+  .markdown-content { font-size: 14px !important; line-height: 1.6 !important; }
+  .markdown-content h1 { font-size: 28px !important; }
+  .markdown-content h2 { font-size: 22px !important; }
+  .markdown-content h3 { font-size: 18px !important; }
+  .markdown-content p, .markdown-content li { font-size: 14px !important; }
+  .markdown-content code { font-size: 13px !important; }
+  .card, .chart-card, .note, .alert, .text-card {
+    border-radius: 10px !important;
+    box-shadow: none !important;
+  }
+</style>
+`;
+
+/** Script injected into mviz iframes to report their content height via postMessage.
+ * This avoids needing allow-same-origin on the iframe sandbox. */
+const HEIGHT_REPORTER_SCRIPT = `
+<script>
+(function() {
+  function reportHeight() {
+    var h = document.body ? document.body.scrollHeight : 0;
+    if (h > 0) parent.postMessage({ type: 'mviz-height', height: h }, '*');
+  }
+  if (document.readyState === 'complete') reportHeight();
+  else window.addEventListener('load', reportHeight);
+  new MutationObserver(reportHeight).observe(document.documentElement, { childList: true, subtree: true });
+  setTimeout(reportHeight, 300);
+  setTimeout(reportHeight, 1000);
+})();
+<\/script>
+`;
+
+function injectCssOverrides(html: string): string {
+  let result = html;
+
+  // Inject CSS into <head>
+  const headCloseIndex = result.indexOf('</head>');
+  if (headCloseIndex !== -1) {
+    result = result.slice(0, headCloseIndex) + CUSTOM_CSS_OVERRIDES + result.slice(headCloseIndex);
+  } else {
+    result = CUSTOM_CSS_OVERRIDES + result;
+  }
+
+  // Inject height reporter before </body> (or at end)
+  const bodyCloseIndex = result.indexOf('</body>');
+  if (bodyCloseIndex !== -1) {
+    result = result.slice(0, bodyCloseIndex) + HEIGHT_REPORTER_SCRIPT + result.slice(bodyCloseIndex);
+  } else {
+    result += HEIGHT_REPORTER_SCRIPT;
+  }
+
+  return result;
+}
+
+const TABLE_AUTO_FMT_SKIP_RE = /\b(id|uuid|guid|key|code|sku|zip|postal|phone|date|time|year|season|month|week|day|quarter)\b/i;
+const DEFAULT_CHART_HEIGHT = 12;
+const DEFAULT_HEIGHT_CHART_TYPES = new Set(['bar', 'line', 'dumbbell']);
+
+function shouldDefaultTableColumnToAuto(
+  col: Record<string, unknown>,
+  data: Array<Record<string, unknown>>
+): boolean {
+  if (col.fmt !== undefined || col.format !== undefined) return false;
+  if (col.type === 'heatmap' || col.type === 'sparkline') return false;
+
+  const id = typeof col.id === 'string' ? col.id : undefined;
+  if (!id) return false;
+
+  const title = typeof col.title === 'string' ? col.title : '';
+  if (TABLE_AUTO_FMT_SKIP_RE.test(`${id} ${title}`)) return false;
+
+  const values = data.map(row => row[id]).filter(value => value !== undefined && value !== null && value !== '');
+  return values.length > 0 && values.every(value => typeof value === 'number' && Number.isFinite(value));
+}
+
+function normalizeMvizSizeSpec(chartType: string, sizeSpec: string): string {
+  if (!DEFAULT_HEIGHT_CHART_TYPES.has(chartType)) return sizeSpec;
+
+  const defaultWidth = DEFAULT_WIDTHS[chartType] ?? 8;
+  const sizeRe = /size=\[\s*(\d+)(?:\s*,\s*\d+)?\s*\]/;
+  const sizeMatch = sizeSpec.match(/size=\[\s*(\d+)(?:\s*,\s*(\d+))?\s*\]/);
+  if (!sizeMatch) {
+    return `${sizeSpec} size=[${defaultWidth},${DEFAULT_CHART_HEIGHT}]`;
+  }
+
+  const oldDefaultHeight = chartType === 'dumbbell' ? '5' : '4';
+  const [, , currentHeight] = sizeMatch;
+  if (!currentHeight || currentHeight === oldDefaultHeight) {
+    return sizeSpec.replace(sizeRe, `size=[$1,${DEFAULT_CHART_HEIGHT}]`);
+  }
+
+  return sizeSpec;
+}
+
+export function sanitizeMvizMarkdown(markdown: string): string {
+  return markdown.replace(
+    /```(big_value|bar|line|table|sparkline|text|note|alert|textarea|delta|area|pie|scatter|heatmap|waterfall|funnel|sankey|boxplot|histogram|calendar|combo|dumbbell|xmr|pct_bar|donut)([^\n]*)\n([\s\S]*?)```/g,
+    (match, chartType, sizeSpec, jsonContent) => {
+      try {
+        const parsed = JSON.parse(jsonContent.trim());
+
+        const sanitize = (obj: unknown): unknown => {
+          if (obj === null || obj === undefined) return '';
+          if (Array.isArray(obj)) return obj.map(sanitize);
+          if (typeof obj === 'object') {
+            return Object.entries(obj as Record<string, unknown>).reduce((acc, [key, value]) => {
+              acc[key] = sanitize(value);
+              return acc;
+            }, {} as Record<string, unknown>);
+          }
+          return obj;
+        };
+
+        let sanitized = sanitize(parsed) as Record<string, unknown>;
+
+        if (chartType === 'table' && sanitized.columns && sanitized.data) {
+          const columns = sanitized.columns as Array<Record<string, unknown>>;
+          const data = sanitized.data as Array<Record<string, unknown>>;
+          const transformedColumns = columns.map(col => {
+            const transformed = {
+              ...col,
+              id: col.id ?? col.key,
+              title: col.title ?? col.label,
+            };
+
+            return shouldDefaultTableColumnToAuto(transformed, data)
+              ? { ...transformed, fmt: 'auto' }
+              : transformed;
+          });
+          const columnIds = transformedColumns
+            .map(c => c.id)
+            .filter((id): id is string => typeof id === 'string' && id.length > 0);
+          const sanitizedData = data.map(row => {
+            const newRow: Record<string, unknown> = { ...row };
+            columnIds.forEach(id => {
+              if (newRow[id] === undefined || newRow[id] === null) newRow[id] = '';
+            });
+            return newRow;
+          });
+          sanitized = { ...sanitized, columns: transformedColumns, data: sanitizedData };
+        }
+
+        return `\`\`\`${chartType}${normalizeMvizSizeSpec(chartType, sizeSpec)}\n${JSON.stringify(sanitized)}\n\`\`\``;
+      } catch {
+        return match;
+      }
+    }
+  );
+}
+
+const MVIZ_TYPES_PATTERN = 'big_value|bar|line|table|sparkline|text|note|alert|textarea|delta|area|pie|scatter|heatmap|waterfall|funnel|sankey|boxplot|histogram|calendar|combo|dumbbell|xmr|pct_bar|donut';
+
+// Default widths per chart type (from mviz docs)
+const DEFAULT_WIDTHS: Record<string, number> = {
+  big_value: 4, delta: 4, sparkline: 4, empty_space: 4,
+  bar: 8, line: 8, area: 8, pie: 8, scatter: 8, bubble: 8,
+  funnel: 8, sankey: 8, heatmap: 8, histogram: 8, boxplot: 8,
+  waterfall: 8, combo: 8, mermaid: 8,
+  dumbbell: 12,
+  table: 16, textarea: 16, calendar: 16, xmr: 16,
+  alert: 16, note: 16, text: 16,
+};
+
+function getBlockWidth(header: string): number {
+  const sizeMatch = header.match(/size=\[(\d+)/);
+  if (sizeMatch) return parseInt(sizeMatch[1], 10);
+  // Extract chart type and use default
+  const typeMatch = header.match(new RegExp('(' + MVIZ_TYPES_PATTERN + ')'));
+  if (typeMatch) return DEFAULT_WIDTHS[typeMatch[1]] ?? 8;
+  return 16; // assume full width if unknown
+}
+
+/**
+ * Smart row packing: collapse blank lines between adjacent mviz blocks
+ * only when they fit on the same row (cumulative width ≤ 16 columns).
+ */
+function packRows(markdown: string): string {
+  // Split into blocks and gaps. A "block" is a ```type ... ``` section.
+  const blockRe = new RegExp('(```(?:' + MVIZ_TYPES_PATTERN + ')[^\\n]*\\n[\\s\\S]*?```)', 'g');
+  const parts: Array<{ type: 'block'; content: string; width: number } | { type: 'gap'; content: string }> = [];
+
+  let lastIndex = 0;
+  let match;
+  while ((match = blockRe.exec(markdown)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ type: 'gap', content: markdown.slice(lastIndex, match.index) });
+    }
+    const header = match[1].split('\n')[0];
+    parts.push({ type: 'block', content: match[1], width: getBlockWidth(header) });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < markdown.length) {
+    parts.push({ type: 'gap', content: markdown.slice(lastIndex) });
+  }
+
+  // Now rebuild: collapse gaps between blocks when they'd fit on one row
+  let result = '';
+  let rowWidth = 0;
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+
+    if (part.type === 'block') {
+      if (rowWidth > 0 && rowWidth + part.width <= 16) {
+        // Fits on current row — join directly (no blank line)
+        result += '\n';
+      } else {
+        // New row — keep any preceding gap as-is, reset row width
+        rowWidth = 0;
+      }
+      result += part.content;
+      rowWidth += part.width;
+    } else {
+      // Gap (non-block content: blank lines, headings, text between blocks)
+      const isBlankOnly = /^\s*$/.test(part.content);
+      if (isBlankOnly) {
+        // Check if next part is a block that fits on the current row
+        const next = parts[i + 1];
+        if (next?.type === 'block' && rowWidth > 0 && rowWidth + next.width <= 16) {
+          // Skip the blank gap — we'll join the blocks
+          continue;
+        }
+        // Otherwise keep the gap (forces new row)
+        result += part.content;
+        rowWidth = 0;
+      } else {
+        // Non-blank content (headings, prose) — keep as-is, reset row
+        result += part.content;
+        rowWidth = 0;
+      }
+    }
+  }
+
+  return result;
+}
+
+export function processMvizMarkdown(markdown: string, theme = 'light'): string {
+  const packed = packRows(markdown);
+  const sanitizedMarkdown = sanitizeMvizMarkdown(packed);
+  // embedOverride (8th arg, mviz ^1.7.0): strips page chrome (red accent bar,
+  // title row, theme toggle), prunes unused CSS/CDN scripts, and minifies for
+  // iframe embedding — the rendering path these tiles live in. Replaces the
+  // manual chrome-stripping we used to carry in CUSTOM_CSS_OVERRIDES.
+  const result = parseMarkdownToDashboard(
+    sanitizedMarkdown,
+    theme,
+    undefined,
+    false,
+    false,
+    MVIZ_CUSTOM_THEME,
+    'generate',
+    true,
+  );
+  return injectCssOverrides(result.html);
+}
+
+export function hasMvizBlocks(content: string): boolean {
+  return /```(big_value|bar|line|table|sparkline|text|note|alert|textarea|delta|area|pie|scatter|heatmap|waterfall|funnel|sankey|boxplot|histogram|calendar|combo|dumbbell|xmr|pct_bar|donut)\b/.test(content);
+}
+
+export interface LintResult {
+  pass: boolean;
+  errors: string[];
+}
+
+/**
+ * Lint mviz markdown blocks. Returns errors found.
+ * Extracts each JSON spec from code blocks and runs lintSpec on each.
+ */
+export function lintMvizMarkdown(markdown: string): LintResult {
+  const errors: string[] = [];
+  const blockRe = /```(big_value|bar|line|table|sparkline|text|note|alert|textarea|delta|area|pie|scatter|heatmap|waterfall|funnel|sankey|boxplot|histogram|calendar|combo|dumbbell|xmr|pct_bar|donut)[^\n]*\n([\s\S]*?)```/g;
+
+  let match;
+  let blockIndex = 0;
+  while ((match = blockRe.exec(markdown)) !== null) {
+    blockIndex++;
+    const chartType = match[1];
+    const jsonContent = match[2].trim();
+
+    try {
+      const spec = JSON.parse(jsonContent);
+      // Ensure type is set for linting
+      if (!spec.type) spec.type = chartType;
+      lintSpec(spec);
+    } catch (err) {
+      if (err instanceof SpecValidationError) {
+        errors.push(`Block ${blockIndex} (${chartType}): ${err.message}`);
+      } else if (err instanceof SyntaxError) {
+        errors.push(`Block ${blockIndex} (${chartType}): Invalid JSON — ${err.message}`);
+      } else {
+        errors.push(`Block ${blockIndex} (${chartType}): ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  }
+
+  return { pass: errors.length === 0, errors };
+}

--- a/projects/data-chat-mini/lib/mviz-theme.ts
+++ b/projects/data-chat-mini/lib/mviz-theme.ts
@@ -1,0 +1,49 @@
+type MvizCustomTheme = {
+  name?: string;
+  extends?: 'light' | 'dark';
+  colors?: Partial<{
+    primary: string;
+    secondary: string;
+    tertiary: string;
+    positive: string;
+    warning: string;
+    error: string;
+    accent: string;
+    background: string;
+    paper: string;
+    text: string;
+    textSecondary: string;
+    border: string;
+  }>;
+  palette?: string[];
+  fonts?: {
+    family?: string;
+    mono?: string;
+    import?: string;
+  };
+};
+
+export const MVIZ_FONT_IMPORT_URL =
+  'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap';
+
+export const MVIZ_CUSTOM_THEME = {
+  name: 'data-chat',
+  extends: 'light',
+  colors: {
+    background: '#FFFFFF',
+    paper: '#FFFFFF',
+    text: '#1C1E26',
+    textSecondary: '#6B7280',
+    border: '#ECEDEF',
+    accent: '#2563EB',
+    positive: '#0E9F6E',
+    warning: '#F59E0B',
+    error: '#DC2626',
+  },
+  palette: ['#9F7AEA', '#0D9488', '#60A5FA', '#F59E0B', '#9CA3AF', '#1D4ED8'],
+  fonts: {
+    family: "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif",
+    mono: "'JetBrains Mono', 'Roboto Mono', ui-monospace, monospace",
+    import: MVIZ_FONT_IMPORT_URL,
+  },
+} satisfies MvizCustomTheme;

--- a/projects/data-chat-mini/lib/mviz-types.ts
+++ b/projects/data-chat-mini/lib/mviz-types.ts
@@ -1,0 +1,25 @@
+/**
+ * Single source of truth for which mviz block types render inline in chat.
+ *
+ * The mviz library (and `lib/mviz-processor.ts`) can sanitize/lint the full
+ * superset of block types, but the product deliberately exposes a narrow,
+ * intentional set: a styled table plus three comparison charts. The fence
+ * streaming detector (`lib/mviz-fence.ts`) gates on this list — anything not
+ * here streams through as a plain code block instead of an inline render.
+ *
+ * To widen the surface, add a type here and teach it in `lib/system-prompt.ts`.
+ * That's the whole change — the fence detector and width defaults derive from
+ * this constant.
+ */
+export const ENABLED_MVIZ_TYPES = ['table', 'bar', 'line', 'dumbbell'] as const;
+
+export type EnabledMvizType = (typeof ENABLED_MVIZ_TYPES)[number];
+
+/** Regex-source alternation of the enabled types, e.g. `table|bar|line|dumbbell`. */
+export const ENABLED_MVIZ_TYPES_PATTERN = ENABLED_MVIZ_TYPES.join('|');
+
+/** Longest opener (```` ```<type> ````) length in chars — used to size the
+ *  streaming partial-opener holdback so we never leak a partial fence opener
+ *  as plain text before recognizing it. */
+export const MAX_MVIZ_OPENER_LEN =
+  3 + Math.max(...ENABLED_MVIZ_TYPES.map(t => t.length));

--- a/projects/data-chat-mini/lib/sse-encoder.ts
+++ b/projects/data-chat-mini/lib/sse-encoder.ts
@@ -14,3 +14,6 @@ export const sseToolStart = (toolCall: { id: string; name: string; args?: Record
 export const sseToolEnd = (toolCall: { id: string; name: string; result?: string; error?: boolean }) =>
   event({ type: 'tool_end', toolCall });
 export const sseUsage = (usage: TurnUsage) => event({ type: 'usage', usage });
+export const sseMvizPending = (id: string) => event({ type: 'mviz_pending', id });
+export const sseMvizHtml = (content: string, meta: { id?: string; source?: string } = {}) =>
+  event({ type: 'mviz_html', content, ...meta });

--- a/projects/data-chat-mini/lib/system-prompt.ts
+++ b/projects/data-chat-mini/lib/system-prompt.ts
@@ -11,5 +11,6 @@ Habits:
 - Prefer concise prose answers with the SQL-relevant caveats.
 - For nba_box_scores_v2.main.box_scores, remember that player/game totals live in period = 'FullGame'. Do not sum all period rows for a game total.
 - For "2026 playoffs", use season_year = 2025 and season_type = 'Playoffs'.
-- If the user asks for a count or leaderboard, run a query instead of estimating.`;
+- If the user asks for a count or leaderboard, run a query instead of estimating.
+- When a chart would be clearer than rows, emit an mviz fenced block after the answer.`;
 }

--- a/projects/data-chat-mini/types/chat.ts
+++ b/projects/data-chat-mini/types/chat.ts
@@ -11,7 +11,7 @@ export interface TurnUsage {
 }
 
 export interface StreamEvent {
-  type: 'text' | 'tool_start' | 'tool_end' | 'usage' | 'error' | 'done';
+  type: 'text' | 'tool_start' | 'tool_end' | 'usage' | 'mviz_pending' | 'mviz_html' | 'error' | 'done';
   content?: string;
   toolCall?: {
     id: string;
@@ -20,5 +20,7 @@ export interface StreamEvent {
     result?: string;
     error?: boolean;
   };
+  id?: string;
+  source?: string;
   usage?: TurnUsage;
 }


### PR DESCRIPTION
Adds the mviz chart rendering checkpoint.\n\nQuick check: ask for top scorers by points per game as a bar chart.\n\nValidation: npm run typecheck for data-chat-mini-step-10.