### PR TITLE
[workshop] data-chat-mini step 12: context intercept

### DIFF
--- a/projects/data-chat-mini/app/api/chat/route.ts
+++ b/projects/data-chat-mini/app/api/chat/route.ts
@@ -3,6 +3,7 @@ import { getModelProfile } from '@/lib/llm-client';
 import { createMCPClient, getFilteredTools, mcpToolsToAnthropicFormat } from '@/lib/mcp-client';
 import { runAgenticLoop } from '@/lib/agentic-loop';
 import { buildSystemPrompt } from '@/lib/system-prompt';
+import { CONTEXT_TOOLS, CONTEXT_PLACEHOLDER } from '@/lib/context-tools';
 import { sseDone, sseError } from '@/lib/sse-encoder';
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 
@@ -13,9 +14,14 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const message = typeof body.message === 'string' ? body.message : '';
+    const history = Array.isArray(body.history) ? body.history as Array<{ role: string; content: unknown }> : [];
+    const resolvedContext = Array.isArray(body.resolvedContext)
+      ? body.resolvedContext as Array<{ callId: string; resultText: string; isError?: boolean }>
+      : [];
+    const isResume = resolvedContext.length > 0;
     const databases = Array.isArray(body.databases) ? body.databases.filter((db: unknown): db is string => typeof db === 'string') : ['nba_box_scores_v2'];
     const sessionId = typeof body.sessionId === 'string' ? body.sessionId : undefined;
-    if (!message.trim()) {
+    if (!message.trim() && !isResume) {
       return Response.json({ error: 'No message provided' }, { status: 400 });
     }
     if (!process.env.MOTHERDUCK_TOKEN) {
@@ -26,15 +32,35 @@ export async function POST(request: NextRequest) {
     }
 
     mcpClient = await createMCPClient(sessionId);
-    const tools = mcpToolsToAnthropicFormat(await getFilteredTools(mcpClient));
+    const tools = [...mcpToolsToAnthropicFormat(await getFilteredTools(mcpClient)), ...CONTEXT_TOOLS];
     const profile = getModelProfile();
 
     const stream = new ReadableStream({
       async start(controller) {
         const emit = (chunk: Uint8Array) => controller.enqueue(chunk);
         try {
+          const messages = history.map(item => ({ role: item.role, content: item.content }));
+          const turnStartIndex = messages.length;
+          if (isResume) {
+            const byId = new Map(resolvedContext.map(result => [result.callId, result]));
+            for (const item of messages) {
+              if (item.role !== 'user' || !Array.isArray(item.content)) continue;
+              for (const block of item.content as Array<Record<string, unknown>>) {
+                if (block.type === 'tool_result' && block.content === CONTEXT_PLACEHOLDER) {
+                  const resolved = byId.get(block.tool_use_id as string);
+                  if (resolved) {
+                    block.content = resolved.resultText;
+                    if (resolved.isError) block.is_error = true;
+                  }
+                }
+              }
+            }
+          } else {
+            messages.push({ role: 'user', content: message });
+          }
           await runAgenticLoop({
-            messages: [{ role: 'user', content: message }],
+            messages,
+            turnStartIndex,
             profile,
             thinkingLevel: 'none',
             client: mcpClient!,

--- a/projects/data-chat-mini/app/chat/ChatPanel.tsx
+++ b/projects/data-chat-mini/app/chat/ChatPanel.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { MvizFrame } from '@/app/components/MvizFrame';
 import { getSessionId } from '@/lib/session-id';
+import { serviceContextTool } from '@/lib/context-store';
 import { deriveTitle, loadConversation, saveConversation } from '@/lib/chat-storage';
-import type { ChatMessage, StreamEvent } from '@/types/chat';
+import type { ChatMessage, ResolvedContextTool, StreamEvent } from '@/types/chat';
 
 export function ChatPanel({
   database,
@@ -21,13 +22,16 @@ export function ChatPanel({
   const [input, setInput] = useState('How many games are in the schedule table?');
   const [isStreaming, setIsStreaming] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const historyRef = useRef<Array<{ role: string; content: unknown }>>([]);
 
   useEffect(() => {
     if (!conversationId) {
       setMessages([]);
+      historyRef.current = [];
       return;
     }
     loadConversation(conversationId).then((conversation) => setMessages(conversation?.messages || []));
+    historyRef.current = [];
   }, [conversationId]);
 
   const persist = async (id: string, nextMessages: ChatMessage[]) => {
@@ -48,6 +52,131 @@ export function ChatPanel({
     queueMicrotask(() => scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight }));
   };
 
+  const stream = async (params: {
+    message: string;
+    assistantId: string;
+    resolvedContext?: ResolvedContextTool[];
+  }) => {
+    const contextCalls: Array<{ callId: string; name: string; args: Record<string, unknown> }> = [];
+    const response = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: params.message,
+        history: historyRef.current,
+        databases: [database],
+        sessionId: getSessionId(),
+        ...(params.resolvedContext && { resolvedContext: params.resolvedContext }),
+      }),
+    });
+    if (!response.ok || !response.body) {
+      updateAssistant(params.assistantId, (message) => ({ ...message, error: `HTTP ${response.status}` }));
+      return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    const handle = (event: StreamEvent) => {
+      if (event.type === 'text') {
+        updateAssistant(params.assistantId, (message) => ({
+          ...message,
+          content: message.content + (event.content || ''),
+          segments: [...(message.segments || []), { type: 'text', text: event.content || '' }],
+        }));
+      } else if (event.type === 'tool_start' && event.toolCall) {
+        const tool = event.toolCall;
+        updateAssistant(params.assistantId, (message) => ({
+          ...message,
+          steps: [...(message.steps || []), {
+            id: tool.id,
+            name: tool.name,
+            status: 'running',
+            args: tool.args,
+          }],
+        }));
+      } else if (event.type === 'tool_end' && event.toolCall) {
+        const tool = event.toolCall;
+        updateAssistant(params.assistantId, (message) => ({
+          ...message,
+          steps: (message.steps || []).map((step) => step.id === tool.id
+            ? { ...step, status: tool.error ? 'error' : 'complete', result: tool.result }
+            : step),
+        }));
+      } else if (event.type === 'context_tool' && event.contextCall) {
+        contextCalls.push(event.contextCall);
+        updateAssistant(params.assistantId, (message) => ({
+          ...message,
+          steps: [...(message.steps || []), {
+            id: event.contextCall!.callId,
+            name: `${event.contextCall!.name} (local)`,
+            status: 'running',
+            args: event.contextCall!.args,
+          }],
+        }));
+      } else if (event.type === 'turn_complete' && event.turnHistory) {
+        historyRef.current.push(...event.turnHistory);
+      } else if (event.type === 'error') {
+        updateAssistant(params.assistantId, (message) => ({ ...message, error: event.content }));
+      } else if (event.type === 'mviz_pending' && event.id) {
+        updateAssistant(params.assistantId, (message) => ({
+          ...message,
+          segments: [...(message.segments || []), { type: 'mviz_pending', id: event.id! }],
+          steps: [...(message.steps || []), {
+            id: `mviz:${event.id}`,
+            name: 'mviz_render',
+            status: 'running',
+            args: { output: 'inline visualization' },
+          }],
+        }));
+      } else if (event.type === 'mviz_html') {
+        updateAssistant(params.assistantId, (message) => ({
+          ...message,
+          segments: (message.segments || []).map((segment) =>
+            segment.type === 'mviz_pending' && (!event.id || segment.id === event.id)
+              ? { type: 'mviz', id: event.id, html: event.content || '' }
+              : segment,
+          ),
+          steps: (message.steps || []).map((step) =>
+            step.id === `mviz:${event.id}`
+              ? { ...step, status: 'complete', result: 'Rendered inline visualization.' }
+              : step,
+          ),
+        }));
+      }
+    };
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        const data = line.slice(6).trim();
+        if (!data) continue;
+        try { handle(JSON.parse(data)); } catch { /* ignore malformed chunks */ }
+      }
+    }
+
+    if (contextCalls.length > 0) {
+      const resolved: ResolvedContextTool[] = [];
+      for (const call of contextCalls) {
+        const result = await serviceContextTool(call.name, call.args);
+        resolved.push({ callId: call.callId, resultText: result.resultText, isError: result.isError });
+        updateAssistant(params.assistantId, (message) => ({
+          ...message,
+          steps: (message.steps || []).map((step) => step.id === call.callId
+            ? { ...step, status: result.isError ? 'error' : 'complete', result: result.resultText }
+            : step),
+        }));
+      }
+      await stream({ message: '', assistantId: params.assistantId, resolvedContext: resolved });
+    }
+  };
+
   const submit = async () => {
     const trimmed = input.trim();
     if (!trimmed || isStreaming) return;
@@ -63,93 +192,7 @@ export function ChatPanel({
     setIsStreaming(true);
 
     try {
-      const response = await fetch('/api/chat', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          message: trimmed,
-          databases: [database],
-          sessionId: getSessionId(),
-        }),
-      });
-      if (!response.ok || !response.body) {
-        updateAssistant(assistant.id, (message) => ({ ...message, error: `HTTP ${response.status}` }));
-        return;
-      }
-
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = '';
-
-      const handle = (event: StreamEvent) => {
-        if (event.type === 'text') {
-          updateAssistant(assistant.id, (message) => ({
-            ...message,
-            content: message.content + (event.content || ''),
-            segments: [...(message.segments || []), { type: 'text', text: event.content || '' }],
-          }));
-        } else if (event.type === 'tool_start' && event.toolCall) {
-          const tool = event.toolCall;
-          updateAssistant(assistant.id, (message) => ({
-            ...message,
-            steps: [...(message.steps || []), {
-              id: tool.id,
-              name: tool.name,
-              status: 'running',
-              args: tool.args,
-            }],
-          }));
-        } else if (event.type === 'tool_end' && event.toolCall) {
-          const tool = event.toolCall;
-          updateAssistant(assistant.id, (message) => ({
-            ...message,
-            steps: (message.steps || []).map((step) => step.id === tool.id
-              ? { ...step, status: tool.error ? 'error' : 'complete', result: tool.result }
-              : step),
-          }));
-        } else if (event.type === 'error') {
-          updateAssistant(assistant.id, (message) => ({ ...message, error: event.content }));
-        } else if (event.type === 'mviz_pending' && event.id) {
-          updateAssistant(assistant.id, (message) => ({
-            ...message,
-            segments: [...(message.segments || []), { type: 'mviz_pending', id: event.id! }],
-            steps: [...(message.steps || []), {
-              id: `mviz:${event.id}`,
-              name: 'mviz_render',
-              status: 'running',
-              args: { output: 'inline visualization' },
-            }],
-          }));
-        } else if (event.type === 'mviz_html') {
-          updateAssistant(assistant.id, (message) => ({
-            ...message,
-            segments: (message.segments || []).map((segment) =>
-              segment.type === 'mviz_pending' && (!event.id || segment.id === event.id)
-                ? { type: 'mviz', id: event.id, html: event.content || '' }
-                : segment,
-            ),
-            steps: (message.steps || []).map((step) =>
-              step.id === `mviz:${event.id}`
-                ? { ...step, status: 'complete', result: 'Rendered inline visualization.' }
-                : step,
-            ),
-          }));
-        }
-      };
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        buffer = lines.pop() || '';
-        for (const line of lines) {
-          if (!line.startsWith('data: ')) continue;
-          const data = line.slice(6).trim();
-          if (!data) continue;
-          try { handle(JSON.parse(data)); } catch { /* ignore malformed chunks */ }
-        }
-      }
+      await stream({ message: trimmed, assistantId: assistant.id });
     } finally {
       setIsStreaming(false);
       setMessages((latest) => {

--- a/projects/data-chat-mini/app/page.tsx
+++ b/projects/data-chat-mini/app/page.tsx
@@ -2,15 +2,16 @@ export default function Home() {
   return (
     <main>
       <section className="workshop-page">
-        <div className="eyebrow">Step 11 · History</div>
-        <h1>Keep the thread.</h1>
+        <div className="eyebrow">Step 12 · Context</div>
+        <h1>Teach the agent.</h1>
         <p>
-          Conversations now persist to IndexedDB. Refresh the page, reopen the
-          chat, and the thread is still available in the sidebar.
+          The model now sees the real MotherDuck context tool names. The loop
+          intercepts those calls, the browser answers from local IndexedDB, and
+          the loop resumes with the result.
         </p>
 
         <div className="check">
-          <p>Quick check: ask a question, refresh, then reopen it from history.</p>
+          <p>Quick check: teach a definition, then ask a follow-up that uses it.</p>
           <pre>{`open http://localhost:3000/chat`}</pre>
           <p>
             The important rule: <code>box_scores</code> is one row per player

--- a/projects/data-chat-mini/lib/agentic-loop.ts
+++ b/projects/data-chat-mini/lib/agentic-loop.ts
@@ -1,13 +1,16 @@
 import { streamChatCompletion } from '@/lib/llm-client';
 import type { ModelProfile } from '@/lib/llm-client';
 import { dispatchTool } from '@/lib/tool-dispatch';
+import { isContextTool, CONTEXT_PLACEHOLDER } from '@/lib/context-tools';
 import {
+  sseContextTool,
   sseError,
   sseMvizHtml,
   sseMvizPending,
   sseText,
   sseToolEnd,
   sseToolStart,
+  sseTurnComplete,
   sseUsage,
 } from '@/lib/sse-encoder';
 import {
@@ -22,6 +25,7 @@ import type { ThinkingLevel } from '@/types/chat';
 
 export interface RunAgenticLoopOpts {
   messages: Array<{ role: string; content: unknown }>;
+  turnStartIndex: number;
   profile: ModelProfile;
   thinkingLevel: ThinkingLevel;
   client: Client;
@@ -34,6 +38,7 @@ const MAX_ITERATIONS = 8;
 
 export async function runAgenticLoop(opts: RunAgenticLoopOpts) {
   const messages = opts.messages;
+  const turnStartIndex = opts.turnStartIndex;
 
   for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
     const llmStream = await streamChatCompletion({
@@ -148,13 +153,27 @@ export async function runAgenticLoop(opts: RunAgenticLoopOpts) {
       if (assistantBlocks.length > 0) {
         messages.push({ role: 'assistant', content: assistantBlocks });
       }
-      return { messages };
+      opts.emit(sseTurnComplete(messages.slice(turnStartIndex)));
+      return { messages, finishReason: 'done' as const };
     }
 
     const toolResults: Array<{ type: 'tool_result'; tool_use_id: string; content: string; is_error?: boolean }> = [];
     for (const tc of pendingToolCalls.values()) {
       let parsedArgs: Record<string, unknown> = {};
       try { parsedArgs = JSON.parse(tc.args || '{}'); } catch { /* keep empty */ }
+
+      if (isContextTool(tc.name)) {
+        opts.emit(sseContextTool({ callId: tc.id, name: tc.name, args: parsedArgs }));
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: tc.id,
+          content: CONTEXT_PLACEHOLDER,
+        });
+        messages.push({ role: 'assistant', content: assistantBlocks });
+        messages.push({ role: 'user', content: toolResults });
+        opts.emit(sseTurnComplete(messages.slice(turnStartIndex)));
+        return { messages, finishReason: 'context_pause' as const };
+      }
 
       opts.emit(sseToolStart({ id: tc.id, name: tc.name, args: parsedArgs }));
       try {
@@ -183,5 +202,6 @@ export async function runAgenticLoop(opts: RunAgenticLoopOpts) {
   }
 
   opts.emit(sseError(`Iteration limit reached (${MAX_ITERATIONS}).`));
-  return { messages };
+  opts.emit(sseTurnComplete(messages.slice(turnStartIndex)));
+  return { messages, finishReason: 'iteration_limit' as const };
 }

--- a/projects/data-chat-mini/lib/context-store.ts
+++ b/projects/data-chat-mini/lib/context-store.ts
@@ -1,0 +1,65 @@
+import { get, set, createStore } from 'idb-keyval';
+import { uuid7 } from './uuid7';
+
+export interface Fragment {
+  id: string;
+  content: string;
+  createdAt: number;
+}
+
+const store = createStore('data-chat-mini', 'context-layer');
+const FRAGMENTS_KEY = 'fragments';
+
+export async function listFragments(): Promise<Fragment[]> {
+  return (await get<Fragment[]>(FRAGMENTS_KEY, store)) || [];
+}
+
+export async function saveFragment(content: string): Promise<Fragment> {
+  const fragment = { id: uuid7(), content, createdAt: Date.now() };
+  const fragments = await listFragments();
+  await set(FRAGMENTS_KEY, [...fragments, fragment], store);
+  return fragment;
+}
+
+async function queryFragments(query: string): Promise<Fragment[]> {
+  const terms = query.toLowerCase().split(/\W+/).filter(Boolean);
+  const fragments = await listFragments();
+  if (terms.length === 0) return fragments;
+  return fragments.filter(fragment => {
+    const content = fragment.content.toLowerCase();
+    return terms.some(term => content.includes(term));
+  });
+}
+
+export async function serviceContextTool(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ resultText: string; isError?: boolean }> {
+  try {
+    if (name === 'query_context_layer') {
+      const query = typeof args.query === 'string' ? args.query : '';
+      const fragments = await queryFragments(query);
+      if (fragments.length === 0) {
+        return { resultText: 'No saved context fragments matched.' };
+      }
+      return { resultText: fragments.map(fragment => `- ${fragment.content}`).join('\n') };
+    }
+
+    if (name === 'update_context_layer') {
+      const content = typeof args.content === 'string'
+        ? args.content
+        : typeof args.value === 'string'
+          ? args.value
+          : '';
+      if (!content.trim()) {
+        return { resultText: 'No content provided.', isError: true };
+      }
+      const fragment = await saveFragment(content.trim());
+      return { resultText: `Saved context fragment ${fragment.id}.` };
+    }
+
+    return { resultText: `Unknown context tool: ${name}`, isError: true };
+  } catch (error) {
+    return { resultText: error instanceof Error ? error.message : 'Context tool failed', isError: true };
+  }
+}

--- a/projects/data-chat-mini/lib/context-tools.ts
+++ b/projects/data-chat-mini/lib/context-tools.ts
@@ -1,0 +1,30 @@
+export const CONTEXT_PLACEHOLDER = '__DATA_CHAT_MINI_CONTEXT_PLACEHOLDER__';
+
+export const CONTEXT_TOOLS = [
+  {
+    name: 'query_context_layer',
+    description: 'Search saved local context fragments for definitions and preferences relevant to a data question.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'update_context_layer',
+    description: 'Save a local context fragment containing a definition or user preference.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        content: { type: 'string' },
+      },
+      required: ['content'],
+    },
+  },
+];
+
+export function isContextTool(name: string): boolean {
+  return name === 'query_context_layer' || name === 'update_context_layer';
+}

--- a/projects/data-chat-mini/lib/sse-encoder.ts
+++ b/projects/data-chat-mini/lib/sse-encoder.ts
@@ -17,3 +17,7 @@ export const sseUsage = (usage: TurnUsage) => event({ type: 'usage', usage });
 export const sseMvizPending = (id: string) => event({ type: 'mviz_pending', id });
 export const sseMvizHtml = (content: string, meta: { id?: string; source?: string } = {}) =>
   event({ type: 'mviz_html', content, ...meta });
+export const sseContextTool = (contextCall: { callId: string; name: string; args: Record<string, unknown> }) =>
+  event({ type: 'context_tool', contextCall });
+export const sseTurnComplete = (turnHistory: Array<{ role: string; content: unknown }>) =>
+  event({ type: 'turn_complete', turnHistory });

--- a/projects/data-chat-mini/lib/system-prompt.ts
+++ b/projects/data-chat-mini/lib/system-prompt.ts
@@ -12,5 +12,6 @@ Habits:
 - For nba_box_scores_v2.main.box_scores, remember that player/game totals live in period = 'FullGame'. Do not sum all period rows for a game total.
 - For "2026 playoffs", use season_year = 2025 and season_type = 'Playoffs'.
 - If the user asks for a count or leaderboard, run a query instead of estimating.
-- When a chart would be clearer than rows, emit an mviz fenced block after the answer.`;
+- When a chart would be clearer than rows, emit an mviz fenced block after the answer.
+- Before answering definitions, rate-stat leaderboards, or "remember that" requests, use query_context_layer or update_context_layer as appropriate.`;
 }

--- a/projects/data-chat-mini/types/chat.ts
+++ b/projects/data-chat-mini/types/chat.ts
@@ -11,7 +11,7 @@ export interface TurnUsage {
 }
 
 export interface StreamEvent {
-  type: 'text' | 'tool_start' | 'tool_end' | 'usage' | 'mviz_pending' | 'mviz_html' | 'error' | 'done';
+  type: 'text' | 'tool_start' | 'tool_end' | 'context_tool' | 'turn_complete' | 'usage' | 'mviz_pending' | 'mviz_html' | 'error' | 'done';
   content?: string;
   toolCall?: {
     id: string;
@@ -22,6 +22,8 @@ export interface StreamEvent {
   };
   id?: string;
   source?: string;
+  contextCall?: { callId: string; name: string; args: Record<string, unknown> };
+  turnHistory?: Array<{ role: string; content: unknown }>;
   usage?: TurnUsage;
 }
 
@@ -55,4 +57,10 @@ export interface ConversationSummary {
   title: string;
   updatedAt: number;
   databases: string[];
+}
+
+export interface ResolvedContextTool {
+  callId: string;
+  resultText: string;
+  isError?: boolean;
 }


### PR DESCRIPTION
Adds local context-tool interception checkpoint.\n\nQuick check: teach a definition, then ask a follow-up that uses the saved fragment.\n\nValidation: npm run typecheck for data-chat-mini-step-12.