### PR TITLE
[workshop] data-chat-mini step 11: history

### DIFF
--- a/projects/data-chat-mini/app/chat/ChatHistorySidebar.tsx
+++ b/projects/data-chat-mini/app/chat/ChatHistorySidebar.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { listConversations, deleteConversation } from '@/lib/chat-storage';
+import type { ConversationSummary } from '@/types/chat';
+
+export function ChatHistorySidebar({
+  activeId,
+  reloadKey,
+  onSelect,
+  onNew,
+}: {
+  activeId: string | null;
+  reloadKey: number;
+  onSelect: (conversation: ConversationSummary) => void;
+  onNew: () => void;
+}) {
+  const [items, setItems] = useState<ConversationSummary[]>([]);
+
+  useEffect(() => {
+    listConversations().then(setItems).catch(() => setItems([]));
+  }, [reloadKey]);
+
+  return (
+    <aside className="history-panel">
+      <button className="new-chat" onClick={onNew}>New chat</button>
+      {items.map((item) => (
+        <div className={activeId === item.id ? 'history-row active' : 'history-row'} key={item.id}>
+          <button onClick={() => onSelect(item)}>{item.title}</button>
+          <button
+            aria-label={`Delete ${item.title}`}
+            onClick={async () => {
+              await deleteConversation(item.id);
+              setItems(await listConversations());
+            }}
+          >
+            x
+          </button>
+        </div>
+      ))}
+    </aside>
+  );
+}

--- a/projects/data-chat-mini/app/chat/ChatPanel.tsx
+++ b/projects/data-chat-mini/app/chat/ChatPanel.tsx
@@ -1,34 +1,49 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { MvizFrame } from '@/app/components/MvizFrame';
 import { getSessionId } from '@/lib/session-id';
-import type { StreamEvent } from '@/types/chat';
+import { deriveTitle, loadConversation, saveConversation } from '@/lib/chat-storage';
+import type { ChatMessage, StreamEvent } from '@/types/chat';
 
-type ToolStep = {
-  id: string;
-  name: string;
-  status: 'running' | 'complete' | 'error';
-  args?: Record<string, unknown>;
-  result?: string;
-};
-
-type Message = {
-  id: string;
-  role: 'user' | 'assistant';
-  content: string;
-  segments?: Array<{ type: 'text'; text: string } | { type: 'mviz_pending'; id: string } | { type: 'mviz'; id?: string; html: string }>;
-  steps?: ToolStep[];
-  error?: string;
-};
-
-export function ChatPanel({ database }: { database: string }) {
-  const [messages, setMessages] = useState<Message[]>([]);
+export function ChatPanel({
+  database,
+  conversationId,
+  onConversationChange,
+  onSaved,
+}: {
+  database: string;
+  conversationId: string | null;
+  onConversationChange: (id: string) => void;
+  onSaved: () => void;
+}) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('How many games are in the schedule table?');
   const [isStreaming, setIsStreaming] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  const updateAssistant = (id: string, updater: (message: Message) => Message) => {
+  useEffect(() => {
+    if (!conversationId) {
+      setMessages([]);
+      return;
+    }
+    loadConversation(conversationId).then((conversation) => setMessages(conversation?.messages || []));
+  }, [conversationId]);
+
+  const persist = async (id: string, nextMessages: ChatMessage[]) => {
+    const now = Date.now();
+    await saveConversation({
+      id,
+      title: deriveTitle(nextMessages),
+      createdAt: now,
+      updatedAt: now,
+      databases: [database],
+      messages: nextMessages,
+    });
+    onSaved();
+  };
+
+  const updateAssistant = (id: string, updater: (message: ChatMessage) => ChatMessage) => {
     setMessages((prev) => prev.map((message) => message.id === id ? updater(message) : message));
     queueMicrotask(() => scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight }));
   };
@@ -37,9 +52,13 @@ export function ChatPanel({ database }: { database: string }) {
     const trimmed = input.trim();
     if (!trimmed || isStreaming) return;
 
-    const user: Message = { id: crypto.randomUUID(), role: 'user', content: trimmed };
-    const assistant: Message = { id: crypto.randomUUID(), role: 'assistant', content: '', steps: [] };
-    setMessages((prev) => [...prev, user, assistant]);
+    const activeId = conversationId || crypto.randomUUID();
+    if (!conversationId) onConversationChange(activeId);
+
+    const user: ChatMessage = { id: crypto.randomUUID(), role: 'user', content: trimmed, timestamp: Date.now() };
+    const assistant: ChatMessage = { id: crypto.randomUUID(), role: 'assistant', content: '', steps: [], timestamp: Date.now() };
+    const startingMessages = [...messages, user, assistant];
+    setMessages(startingMessages);
     setInput('');
     setIsStreaming(true);
 
@@ -133,6 +152,10 @@ export function ChatPanel({ database }: { database: string }) {
       }
     } finally {
       setIsStreaming(false);
+      setMessages((latest) => {
+        persist(activeId, latest).catch((error) => console.error('[history] save failed', error));
+        return latest;
+      });
     }
   };
 

--- a/projects/data-chat-mini/app/chat/ChatShell.tsx
+++ b/projects/data-chat-mini/app/chat/ChatShell.tsx
@@ -2,10 +2,13 @@
 
 import { useState } from 'react';
 import { ChatPanel } from './ChatPanel';
+import { ChatHistorySidebar } from './ChatHistorySidebar';
 import { SchemaExplorerSidebar } from './SchemaExplorerSidebar';
 
 export function ChatShell() {
   const [database] = useState('nba_box_scores_v2');
+  const [conversationId, setConversationId] = useState<string | null>(null);
+  const [historyReloadKey, setHistoryReloadKey] = useState(0);
 
   return (
     <main className="app-shell">
@@ -16,7 +19,18 @@ export function ChatShell() {
         </div>
       </header>
       <div className="workspace-grid">
-        <ChatPanel database={database} />
+        <ChatHistorySidebar
+          activeId={conversationId}
+          reloadKey={historyReloadKey}
+          onSelect={(conversation) => setConversationId(conversation.id)}
+          onNew={() => setConversationId(null)}
+        />
+        <ChatPanel
+          database={database}
+          conversationId={conversationId}
+          onConversationChange={setConversationId}
+          onSaved={() => setHistoryReloadKey((key) => key + 1)}
+        />
         <SchemaExplorerSidebar database={database} />
       </div>
     </main>

--- a/projects/data-chat-mini/app/globals.css
+++ b/projects/data-chat-mini/app/globals.css
@@ -141,6 +141,37 @@ pre {
   background: white;
 }
 
+.history-panel {
+  display: flex;
+  width: 220px;
+  flex-direction: column;
+  gap: 8px;
+  border: 1px solid #d1d5db;
+  background: white;
+  padding: 12px;
+}
+
+.new-chat,
+.history-row button {
+  border: 1px solid #d1d5db;
+  background: white;
+  padding: 8px;
+  text-align: left;
+}
+
+.history-row {
+  display: flex;
+  gap: 4px;
+}
+
+.history-row button:first-child {
+  flex: 1;
+}
+
+.history-row.active button:first-child {
+  border-color: #2563eb;
+}
+
 .messages {
   flex: 1;
   overflow: auto;

--- a/projects/data-chat-mini/app/page.tsx
+++ b/projects/data-chat-mini/app/page.tsx
@@ -2,15 +2,15 @@ export default function Home() {
   return (
     <main>
       <section className="workshop-page">
-        <div className="eyebrow">Step 10 · Charts</div>
-        <h1>Make answers legible.</h1>
+        <div className="eyebrow">Step 11 · History</div>
+        <h1>Keep the thread.</h1>
         <p>
-          The loop now recognizes mviz chart fences, renders them, and streams
-          inline visualizations into the chat.
+          Conversations now persist to IndexedDB. Refresh the page, reopen the
+          chat, and the thread is still available in the sidebar.
         </p>
 
         <div className="check">
-          <p>Quick check: ask for top scorers by points per game as a bar chart.</p>
+          <p>Quick check: ask a question, refresh, then reopen it from history.</p>
           <pre>{`open http://localhost:3000/chat`}</pre>
           <p>
             The important rule: <code>box_scores</code> is one row per player

--- a/projects/data-chat-mini/lib/chat-storage.ts
+++ b/projects/data-chat-mini/lib/chat-storage.ts
@@ -1,0 +1,45 @@
+import { get, set, del, createStore } from 'idb-keyval';
+import type { ChatMessage, ConversationSummary, StoredConversation } from '@/types/chat';
+
+const store = createStore('data-chat-mini', 'chat-history');
+const INDEX_KEY = 'conv_index';
+const CONV_PREFIX = 'conv:';
+
+function convKey(id: string): string {
+  return `${CONV_PREFIX}${id}`;
+}
+
+export function deriveTitle(messages: ChatMessage[]): string {
+  const firstUser = messages.find(message => message.role === 'user' && message.content.trim());
+  const raw = firstUser?.content.trim() || 'New conversation';
+  return raw.length > 60 ? `${raw.slice(0, 57)}...` : raw;
+}
+
+export async function listConversations(): Promise<ConversationSummary[]> {
+  const list = (await get<ConversationSummary[]>(INDEX_KEY, store)) || [];
+  return [...list].sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+export async function loadConversation(id: string): Promise<StoredConversation | null> {
+  return (await get<StoredConversation>(convKey(id), store)) || null;
+}
+
+export async function saveConversation(conversation: StoredConversation): Promise<void> {
+  await set(convKey(conversation.id), conversation, store);
+  const index = (await get<ConversationSummary[]>(INDEX_KEY, store)) || [];
+  const next = index.filter(item => item.id !== conversation.id);
+  next.push({
+    id: conversation.id,
+    title: conversation.title,
+    updatedAt: conversation.updatedAt,
+    databases: conversation.databases,
+  });
+  next.sort((a, b) => b.updatedAt - a.updatedAt);
+  await set(INDEX_KEY, next, store);
+}
+
+export async function deleteConversation(id: string): Promise<void> {
+  await del(convKey(id), store);
+  const index = (await get<ConversationSummary[]>(INDEX_KEY, store)) || [];
+  await set(INDEX_KEY, index.filter(item => item.id !== id), store);
+}

--- a/projects/data-chat-mini/types/chat.ts
+++ b/projects/data-chat-mini/types/chat.ts
@@ -24,3 +24,35 @@ export interface StreamEvent {
   source?: string;
   usage?: TurnUsage;
 }
+
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: number;
+  segments?: Array<{ type: 'text'; text: string } | { type: 'mviz_pending'; id: string } | { type: 'mviz'; id?: string; html: string }>;
+  steps?: Array<{
+    id: string;
+    name: string;
+    status: 'running' | 'complete' | 'error';
+    args?: Record<string, unknown>;
+    result?: string;
+  }>;
+  error?: string;
+}
+
+export interface StoredConversation {
+  id: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  databases: string[];
+  messages: ChatMessage[];
+}
+
+export interface ConversationSummary {
+  id: string;
+  title: string;
+  updatedAt: number;
+  databases: string[];
+}


### PR DESCRIPTION
Adds the IndexedDB chat history checkpoint.\n\nQuick check: ask a question, refresh, and reopen the conversation from history.\n\nValidation: npm run typecheck for data-chat-mini-step-11.