### PR TITLE
Improve data-chat-mini mobile mode UX

### DIFF
--- a/projects/data-chat-mini/app/chat/ChatShell.tsx
+++ b/projects/data-chat-mini/app/chat/ChatShell.tsx
@@ -59,7 +59,7 @@ export function ChatShell() {
 
   if (!database) {
     return (
-      <div className="h-screen">
+      <div className="picker-shell">
         <DatabasePicker onPick={pickDatabase} onStartDemo={startDemo} />
       </div>
     );
@@ -87,12 +87,24 @@ export function ChatShell() {
         >
           Switch
         </button>
-        <button
-          onClick={() => setDemoMode((mode) => ({ ...mode, enabled: !mode.enabled }))}
-          className={demoMode.enabled ? 'solid-button compact' : 'ghost-button'}
-        >
-          Demo
-        </button>
+        <div className="mode-switch topbar-mode-switch" role="group" aria-label="Chat mode">
+          <button
+            type="button"
+            onClick={() => setDemoMode((mode) => ({ ...mode, enabled: false }))}
+            className={!demoMode.enabled ? 'active' : ''}
+            aria-pressed={!demoMode.enabled}
+          >
+            Interactive mode
+          </button>
+          <button
+            type="button"
+            onClick={() => setDemoMode((mode) => ({ ...mode, enabled: true }))}
+            className={demoMode.enabled ? 'active' : ''}
+            aria-pressed={demoMode.enabled}
+          >
+            Workshop mode
+          </button>
+        </div>
         <label className="thinking-control">
           Thinking
           <select
@@ -105,6 +117,12 @@ export function ChatShell() {
           </select>
         </label>
       </header>
+
+      <div className="mode-guidance">
+        {demoMode.enabled
+          ? 'Workshop mode: follow the guided NBA steps, then insert a prompt or replay a validation turn.'
+          : `Interactive mode: ask a freeform question about ${database} in the input at the bottom.`}
+      </div>
 
       <div className={`workspace-grid ${demoMode.enabled ? 'with-demo' : ''}`}>
         <ChatHistorySidebar

--- a/projects/data-chat-mini/app/chat/DatabasePicker.tsx
+++ b/projects/data-chat-mini/app/chat/DatabasePicker.tsx
@@ -18,6 +18,7 @@ export function DatabasePicker({
 }) {
   const [databases, setDatabases] = useState<string[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [mode, setMode] = useState<'interactive' | 'workshop'>('interactive');
 
   useEffect(() => {
     (async () => {
@@ -43,6 +44,32 @@ export function DatabasePicker({
   return (
     <div className="picker-screen">
       <div className="picker-card">
+        <div className="picker-mode-header">
+          <div className="mode-switch" role="group" aria-label="Start mode">
+            <button
+              type="button"
+              onClick={() => setMode('interactive')}
+              className={mode === 'interactive' ? 'active' : ''}
+              aria-pressed={mode === 'interactive'}
+            >
+              Interactive mode
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode('workshop')}
+              className={mode === 'workshop' ? 'active' : ''}
+              aria-pressed={mode === 'workshop'}
+            >
+              Workshop mode
+            </button>
+          </div>
+          <p>
+            {mode === 'interactive'
+              ? 'Choose a database, then ask a freeform question in the chat input.'
+              : 'Use the NBA workshop path to replay the demo or run each prompt live.'}
+          </p>
+        </div>
+
         <div className="brand-lockup picker-brand">
           <MotherDuckLogo />
           <div>
@@ -51,48 +78,54 @@ export function DatabasePicker({
           </div>
         </div>
         <p className="picker-lede">
-          Pick a MotherDuck database or launch the presenter-ready NBA workshop path.
+          {mode === 'interactive'
+            ? 'Pick a MotherDuck database to start a read-only data chat.'
+            : 'Launch the presenter-ready NBA workshop path.'}
         </p>
 
-        <div className="demo-start-panel">
-          <div>
-            <div className="eyebrow">Workshop mode</div>
-            <h2>{CANONICAL_DEMO_DATABASE}</h2>
-            <p>Guided prompts, replayable transcript, traceable SQL, context, and mviz artifacts.</p>
+        {mode === 'workshop' ? (
+          <div className="demo-start-panel">
+            <div>
+              <div className="eyebrow">Workshop mode</div>
+              <h2>{CANONICAL_DEMO_DATABASE}</h2>
+              <p>Guided prompts, replayable transcript, traceable SQL, context, and mviz artifacts.</p>
+            </div>
+            <div className="demo-start-actions">
+              <button onClick={() => onStartDemo(true)}>Replay demo</button>
+              <button onClick={() => onStartDemo(false)}>Live demo</button>
+            </div>
           </div>
-          <div className="demo-start-actions">
-            <button onClick={() => onStartDemo(true)}>Replay demo</button>
-            <button onClick={() => onStartDemo(false)}>Live demo</button>
-          </div>
-        </div>
+        ) : (
+          <>
+            {error && (
+              <div className="error-card">
+                {error === 'auth_expired'
+                  ? 'MotherDuck connection failed — check MOTHERDUCK_TOKEN in .env.local.'
+                  : error}
+              </div>
+            )}
 
-        {error && (
-          <div className="error-card">
-            {error === 'auth_expired'
-              ? 'MotherDuck connection failed — check MOTHERDUCK_TOKEN in .env.local.'
-              : error}
-          </div>
+            {databases === null && !error && (
+              <div className="loading-row">Loading databases…</div>
+            )}
+
+            {databases && databases.length === 0 && (
+              <div className="loading-row">No databases found for this token.</div>
+            )}
+
+            <div className="database-list">
+              {databases?.map((db) => (
+                <button
+                  key={db}
+                  onClick={() => onPick(db)}
+                >
+                  <span>{db}</span>
+                  <small>Read-only chat workspace</small>
+                </button>
+              ))}
+            </div>
+          </>
         )}
-
-        {databases === null && !error && (
-          <div className="loading-row">Loading databases…</div>
-        )}
-
-        {databases && databases.length === 0 && (
-          <div className="loading-row">No databases found for this token.</div>
-        )}
-
-        <div className="database-list">
-          {databases?.map((db) => (
-            <button
-              key={db}
-              onClick={() => onPick(db)}
-            >
-              <span>{db}</span>
-              <small>Read-only chat workspace</small>
-            </button>
-          ))}
-        </div>
       </div>
     </div>
   );

--- a/projects/data-chat-mini/app/globals.css
+++ b/projects/data-chat-mini/app/globals.css
@@ -123,8 +123,9 @@ pre {
 
 .app-shell {
   display: flex;
-  min-height: 100vh;
-  height: 100vh;
+  min-height: 100svh;
+  height: 100svh;
+  height: 100dvh;
   flex-direction: column;
   overflow: hidden;
   background: var(--background);
@@ -209,6 +210,49 @@ pre {
   flex: 0 0 auto;
 }
 
+.mode-switch {
+  display: inline-flex;
+  max-width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-pill);
+  background: var(--panel);
+  padding: 2px;
+  flex: 0 1 auto;
+}
+
+.mode-switch button {
+  min-height: 30px;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--muted);
+  padding: 0 12px;
+  font-size: var(--text-caption);
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.mode-switch button.active {
+  background: var(--foreground);
+  color: #ffffff;
+}
+
+.topbar-mode-switch {
+  flex: 0 1 286px;
+}
+
+.mode-guidance {
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--muted);
+  padding: 8px 14px;
+  font-size: var(--text-caption);
+  line-height: 1.4;
+  flex-shrink: 0;
+}
+
 .ghost-button,
 .solid-button,
 .send-button,
@@ -242,8 +286,13 @@ pre {
 .schema-table-button:hover,
 .schema-column-button:hover,
 .context-fragment-card:hover,
+.mode-switch button:hover,
 .segmented-control button:hover {
   background: var(--subtle);
+}
+
+.mode-switch button.active:hover {
+  background: var(--foreground);
 }
 
 .solid-button,
@@ -626,6 +675,7 @@ pre {
   min-width: 0;
   min-height: 0;
   flex-direction: column;
+  overflow: hidden;
   background: var(--background);
 }
 
@@ -1195,6 +1245,13 @@ pre {
   line-height: 1.45;
 }
 
+.picker-shell {
+  min-height: 100svh;
+  height: 100svh;
+  height: 100dvh;
+  overflow-y: auto;
+}
+
 .picker-screen {
   display: grid;
   min-height: 100%;
@@ -1210,6 +1267,24 @@ pre {
   background: var(--panel);
   padding: 24px;
   box-shadow: var(--shadow-sm);
+}
+
+.picker-mode-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 16px;
+}
+
+.picker-mode-header p {
+  max-width: 330px;
+  margin: 0;
+  color: var(--muted);
+  font-size: var(--text-caption);
+  line-height: 1.45;
 }
 
 .picker-brand {
@@ -1328,6 +1403,19 @@ pre {
     max-width: 42vw;
   }
 
+  .topbar-mode-switch {
+    flex: 1 1 100%;
+    order: 10;
+  }
+
+  .topbar-mode-switch button {
+    flex: 1;
+  }
+
+  .mode-guidance {
+    padding: 7px 14px;
+  }
+
   .workspace-grid.with-demo {
     grid-template-columns: minmax(0, 1fr);
     grid-template-rows: auto minmax(0, 1fr);
@@ -1361,6 +1449,27 @@ pre {
 
   .picker-card {
     padding: 16px;
+  }
+
+  .picker-mode-header {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 16px;
+    padding-bottom: 14px;
+  }
+
+  .picker-mode-header .mode-switch {
+    width: 100%;
+  }
+
+  .picker-mode-header .mode-switch button {
+    flex: 1;
+    padding-inline: 8px;
+  }
+
+  .picker-mode-header p {
+    max-width: none;
   }
 
   .demo-start-actions,


### PR DESCRIPTION
## Summary
- add Interactive mode / Workshop mode pill toggles on the picker and chat shell
- default the picker to Interactive mode with clear guidance text
- keep mobile chat composer visible by using dynamic viewport sizing and clipped chat layout

## Verification
- npm run typecheck
- npm run lint
- git diff --check
- mobile browser checks at 390x844 and 375x667