### PR TITLE
Keep data-chat mode toggle on database picker

### DIFF
--- a/projects/data-chat-mini/app/chat/ChatShell.tsx
+++ b/projects/data-chat-mini/app/chat/ChatShell.tsx
@@ -40,13 +40,15 @@ export function ChatShell() {
   // (re)picking a database must drop the active conversation so a chat from
   // database A can't be resumed under database B's prompt/context.
   const pickDatabase = (db: string) => {
+    setDemoMode((mode) => ({ ...mode, enabled: false }));
     setDatabase(db);
     setConversationId(null);
   };
 
   const startDemo = (replay: boolean) => {
     setDemoMode({ enabled: true, replay, activeStepId: 'pick-database' });
-    pickDatabase(CANONICAL_DEMO_DATABASE);
+    setDatabase(CANONICAL_DEMO_DATABASE);
+    setConversationId(null);
   };
 
   // Selecting a conversation from history switches to the database it was
@@ -87,24 +89,6 @@ export function ChatShell() {
         >
           Switch
         </button>
-        <div className="mode-switch topbar-mode-switch" role="group" aria-label="Chat mode">
-          <button
-            type="button"
-            onClick={() => setDemoMode((mode) => ({ ...mode, enabled: false }))}
-            className={!demoMode.enabled ? 'active' : ''}
-            aria-pressed={!demoMode.enabled}
-          >
-            Interactive mode
-          </button>
-          <button
-            type="button"
-            onClick={() => setDemoMode((mode) => ({ ...mode, enabled: true }))}
-            className={demoMode.enabled ? 'active' : ''}
-            aria-pressed={demoMode.enabled}
-          >
-            Workshop mode
-          </button>
-        </div>
         <label className="thinking-control">
           Thinking
           <select
@@ -117,12 +101,6 @@ export function ChatShell() {
           </select>
         </label>
       </header>
-
-      <div className="mode-guidance">
-        {demoMode.enabled
-          ? 'Workshop mode: follow the guided NBA steps, then insert a prompt or replay a validation turn.'
-          : `Interactive mode: ask a freeform question about ${database} in the input at the bottom.`}
-      </div>
 
       <div className={`workspace-grid ${demoMode.enabled ? 'with-demo' : ''}`}>
         <ChatHistorySidebar

--- a/projects/data-chat-mini/app/globals.css
+++ b/projects/data-chat-mini/app/globals.css
@@ -239,20 +239,6 @@ pre {
   color: #ffffff;
 }
 
-.topbar-mode-switch {
-  flex: 0 1 286px;
-}
-
-.mode-guidance {
-  border-bottom: 1px solid var(--border);
-  background: var(--surface-2);
-  color: var(--muted);
-  padding: 8px 14px;
-  font-size: var(--text-caption);
-  line-height: 1.4;
-  flex-shrink: 0;
-}
-
 .ghost-button,
 .solid-button,
 .send-button,
@@ -1401,19 +1387,6 @@ pre {
 
   .db-chip {
     max-width: 42vw;
-  }
-
-  .topbar-mode-switch {
-    flex: 1 1 100%;
-    order: 10;
-  }
-
-  .topbar-mode-switch button {
-    flex: 1;
-  }
-
-  .mode-guidance {
-    padding: 7px 14px;
   }
 
   .workspace-grid.with-demo {


### PR DESCRIPTION
## Summary
- remove the Interactive/Workshop mode pill from the chat header
- keep the mode pill on the database selection screen only
- make interactive database selection explicitly disable workshop mode while workshop launch still enables it

## Verification
- npm run typecheck
- npm run lint
- git diff --check
- mobile browser check at 390x844: picker has the mode pill, chat header has no mode switch, composer remains visible