### PR TITLE
data-chat-mini: reset thinking level to default on new conversation

### DIFF
--- a/projects/data-chat-mini/app/chat/ChatPanel.tsx
+++ b/projects/data-chat-mini/app/chat/ChatPanel.tsx
@@ -37,6 +37,7 @@ export function ChatPanel({
   databases,
   thinkingLevel,
   onThinkingLevelChange,
+  defaultThinkingLevel,
   conversationId,
   draftPrompt,
   submitPrompt,
@@ -49,6 +50,7 @@ export function ChatPanel({
   databases: string[];
   thinkingLevel: ThinkingLevel;
   onThinkingLevelChange: (level: ThinkingLevel) => void;
+  defaultThinkingLevel: ThinkingLevel;
   conversationId: string | null;
   draftPrompt?: { text: string; nonce: number } | null;
   submitPrompt?: { text: string; nonce: number } | null;
@@ -75,6 +77,10 @@ export function ChatPanel({
       setMessages([]);
       historyRef.current = [];
       loadedRef.current = null;
+      // Starting a new conversation resets the thinking level to the default.
+      // Without this, opening an old `none` conversation and then clicking New
+      // would leave the new chat stuck on `none` instead of the default.
+      onThinkingLevelChange(defaultThinkingLevel);
       return;
     }
     if (loadedRef.current === conversationId) return;
@@ -94,7 +100,7 @@ export function ChatPanel({
       // the conversation's original privacy/cost choice.
       if (conv.thinkingLevel) onThinkingLevelChange(conv.thinkingLevel);
     })();
-  }, [conversationId, onThinkingLevelChange]);
+  }, [conversationId, onThinkingLevelChange, defaultThinkingLevel]);
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });

--- a/projects/data-chat-mini/app/chat/ChatShell.tsx
+++ b/projects/data-chat-mini/app/chat/ChatShell.tsx
@@ -121,6 +121,7 @@ export function ChatShell() {
           databases={databases}
           thinkingLevel={thinkingLevel}
           onThinkingLevelChange={setThinkingLevel}
+          defaultThinkingLevel={DEFAULT_THINKING}
           conversationId={conversationId}
           draftPrompt={draftPrompt}
           submitPrompt={submitPrompt}


### PR DESCRIPTION
Follow-up to #42. Fixes a bug found in prod: open an old conversation saved with `none` → the restore-on-open (from #42) sets the shell to `none` → click **New** → the new chat stays stuck on `none` instead of the `medium` default.

**Cause:** the conversation-load effect only *restored* the saved level for existing conversations; the new-conversation (`conversationId === null`) branch never reset it.

**Fix:** the null branch now resets to the default (`defaultThinkingLevel`, passed down from `ChatShell`). The freshly-minted-conversation send path is unaffected — it sets `loadedRef` before `onConversationChange`, so the effect early-returns and the new chat keeps whatever level it had.

Behavior after this:
- New chat → `medium` (default), even right after viewing a `none` conversation
- Reopened chat → its saved level (unchanged from #42)
- Manually changing the dropdown mid-chat → preserved (effect only fires on `conversationId` change)

Typecheck/lint clean, 79/79 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)