### PR TITLE
context who? fetch_context → semantic_lookup

### DIFF
--- a/projects/agentic-sql-claude-edition/README.md
+++ b/projects/agentic-sql-claude-edition/README.md
@@ -6,7 +6,7 @@ ideas from Anthropic's *self-service data analytics* work:
 1. **A compact skill** (`skill/SKILL.md`) injected into the system prompt — it
    teaches the agent *how* to work and *where* knowledge lives, not the knowledge
    itself.
-2. **A semantic layer via `fetch_context`** — domain knowledge (fee matching,
+2. **A semantic layer via `semantic_lookup`** — domain knowledge (fee matching,
    bucketing, terminology, SQL patterns, answer formatting) lives in a context
    store and is fetched **progressively**: domains → one-line item summaries →
    full text. The agent loads only what each question needs.
@@ -22,7 +22,7 @@ template T01–T26; `train_ids` in `data/split.json`).
 - **Set:** all 450 DABStep questions minus the 26 template reps (= 424 held-out)
   minus **5 provably-wrong `hf_consensus` golds** set aside in `data/bad_golds.json`
   (our SQL is correct; those golds disagree with the data — verified) → **419**.
-- **Approach:** a compact always-on skill + a 27-item `fetch_context` semantic layer.
+- **Approach:** a compact always-on skill + a 27-item `semantic_lookup` semantic layer.
   The whole knowledge base is ~53K chars but the agent loads only ~16K per hard
   question — the *always-on* prompt is ~3.4× smaller than injecting the manual.
 - **Reasoning sweet spot:** `low` matches `medium` accuracy at ~half the cost; `off`
@@ -46,9 +46,9 @@ answer flow and the log-driven improvement loop.
 
 ```
 system prompt + SKILL + question
-  → fetch_context()                         # list domains
-  → fetch_context(domains=["fees", ...])    # item summaries
-  → fetch_context(ids=["fees-matching-9dim", ...])   # full context
+  → semantic_lookup()                         # list domains
+  → semantic_lookup(domains=["fees", ...])    # item summaries
+  → semantic_lookup(ids=["fees-matching-9dim", ...])   # full context
   → list_tables / list_columns              # explore schema
   → query (verify SQL)
   → submit_answer                           # the SQL whose result IS the answer
@@ -82,7 +82,7 @@ cp .env.example .env   # fill in OPENROUTER_API_KEY and MOTHERDUCK_TOKEN
 # 1. Build the MotherDuck database from data/dabstep/context/
 uv run asm load
 
-# 2. Inspect the semantic layer (mirrors the fetch_context tool)
+# 2. Inspect the semantic layer (mirrors the semantic_lookup tool)
 uv run asm context                       # list domains
 uv run asm context --domains fees,bucketing
 uv run asm context --ids fees-matching-9dim
@@ -98,7 +98,7 @@ uv run asm summary results/templates_<ts>.jsonl
 # 5. Visualize a run. controllog-viz is a standalone CLI (it caps duckdb at
 #    1.5.2, so it runs in its own environment, not this project's). It reads the
 #    JSONL under results/. `review` shows the rich per-question trace cards
-#    (chain-of-thought + every fetch_context/query/submit_answer call, predicted
+#    (chain-of-thought + every semantic_lookup/query/submit_answer call, predicted
 #    vs gold) — driven by the `evaluation_result` events the eval emits.
 uvx --from "git+https://github.com/motherduckdb/labs#subdirectory=projects/controllog-viz" \
     controllog-viz review --source results --latest --open -o review.html
@@ -115,14 +115,14 @@ Each miss points at one of four artifacts to fix, then re-run:
 - a **skill-navigation** gap (`skill/SKILL.md`).
 
 `controllog-viz review` renders the full tool-call trace (including
-`fetch_context` navigation) and predicted-vs-gold for diagnosis.
+`semantic_lookup` navigation) and predicted-vs-gold for diagnosis.
 
 ## Layout
 
 ```
 skill/SKILL.md          the skill (procedure + navigation)
 context/items/*.md      the semantic-layer context store (one file = one item)
-src/context_store.py    loads items, powers fetch_context
+src/context_store.py    loads items, powers semantic_lookup
 src/agent.py            tools + prompt + OpenRouter provider
 src/load.py             build the MotherDuck database
 src/run.py              CLI: load / context / evaluate / summary

--- a/projects/agentic-sql-claude-edition/docs/error-fixes.md
+++ b/projects/agentic-sql-claude-edition/docs/error-fixes.md
@@ -143,7 +143,7 @@ doesn't match the wrong gold.
 `results/test419.jsonl` → 412/419 (98.33%). The 7 misses + fixes:
 - **36, 44** (shopper math): customer/shopper = NON-NULL email; `terminology-term-mapping.md`.
 - **2571, 2573, 2574** (T01): the agent wasn't *loading* the T01 item — passed a domain name as
-  an id, or skipped `sql_patterns`. Fixed `fetch_context` to tolerate domain-name-as-id,
+  an id, or skipped `sql_patterns`. Fixed `semantic_lookup` to tolerate domain-name-as-id,
   sharpened the item summary, added a WRONG/RIGHT worked example, and a skill nudge to drill in.
 - **2740, 2755** (T08): the agent hallucinated `capture_delay 'immediate' → '<3'`, changing the
   matched fee rules. Hardened `bucketing-capture-delay.md` + the master CTE comment: never remap

--- a/projects/agentic-sql-claude-edition/docs/how-it-works.md
+++ b/projects/agentic-sql-claude-edition/docs/how-it-works.md
@@ -6,7 +6,7 @@ loop that tunes the skill + context from the eval logs.
 ## 1. Answering a data question (runtime)
 
 The agent always has the compact `SKILL.md` in its prompt; the heavy domain knowledge
-is pulled on demand through `fetch_context` (progressive disclosure: domains →
+is pulled on demand through `semantic_lookup` (progressive disclosure: domains →
 one-line summaries → full bodies), then it explores the schema, verifies SQL, and
 submits. `controllog` captures the full trace for later inspection.
 
@@ -16,9 +16,9 @@ flowchart TD
     SKILL["SKILL.md — always in the prompt:<br/>procedure + where knowledge lives + key rules"] -.->|injected| AG
     AG["Agent loop<br/>gemini-3-flash · reasoning low"]
 
-    AG -->|"1 · fetch_context()"| DOM["6 domains"]
-    DOM -->|"2 · fetch_context(domains=[...])"| SUMM["item one-line summaries"]
-    SUMM -->|"3 · fetch_context(ids=[...])"| BODY["full item bodies"]
+    AG -->|"1 · semantic_lookup()"| DOM["6 domains"]
+    DOM -->|"2 · semantic_lookup(domains=[...])"| SUMM["item one-line summaries"]
+    SUMM -->|"3 · semantic_lookup(ids=[...])"| BODY["full item bodies"]
     BODY -.->|knowledge| AG
     STORE[("context/items/*.md<br/>27-item semantic layer")] -.serves.-> DOM & SUMM & BODY
 
@@ -34,7 +34,7 @@ flowchart TD
 ## 2. Improving the system (from the logs)
 
 Each eval writes per-question JSONL plus `controllog` events/postings.
-`controllog-viz` renders trace cards (the `fetch_context` path the agent took, its
+`controllog-viz` renders trace cards (the `semantic_lookup` path the agent took, its
 SQL, and predicted vs gold). Every miss is triaged into one of three buckets, fixed
 at the **template-family** level (validated against *all* variations, not one gold),
 re-run for stability, and merged.
@@ -42,11 +42,11 @@ re-run for stability, and merged.
 ```mermaid
 flowchart TD
     RUN["asm evaluate --split test<br/>reasoning low · concurrency 15"] --> OUT["results/*.jsonl<br/>+ controllog/{events,postings}"]
-    OUT --> VIZ["controllog-viz review / dashboard<br/>trace cards: fetch_context path, SQL, pred vs gold"]
+    OUT --> VIZ["controllog-viz review / dashboard<br/>trace cards: semantic_lookup path, SQL, pred vs gold"]
     VIZ --> TRIAGE{"triage each miss"}
 
     TRIAGE -->|"context gap<br/>(wrong/missing rule)"| FIXC["edit the context item<br/>context/items/*.md"]
-    TRIAGE -->|"model-variance /<br/>didn't load the rule"| FIXS["promote rule to always-on SKILL<br/>+ sharpen summary / fetch_context"]
+    TRIAGE -->|"model-variance /<br/>didn't load the rule"| FIXS["promote rule to always-on SKILL<br/>+ sharpen summary / semantic_lookup"]
     TRIAGE -->|"gold noise<br/>(our SQL provably right)"| BAD["add to data/bad_golds.json<br/>(set aside)"]
 
     FIXC --> VAL["validate vs the WHOLE template family<br/>(not a single gold)"]

--- a/projects/agentic-sql-claude-edition/pyproject.toml
+++ b/projects/agentic-sql-claude-edition/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "agentic-sql-claude-edition"
 version = "0.1.0"
-description = "Skill + semantic-layer agent for DABStep: a compact skill + fetch_context progressive disclosure, aiming for 100% on the 26 template representatives."
+description = "Skill + semantic-layer agent for DABStep: a compact skill + semantic_lookup progressive disclosure, aiming for 100% on the 26 template representatives."
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [

--- a/projects/agentic-sql-claude-edition/skill/SKILL.md
+++ b/projects/agentic-sql-claude-edition/skill/SKILL.md
@@ -8,7 +8,7 @@ description: "IF the user asks a factoid question about the payments / fees / me
 
 You answer factoid questions about a synthetic Adyen-like payments dataset. The
 **knowledge you need is not in this prompt** — it lives in a context store you
-read on demand via `fetch_context`. This skill tells you *how* to work and
+read on demand via `semantic_lookup`. This skill tells you *how* to work and
 *where* each kind of knowledge lives. Read the relevant context **before** you
 write SQL; most wrong answers come from skipping it.
 
@@ -16,10 +16,10 @@ write SQL; most wrong answers come from skipping it.
 
 Before writing any SQL, load context progressively:
 
-1. `fetch_context()` — no arguments → the list of knowledge **domains**.
-2. `fetch_context(domains=["fees", "bucketing"])` — → a list of context **items**
+1. `semantic_lookup()` — no arguments → the list of knowledge **domains**.
+2. `semantic_lookup(domains=["fees", "bucketing"])` — → a list of context **items**
    in those domains, each as `id — one-line summary`.
-3. `fetch_context(ids=["fees-matching-9dim", "fees-formula"])` — → the **full
+3. `semantic_lookup(ids=["fees-matching-9dim", "fees-formula"])` — → the **full
    text** of the items you chose. Pass several ids at once.
 
 You do not need every domain for every question. Use PART 3 below to pick. The
@@ -122,7 +122,7 @@ SQL — without drilling into a domain (step 2) and reading the matching item bo
 
 ## PART 3 — DATA REFERENCES (which domain for which question)
 
-Call `fetch_context(domains=[...])` to browse, then `fetch_context(ids=[...])`.
+Call `semantic_lookup(domains=[...])` to browse, then `semantic_lookup(ids=[...])`.
 
 - **`schema`** — column dictionaries, table relationships, what "the dataset"
   means, type mismatches (e.g. MCC VARCHAR vs BIGINT). Fetch when unsure which

--- a/projects/agentic-sql-claude-edition/src/agent.py
+++ b/projects/agentic-sql-claude-edition/src/agent.py
@@ -1,14 +1,14 @@
-"""SQL agent with a semantic-layer `fetch_context` tool.
+"""SQL agent with a semantic-layer `semantic_lookup` tool.
 
 Five tools, one loop:
-  - `fetch_context` — the semantic layer (domains -> item summaries -> full bodies)
+  - `semantic_lookup` — the semantic layer (domains -> item summaries -> full bodies)
   - `list_tables`   — list tables/views in the target database
   - `list_columns`  — describe one table's columns
   - `query`         — run a SELECT, return up to 50 rows as text
   - `submit_answer` — submit the SQL whose result IS the answer
 
 The agent always has a compact SKILL (procedure + where-knowledge-lives) in its
-system prompt; the heavy domain knowledge is fetched on demand via fetch_context.
+system prompt; the heavy domain knowledge is fetched on demand via semantic_lookup.
 The DuckDB connection is MotherDuck-attached, so tools run against `md:<db>`.
 
 Provider/usage/caching machinery is ported from agentic-sql-mini unchanged.
@@ -36,7 +36,7 @@ from agents import (
 from agents.run import RunConfig
 from openai import AsyncOpenAI
 
-from src.context_store import ContextStore, render_fetch_context
+from src.context_store import ContextStore, render_semantic_lookup
 from src.score import ExecutionError
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -208,14 +208,14 @@ class OpenRouterProvider(ModelProvider):
 
 # Small, stable base. The bulk of "how to work" lives in SKILL.md (appended
 # below); the bulk of "what the data means" lives in the context store, fetched
-# on demand via fetch_context. Keep this lean — it is cached across questions.
+# on demand via semantic_lookup. Keep this lean — it is cached across questions.
 _BASE_SYSTEM_PROMPT = """You are an expert data analyst. You answer factoid questions by querying a payments database with SQL via tools.
 
 **Database:** {database}  (MotherDuck, DuckDB SQL). Schema: main.
 Use fully-qualified names when helpful: `{database}.main.table_name`.
 
 You have five tools:
-- `fetch_context` — the semantic layer. Knowledge about this dataset (fee rules, bucketing, terminology, SQL patterns, answer formatting) is NOT in this prompt; you fetch it on demand. See the Semantic Layer section of the skill below.
+- `semantic_lookup` — the semantic layer. Knowledge about this dataset (fee rules, bucketing, terminology, SQL patterns, answer formatting) is NOT in this prompt; you fetch it on demand. See the Semantic Layer section of the skill below.
 - `list_tables` — list tables/views.
 - `list_columns` — describe one table's columns.
 - `query` — run a SELECT (returns up to 50 rows).
@@ -297,7 +297,7 @@ def _make_tools(state: RunState) -> list:
         return cols, rows
 
     @function_tool
-    def fetch_context(domains: list[str] | None = None, ids: list[str] | None = None) -> str:
+    def semantic_lookup(domains: list[str] | None = None, ids: list[str] | None = None) -> str:
         """Fetch dataset knowledge progressively (the semantic layer).
 
         - Call with NO arguments to list the knowledge domains.
@@ -306,10 +306,10 @@ def _make_tools(state: RunState) -> list:
         - Call with `ids` (e.g. ["fees-matching-9dim"]) to read the FULL text of
           those items. You may pass several ids at once.
         """
-        out = render_fetch_context(state.store, domains=domains, ids=ids)
+        out = render_semantic_lookup(state.store, domains=domains, ids=ids)
         state.record(
             {
-                "tool": "fetch_context",
+                "tool": "semantic_lookup",
                 "domains": domains,
                 "ids": ids,
                 "result_chars": len(out),
@@ -382,7 +382,7 @@ def _make_tools(state: RunState) -> list:
         state.record({"tool": "submit_answer", "sql": sql, "rows": len(rows)})
         return f"Submitted. {len(rows)} rows."
 
-    return [fetch_context, list_tables, list_columns, query, submit_answer]
+    return [semantic_lookup, list_tables, list_columns, query, submit_answer]
 
 
 @dataclass

--- a/projects/agentic-sql-claude-edition/src/context_store.py
+++ b/projects/agentic-sql-claude-edition/src/context_store.py
@@ -1,4 +1,4 @@
-"""Semantic-layer context store backing the `fetch_context` tool.
+"""Semantic-layer context store backing the `semantic_lookup` tool.
 
 Knowledge that used to be dumped wholesale into the system prompt (fee-matching
 rules, bucketing logic, term mappings, SQL patterns, format rules) lives here as
@@ -15,9 +15,9 @@ each with YAML frontmatter:
 The agent navigates this store progressively, exactly like Anthropic's
 self-service-analytics semantic layer:
 
-    fetch_context()                      -> list of domains (+ one-line each)
-    fetch_context(domains=["fees"])      -> {id, summary} for every item in a domain
-    fetch_context(ids=["fees-matching-9dim"]) -> full body of those items
+    semantic_lookup()                      -> list of domains (+ one-line each)
+    semantic_lookup(domains=["fees"])      -> {id, summary} for every item in a domain
+    semantic_lookup(ids=["fees-matching-9dim"]) -> full body of those items
 
 Each domain also carries a one-sentence description, taken from a `domain:`
 description item if present, else synthesized from the domain name.
@@ -32,7 +32,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ITEMS_DIR = REPO_ROOT / "context" / "items"
 
-# One-line description per domain, shown by the no-arg fetch_context() call.
+# One-line description per domain, shown by the no-arg semantic_lookup() call.
 DOMAIN_DESCRIPTIONS: dict[str, str] = {
     "schema": "Tables, columns, relationships, and what 'the dataset' means.",
     "fees": "How fee rules match transactions and how the fee amount is computed.",
@@ -99,7 +99,7 @@ class ContextStore:
         extra = sorted(d for d in self._by_domain if d not in DOMAIN_ORDER)
         return known + extra
 
-    # -- the three fetch_context modes -------------------------------------
+    # -- the three semantic_lookup modes -------------------------------------
 
     def list_domains(self) -> list[dict]:
         out = []
@@ -163,8 +163,8 @@ def _split_arg(value) -> list[str]:
     return [str(value).strip()]
 
 
-def render_fetch_context(store: ContextStore, domains=None, ids=None) -> str:
-    """Render the fetch_context tool output for all three modes.
+def render_semantic_lookup(store: ContextStore, domains=None, ids=None) -> str:
+    """Render the semantic_lookup tool output for all three modes.
 
     Precedence: ids > domains > (neither -> domain list).
     """
@@ -185,7 +185,7 @@ def render_fetch_context(store: ContextStore, domains=None, ids=None) -> str:
             ditems, _ = store.list_items(as_domains)
             lines = [
                 f"[note: {', '.join(as_domains)} is a DOMAIN, not an item id — here are "
-                f"its items; call fetch_context(ids=[...]) with one of these:]"
+                f"its items; call semantic_lookup(ids=[...]) with one of these:]"
             ]
             for it in ditems:
                 lines.append(f"- {it['id']}  [{it['domain']}] — {it['summary']}")
@@ -194,12 +194,12 @@ def render_fetch_context(store: ContextStore, domains=None, ids=None) -> str:
         if truly_unknown:
             chunks.append(
                 f"[unknown ids: {', '.join(truly_unknown)}. To browse, call "
-                f"fetch_context(domains=[...]) — valid domains: {valid_domains}]"
+                f"semantic_lookup(domains=[...]) — valid domains: {valid_domains}]"
             )
         if not items and not as_domains:
             return (
                 f"No context found for ids: {', '.join(id_tokens)}. Call "
-                f"fetch_context(domains=[...]) to see valid ids. Domains: {valid_domains}"
+                f"semantic_lookup(domains=[...]) to see valid ids. Domains: {valid_domains}"
             )
         return "\n\n".join(chunks)
 
@@ -207,7 +207,7 @@ def render_fetch_context(store: ContextStore, domains=None, ids=None) -> str:
         items, unknown = store.list_items(domain_tokens)
         lines: list[str] = []
         if items:
-            lines.append("Context items (call fetch_context(ids=[...]) to read the full text):")
+            lines.append("Context items (call semantic_lookup(ids=[...]) to read the full text):")
             for it in items:
                 lines.append(f"- {it['id']}  [{it['domain']}] — {it['summary']}")
         if unknown:
@@ -218,7 +218,7 @@ def render_fetch_context(store: ContextStore, domains=None, ids=None) -> str:
         return "\n".join(lines)
 
     # No args -> list domains.
-    lines = ["Knowledge domains (call fetch_context(domains=[...]) to see items in one or more):"]
+    lines = ["Knowledge domains (call semantic_lookup(domains=[...]) to see items in one or more):"]
     for d in store.list_domains():
         lines.append(f"- {d['domain']} ({d['n_items']} items) — {d['description']}")
     return "\n".join(lines)

--- a/projects/agentic-sql-claude-edition/src/run.py
+++ b/projects/agentic-sql-claude-edition/src/run.py
@@ -105,11 +105,11 @@ def load(database: str | None) -> None:
 @click.option("--domains", default=None, help="Comma-separated domains to list items for.")
 @click.option("--ids", default=None, help="Comma-separated context ids to print in full.")
 def context_cmd(domains: str | None, ids: str | None) -> None:
-    """Inspect the semantic-layer context store (mirrors the fetch_context tool)."""
-    from src.context_store import render_fetch_context
+    """Inspect the semantic-layer context store (mirrors the semantic_lookup tool)."""
+    from src.context_store import render_semantic_lookup
 
     store = ContextStore()
-    console.print(render_fetch_context(store, domains=domains, ids=ids))
+    console.print(render_semantic_lookup(store, domains=domains, ids=ids))
 
 
 def _correctness_mark(c: str) -> str:
@@ -224,7 +224,7 @@ def _render_tool_call(call: dict, task_id: str | None = None) -> None:
             t.append(extra)
         return t
 
-    if tool == "fetch_context":
+    if tool == "semantic_lookup":
         domains = call.get("domains")
         ids = call.get("ids")
         if ids:


### PR DESCRIPTION
## What

Renames the agent-facing tool that reads the semantic layer from `fetch_context` to **`semantic_lookup`** in `projects/agentic-sql-claude-edition`. Pure rename, no behavior change — ports [motherduckdb/agentic-sql-claude-edition#5](https://github.com/motherduckdb/agentic-sql-claude-edition/pull/5) into the in-labs copy.

## Why

`fetch_context` framed the tool as generic "context," undercutting what it actually is — a structured, hierarchical **semantic layer**. `semantic_lookup` names the artifact and matches how we describe it: the agent *looks something up* in the layer. "lookup" also fits the progressive-disclosure behavior and doesn't collide with the existing `query` (SQL) tool.

## Scope

- Tool fn + registration in `src/agent.py`; base system-prompt tool list
- Controllog event name + replay check (`tool == "semantic_lookup"`) in `src/run.py`
- Helper `render_fetch_context` → `render_semantic_lookup` in `src/context_store.py`
- Prose/docs: `README.md`, `skill/SKILL.md`, `docs/how-it-works.md`, `docs/error-fixes.md`, `pyproject.toml`

Left unchanged: the `asm context` CLI subcommand (dev-facing surface) and historical `results/*.jsonl` traces.

## Verification

- `py_compile` clean on changed modules; no residual `fetch_context` outside historical `results/`.
- Smoke test on the 26 template representatives: **26/26 = 100%** ($0.56, 0 hit_limit).
- Runtime traces confirm the rename took effect: **55 `semantic_lookup` calls, 0 `fetch_context`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)