### PR TITLE
agentic-malloy: layer-improve — model-driven targeted layer repair + manner triage + tool-error meta-analysis

### DIFF
--- a/projects/agentic-malloy/README.md
+++ b/projects/agentic-malloy/README.md
@@ -110,9 +110,10 @@ human) complement to the rule above: it triages a run's misses and edits the lay
   tool over **15%** (`--tool-error-threshold`) gets a model diagnosis of the
   *systemic* cause + where the durable fix belongs. A layer-cause routes into the
   repair path (only if a view is actually broken); skill/linter causes become
-  precise recommendations — and `--apply-skill-fixes` appends the general rule to a
-  marked section of `src/skill.md` (the skill is a tunable prompt, not the layer, so
-  this doesn't touch `malloy_provenance`).
+  precise recommendations. A diagnosed `skill` rule is appended to a marked section
+  of `src/skill.md` **by default** (it only ever fires for a tool over the >15%
+  threshold, so it stays sparing) — `--no-apply-skill-fixes` to only recommend. The
+  skill is a tunable prompt, not the layer, so this never touches `malloy_provenance`.
 - **No leakage.** A repair prompt sees only the failing Malloy, exec diagnostics,
   "this view returns 0/errors", the column profile, and the manual — **never the
   gold answer**, and it must not tune to a train value. Fixes are general

--- a/projects/agentic-malloy/README.md
+++ b/projects/agentic-malloy/README.md
@@ -85,6 +85,33 @@ honest:
   **rerun `layer-build`** — then re-run `evaluate`. Hand-edits make the run
   `human_edited` and disqualify it from the official 26/26.
 
+## `layer-improve` — targeted, model-driven layer repair (stays model_authored)
+
+`asm-malloy layer-improve --from results/<run>.jsonl` is the MODEL-driven (never
+human) complement to the rule above: it triages a run's misses and edits the layer
+**only** for genuine structural defects, keeping provenance `model_authored`.
+
+- **Triage (the hard part).** For each `is_correct:false` row it re-runs the
+  submitted Malloy through the runtime and smoke-runs each named layer view it
+  referenced. A pure classifier (`classifyMiss`) decides, from that evidence alone:
+  a NAMED layer view that errors / is wrongly empty on its own ⇒ **layer** defect;
+  a query that re-runs fine but returns the wrong rows ⇒ **skill** (the agent's
+  inline filter/field/grain); no submission ⇒ **answering** (turn budget). Only
+  layer-suspected misses get a model verdict (which may downgrade to skill).
+- **No leakage.** A repair prompt sees only the failing Malloy, exec diagnostics,
+  "this view returns 0/errors", the column profile, and the manual — **never the
+  gold answer**, and it must not tune to a train value. Fixes are general
+  (join scope, wildcard/domain handling, grain), exactly like `layer-build`.
+- **Don't regress.** Edits are minimal atomic `{old,new}` patches, re-validated by
+  the same P0 gate (compile + execute every view). If the post-edit all-views gate
+  fails, **every edit is rolled back** and provenance is left untouched.
+- **Honest / idempotent.** When no miss is a structural layer defect (the common
+  case — the current layer is clean), it edits nothing, leaves the hash/provenance
+  untouched, and reports where each fix belongs (skill / prompt / model-capability).
+  On a successful edit it re-hashes, re-stamps `model_authored` with an
+  `improve_lineage` (from/to hash, round, edited files, source run), and emits a
+  controllog build run. `--re-eval` then re-runs the same task-ids to measure.
+
 ## Harness status
 
 End-to-end harness wired and unit-verified (all but a live eval, which needs

--- a/projects/agentic-malloy/README.md
+++ b/projects/agentic-malloy/README.md
@@ -96,8 +96,23 @@ human) complement to the rule above: it triages a run's misses and edits the lay
   referenced. A pure classifier (`classifyMiss`) decides, from that evidence alone:
   a NAMED layer view that errors / is wrongly empty on its own ⇒ **layer** defect;
   a query that re-runs fine but returns the wrong rows ⇒ **skill** (the agent's
-  inline filter/field/grain); no submission ⇒ **answering** (turn budget). Only
-  layer-suspected misses get a model verdict (which may downgrade to skill).
+  inline filter/field/grain); no submission ⇒ **answering** (turn budget). A layer
+  EDIT requires BOTH this structural probe AND a model verdict of `layer`.
+- **Manner of failure (from the logs).** It correlates the run to its controllog
+  (by `(task_id, submitted Malloy)`), pulls each miss's **tool trace**, and a model
+  verdict labels *how* it failed — `overspecified` · `underspecified` ·
+  `hallucination` · `layer_not_used` (the right view existed but the agent
+  hand-wrote raw Malloy) · `wrong_logic` · `gave_up` — with a recommended fix
+  (`skill` / `linter` / `layer` / `model`). The answer **shape** (scalar vs. list
+  vs. bracketed-list) and "did it reuse a named view" feed over/under-specification
+  reasoning — all gold-free (`--no-manner` restores the cheap deterministic-only path).
+- **Tool-error meta-analysis.** It aggregates the run's per-tool error rate; any
+  tool over **15%** (`--tool-error-threshold`) gets a model diagnosis of the
+  *systemic* cause + where the durable fix belongs. A layer-cause routes into the
+  repair path (only if a view is actually broken); skill/linter causes become
+  precise recommendations — and `--apply-skill-fixes` appends the general rule to a
+  marked section of `src/skill.md` (the skill is a tunable prompt, not the layer, so
+  this doesn't touch `malloy_provenance`).
 - **No leakage.** A repair prompt sees only the failing Malloy, exec diagnostics,
   "this view returns 0/errors", the column profile, and the manual — **never the
   gold answer**, and it must not tune to a train value. Fixes are general

--- a/projects/agentic-malloy/src/cli.ts
+++ b/projects/agentic-malloy/src/cli.ts
@@ -19,6 +19,7 @@ import { buildToolSchemas, newRunState, type ToolDeps } from './tools.js';
 import { runTask } from './agentic-loop.js';
 import { resolveModel } from './llm-client.js';
 import { buildLayer, hashLayerOnDisk, PROVENANCE_PATH } from './layer-build.js';
+import { improveLayer } from './layer-improve.js';
 import { uploadControllog } from './upload.js';
 import { runPool, makeSerializedWriter } from './pool.js';
 import * as cl from './controllog.js';
@@ -560,6 +561,49 @@ async function cmdLayerBuild(flags: Record<string, string | boolean>) {
   }
 }
 
+async function cmdLayerImprove(flags: Record<string, string | boolean>) {
+  const fromFlag = flags.from as string | undefined;
+  if (!fromFlag) throw new Error('layer-improve needs --from <results.jsonl> (an eval run to triage).');
+  const fromPath = path.isAbsolute(fromFlag) ? fromFlag : path.join(REPO_ROOT, fromFlag);
+  const model = resolveModel((flags.model as string) || 'opus');
+  const reasoning = (flags.reasoning as string) || 'medium';
+  const provider = (flags.provider as string) || process.env.OPENROUTER_PROVIDER || undefined;
+  const maxRounds = Number(flags['max-rounds'] ?? 4);
+  // Default: triage + validate against the LOCAL compile DB (credential-free,
+  // same data, matches the build gate). --md re-executes against MotherDuck.
+  const motherduckDb = flags.md ? ((flags.database as string) || process.env.MD_DATABASE || 'agentic_malloy') : undefined;
+
+  // Wrap in a controllog session so the improve pass shows in the dive's Build tab.
+  cl.init({ project: PROJECT_ID, logDir: RESULTS_DIR, agentId: 'agent:asm-malloy-builder' });
+  const session = cl.createSession();
+  const runId = cl.newId();
+  let res!: Awaited<ReturnType<typeof improveLayer>>;
+  await cl.runInSession(session, async () => {
+    res = await improveLayer({ fromPath, model, reasoningEffort: reasoning, provider, maxRounds, motherduckDb, runId });
+  });
+  await cl.flushSession(session);
+
+  console.log(`\n${res.summary}`);
+  console.log(`\n  cost $${res.cost.toFixed(4)} · improve run_id ${runId} logged to results/controllog`);
+  if (!res.ok) {
+    console.error(`\n✗ layer-improve did not complete cleanly: ${res.diagnostics}`);
+    process.exit(1);
+  }
+
+  // --re-eval: only meaningful when edits were applied. Re-run the SAME task-ids
+  // the --from run covered (passers + fixed) so both the fix AND no-regression
+  // are measured. A no-op edit set means nothing changed — skip.
+  if (flags['re-eval']) {
+    if (!res.editsApplied) {
+      console.log(`\n--re-eval skipped: no layer edits were applied (nothing changed to measure).`);
+      return;
+    }
+    const ids = (await readFile(fromPath, 'utf8')).split('\n').filter((l) => l.trim()).map((l) => String((JSON.parse(l) as { task_id: unknown }).task_id));
+    console.log(`\n▶ re-evaluating ${ids.length} task-id(s) from ${path.basename(fromPath)} to measure the improvement …`);
+    await cmdEvaluate({ ...flags, 'task-id': ids.join(','), from: undefined as unknown as string });
+  }
+}
+
 async function cmdUpload(flags: Record<string, string | boolean>) {
   const database = (flags.database as string) || process.env.CONTROLLOG_DB || 'agentic_malloy_logs';
   console.log(`Uploading controllog → MotherDuck ${database}.main.{events,postings} …`);
@@ -598,6 +642,8 @@ async function main() {
       return cmdPreflight();
     case 'layer-build':
       return cmdLayerBuild(flags);
+    case 'layer-improve':
+      return cmdLayerImprove(flags);
     case 'evaluate':
       return cmdEvaluate(flags);
     case 'upload':
@@ -605,9 +651,12 @@ async function main() {
     case 'summary':
       return cmdSummary(rest[0]);
     default:
-      console.log('usage: asm-malloy <load|malloy-preflight|layer-build|evaluate|upload|summary> [flags]');
+      console.log('usage: asm-malloy <load|malloy-preflight|layer-build|layer-improve|evaluate|upload|summary> [flags]');
       console.log('  load [--motherduck --database agentic_malloy]');
       console.log('  layer-build --model opus --reasoning medium [--no-manual] [--max-rounds 3] [--provider anthropic]');
+      console.log('  layer-improve --from results/RUN.jsonl [--model opus --reasoning medium --max-rounds 4] \\');
+      console.log('           [--provider anthropic] [--md [--database agentic_malloy]] [--re-eval --author sonnet --fixer opus --run-class official]');
+      console.log('           (triages a run\'s misses: edits the layer ONLY for structural defects, never tunes to a gold answer)');
       console.log('  evaluate --split templates|test|all --task-id ID --author sonnet --fixer opus \\');
       console.log('           --run-class smoke|official --escalate-after 2 --concurrency 4 --limit N [--provider anthropic]');
       console.log('           (--provider pins the OpenRouter upstream; defaults to $OPENROUTER_PROVIDER)');

--- a/projects/agentic-malloy/src/cli.ts
+++ b/projects/agentic-malloy/src/cli.ts
@@ -572,6 +572,12 @@ async function cmdLayerImprove(flags: Record<string, string | boolean>) {
   // Default: triage + validate against the LOCAL compile DB (credential-free,
   // same data, matches the build gate). --md re-executes against MotherDuck.
   const motherduckDb = flags.md ? ((flags.database as string) || process.env.MD_DATABASE || 'agentic_malloy') : undefined;
+  // --no-manner skips the per-miss failure-MANNER model call (cheaper; model
+  // call then fires only for layer-suspected misses). --apply-skill-fixes lets a
+  // diagnosed tool-error rule be appended to src/skill.md.
+  const manner = !flags['no-manner'];
+  const applySkillFixes = !!flags['apply-skill-fixes'];
+  const toolErrorThreshold = flags['tool-error-threshold'] ? Number(flags['tool-error-threshold']) : undefined;
 
   // Wrap in a controllog session so the improve pass shows in the dive's Build tab.
   cl.init({ project: PROJECT_ID, logDir: RESULTS_DIR, agentId: 'agent:asm-malloy-builder' });
@@ -579,7 +585,7 @@ async function cmdLayerImprove(flags: Record<string, string | boolean>) {
   const runId = cl.newId();
   let res!: Awaited<ReturnType<typeof improveLayer>>;
   await cl.runInSession(session, async () => {
-    res = await improveLayer({ fromPath, model, reasoningEffort: reasoning, provider, maxRounds, motherduckDb, runId });
+    res = await improveLayer({ fromPath, model, reasoningEffort: reasoning, provider, maxRounds, motherduckDb, manner, applySkillFixes, toolErrorThreshold, controllogDir: path.join(RESULTS_DIR, 'controllog'), runId });
   });
   await cl.flushSession(session);
 
@@ -655,8 +661,10 @@ async function main() {
       console.log('  load [--motherduck --database agentic_malloy]');
       console.log('  layer-build --model opus --reasoning medium [--no-manual] [--max-rounds 3] [--provider anthropic]');
       console.log('  layer-improve --from results/RUN.jsonl [--model opus --reasoning medium --max-rounds 4] \\');
-      console.log('           [--provider anthropic] [--md [--database agentic_malloy]] [--re-eval --author sonnet --fixer opus --run-class official]');
-      console.log('           (triages a run\'s misses: edits the layer ONLY for structural defects, never tunes to a gold answer)');
+      console.log('           [--provider anthropic] [--md [--database agentic_malloy]] [--no-manner] [--apply-skill-fixes] \\');
+      console.log('           [--tool-error-threshold 0.15] [--re-eval --author sonnet --fixer opus --run-class official]');
+      console.log('           (triages a run\'s misses by MANNER of failure + runs a tool-error meta-analysis;');
+      console.log('            edits the layer ONLY for structural defects, never tunes to a gold answer)');
       console.log('  evaluate --split templates|test|all --task-id ID --author sonnet --fixer opus \\');
       console.log('           --run-class smoke|official --escalate-after 2 --concurrency 4 --limit N [--provider anthropic]');
       console.log('           (--provider pins the OpenRouter upstream; defaults to $OPENROUTER_PROVIDER)');

--- a/projects/agentic-malloy/src/cli.ts
+++ b/projects/agentic-malloy/src/cli.ts
@@ -573,10 +573,11 @@ async function cmdLayerImprove(flags: Record<string, string | boolean>) {
   // same data, matches the build gate). --md re-executes against MotherDuck.
   const motherduckDb = flags.md ? ((flags.database as string) || process.env.MD_DATABASE || 'agentic_malloy') : undefined;
   // --no-manner skips the per-miss failure-MANNER model call (cheaper; model
-  // call then fires only for layer-suspected misses). --apply-skill-fixes lets a
-  // diagnosed tool-error rule be appended to src/skill.md.
+  // call then fires only for layer-suspected misses). Tool-error robustness rules
+  // are appended to src/skill.md BY DEFAULT (only ever triggered by a tool over
+  // the >15% error threshold, so it stays sparing); --no-apply-skill-fixes opts out.
   const manner = !flags['no-manner'];
-  const applySkillFixes = !!flags['apply-skill-fixes'];
+  const applySkillFixes = !flags['no-apply-skill-fixes'];
   const toolErrorThreshold = flags['tool-error-threshold'] ? Number(flags['tool-error-threshold']) : undefined;
 
   // Wrap in a controllog session so the improve pass shows in the dive's Build tab.
@@ -661,10 +662,11 @@ async function main() {
       console.log('  load [--motherduck --database agentic_malloy]');
       console.log('  layer-build --model opus --reasoning medium [--no-manual] [--max-rounds 3] [--provider anthropic]');
       console.log('  layer-improve --from results/RUN.jsonl [--model opus --reasoning medium --max-rounds 4] \\');
-      console.log('           [--provider anthropic] [--md [--database agentic_malloy]] [--no-manner] [--apply-skill-fixes] \\');
+      console.log('           [--provider anthropic] [--md [--database agentic_malloy]] [--no-manner] [--no-apply-skill-fixes] \\');
       console.log('           [--tool-error-threshold 0.15] [--re-eval --author sonnet --fixer opus --run-class official]');
       console.log('           (triages a run\'s misses by MANNER of failure + runs a tool-error meta-analysis;');
-      console.log('            edits the layer ONLY for structural defects, never tunes to a gold answer)');
+      console.log('            edits the layer ONLY for structural defects, never tunes to a gold answer;');
+      console.log('            tool-error robustness rules are appended to src/skill.md by default → --no-apply-skill-fixes to only recommend)');
       console.log('  evaluate --split templates|test|all --task-id ID --author sonnet --fixer opus \\');
       console.log('           --run-class smoke|official --escalate-after 2 --concurrency 4 --limit N [--provider anthropic]');
       console.log('           (--provider pins the OpenRouter upstream; defaults to $OPENROUTER_PROVIDER)');

--- a/projects/agentic-malloy/src/layer-build.ts
+++ b/projects/agentic-malloy/src/layer-build.ts
@@ -23,10 +23,10 @@ import { LOCAL_DB_PATH, buildLocalDuckDB } from './load.js';
 import * as cl from './controllog.js';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const DATA_DIR = path.join(REPO_ROOT, 'data');
+export const DATA_DIR = path.join(REPO_ROOT, 'data');
 const MALLOY_DIR = path.join(REPO_ROOT, 'malloy');
-const MODELS_DIR = path.join(MALLOY_DIR, 'models');
-const META_DIR = path.join(MALLOY_DIR, '_meta');
+export const MODELS_DIR = path.join(MALLOY_DIR, 'models');
+export const META_DIR = path.join(MALLOY_DIR, '_meta');
 export const PROVENANCE_PATH = path.join(MALLOY_DIR, '.provenance.json');
 const TABLES = ['payments', 'fees', 'merchants', 'acquirer_countries', 'merchant_category_codes'];
 
@@ -132,12 +132,12 @@ async function trainQA(includeAnswers: boolean): Promise<string> {
 }
 
 const DOCS_DIR = path.join(REPO_ROOT, 'docs', 'malloy');
-async function readDoc(name: string): Promise<string> {
+export async function readDoc(name: string): Promise<string> {
   return readFile(path.join(DOCS_DIR, name), 'utf8');
 }
 
 // DuckDB-specifics the primer doesn't cover + the Malloy-first rule + output format.
-const DUCKDB_NOTES = `Malloy-on-DuckDB specifics (in addition to the primer above):
+export const DUCKDB_NOTES = `Malloy-on-DuckDB specifics (in addition to the primer above):
 - Reference a table by NAME: \`duckdb.table('payments')\` — never a file path. The model files compile as ONE unit (concatenated), so do NOT use \`import\`; every source sees every other.
 - Do NOT redefine an existing table column as a dimension/measure (e.g. \`dimension: merchant is ...\` when a \`merchant\` column exists → "Cannot redefine"). Only ADD derived fields with NEW names.
 - ANY DuckDB SQL function the primer doesn't list needs the TYPED raw escape \`fn!returntype(args)\` — e.g. \`list_contains!boolean(fees.aci, aci)\`, \`len!number(fees.aci)\`, \`lpad!string(x, 3, '0')\`, \`strftime!string(d, '%Y')\`, \`make_date!date(y, m, d)\`. Plain \`lpad(...)\`/\`strftime(...)\` fail with "Unknown function". There is no native list-membership operator — use \`list_contains!boolean\` for list columns. Prefer Malloy-native date ops (\`@2023\`, \`.month\`, \`::date\`) over SQL date formatting where possible.
@@ -161,7 +161,7 @@ Output EXACTLY two fenced blocks and nothing else:
 // ---------------------------------------------------------------------------
 
 /** Parse a JSON array of {old,new} search/replace edits from a repair response. */
-function parseEdits(text: string): Array<{ old: string; new: string }> {
+export function parseEdits(text: string): Array<{ old: string; new: string }> {
   const m = text.match(/\[[\s\S]*\]/);
   try {
     const arr = JSON.parse(m ? m[0] : text) as Array<{ old?: unknown; new?: unknown }>;
@@ -200,7 +200,7 @@ async function clearLayer(): Promise<void> {
 
 /** Source names declared in a model file — targets the execution smoke test at
  *  the sources this file actually introduces (not inherited ones). */
-function sourceNamesIn(src: string): string[] {
+export function sourceNamesIn(src: string): string[] {
   return [...src.matchAll(/^[ \t]*source:[ \t]*([A-Za-z_][A-Za-z0-9_]*)[ \t]+is\b/gm)].map((m) => m[1]);
 }
 
@@ -213,7 +213,7 @@ function sourceNamesIn(src: string): string[] {
  * that class of bug, leaving every fee view unusable at answer time. The first
  * execution failure is returned as a diagnostic so the repair loop fixes it.
  */
-async function validateModel(modelFile?: string): Promise<{ ok: boolean; diag: string }> {
+export async function validateModel(modelFile?: string): Promise<{ ok: boolean; diag: string }> {
   const rt = new MalloyRuntime();
   try {
     const inv = await rt.describe(); // compile check (throws on compile error)

--- a/projects/agentic-malloy/src/layer-improve.test.ts
+++ b/projects/agentic-malloy/src/layer-improve.test.ts
@@ -15,10 +15,12 @@ import {
   identifiersIn,
   classifyMiss,
   evidenceBlock,
+  traceBlock,
   analyzeMiss,
   type MissAnalysis,
   type MissClassification,
 } from './layer-improve.js';
+import type { TaskTrace } from './run-log.js';
 import type { MalloyRuntime } from './malloy-runtime.js';
 
 // A miniature layer mirroring the real f2163373 structure: a lens source in
@@ -180,5 +182,27 @@ describe('no leakage', () => {
     expect(ev).toContain('avg fee for NexPay'); // the question (intent) is allowed
     expect(ev).toContain('5.757053'); // the agent's OWN predicted output is structural evidence
     expect(ev).not.toContain('5.715872'); // the GOLD answer must never appear
+  });
+
+  it('the trace block surfaces the agent actions + answer shape but never the gold', () => {
+    const trace: TaskTrace = {
+      taskId: '1290',
+      steps: [
+        { name: 'list_malloy_files', ok: true, args: {} },
+        { name: 'run_malloy', ok: false, output: 'compile error' },
+        { name: 'submit_answer', ok: true, args: { source: 'run: rules_lens -> {}' } },
+      ],
+      exploredLayer: true,
+      runMalloyErrors: 1,
+      submitErrors: 0,
+      toolCalls: 3,
+    };
+    const tb = traceBlock(trace, '5.757053', true);
+    expect(tb).toContain('list_malloy_files');
+    expect(tb).toContain('run_malloy');
+    expect(tb).toContain('Explored the layer');
+    expect(tb).toContain('Reused a NAMED layer view');
+    expect(tb).toContain('scalar'); // answer-shape signal (shape only, not the value)
+    expect(tb).not.toContain('5.715872'); // gold never enters the trace evidence
   });
 });

--- a/projects/agentic-malloy/src/layer-improve.test.ts
+++ b/projects/agentic-malloy/src/layer-improve.test.ts
@@ -1,0 +1,184 @@
+/**
+ * layer-improve unit tests. Two pieces the handoff calls out specifically:
+ *  - the MISS → FILE mapping (which layer file a submitted query implicates), and
+ *  - the LAYER-vs-SKILL triage (classifyMiss, a pure function over re-execution
+ *    evidence — the hard, valuable part).
+ * Plus a no-leakage assertion: the evidence fed to the model never carries the
+ * gold answer. No credentials / runtime needed — the structural-defect probe is
+ * modeled as plain MissAnalysis inputs.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildLayerIndex,
+  mapMalloyToFiles,
+  referencedViews,
+  identifiersIn,
+  classifyMiss,
+  evidenceBlock,
+  analyzeMiss,
+  type MissAnalysis,
+  type MissClassification,
+} from './layer-improve.js';
+import type { MalloyRuntime } from './malloy-runtime.js';
+
+// A miniature layer mirroring the real f2163373 structure: a lens source in
+// dabstep.malloy, a fee-match source + views in c3, base views in fees_base.
+const BODIES: Record<string, string> = {
+  'fees_base.malloy': `source: fees_base is duckdb.table('fees') extend {
+  measure: avg_fee is avg(fee)
+  view: by_card_scheme is { group_by: card_scheme; aggregate: avg_fee }
+}`,
+  'dabstep.malloy': `source: rules_lens is fees_base extend {
+  dimension: avg_fee_1000eur is fixed_amount + rate
+  view: by_card_scheme_avg_fee is { group_by: card_scheme; aggregate: m is avg(avg_fee_1000eur) }
+}`,
+  'c3_fee_assignment.malloy': `source: fee_match is fee_match_facts extend {
+  measure: total_fee_amount is matched.sum(matched.fee)
+  view: total_fees_by_merchant_year is { group_by: merchant, year; aggregate: total_fee_amount }
+  view: total_fees_by_merchant_month is { group_by: merchant, month; aggregate: total_fee_amount }
+}`,
+};
+
+const INDEX = buildLayerIndex(BODIES);
+
+describe('miss → file mapping', () => {
+  it('indexes every source and view to its defining file', () => {
+    expect(INDEX.sources.has('fees_base')).toBe(true);
+    expect(INDEX.sources.has('rules_lens')).toBe(true);
+    expect(INDEX.sources.has('fee_match')).toBe(true);
+    expect(INDEX.views.has('total_fees_by_merchant_year')).toBe(true);
+    expect(INDEX.fileOf.get('rules_lens')).toBe('dabstep.malloy');
+    expect(INDEX.fileOf.get('total_fees_by_merchant_year')).toBe('c3_fee_assignment.malloy');
+    expect(INDEX.fileOf.get('by_card_scheme')).toBe('fees_base.malloy');
+  });
+
+  it('maps a query on a lens source to the file that defines the source', () => {
+    const src = `run: rules_lens -> { where: card_scheme = 'NexPay'; aggregate: m is avg(avg_fee_1000eur) }`;
+    expect(mapMalloyToFiles(src, INDEX)).toEqual(['dabstep.malloy']);
+  });
+
+  it('maps a bare named-view query to the file defining the source AND the view', () => {
+    const src = `run: fee_match -> total_fees_by_merchant_year`;
+    expect(mapMalloyToFiles(src, INDEX)).toEqual(['c3_fee_assignment.malloy']);
+    expect(referencedViews(src, INDEX)).toEqual(['total_fees_by_merchant_year']);
+  });
+
+  it('ignores tokens that are not known sources/views (keywords, fields, literals)', () => {
+    const src = `run: rules_lens -> { group_by: card_scheme; aggregate: avg_fee }`;
+    // card_scheme / avg_fee / group_by are fields/keywords, not source/view names.
+    expect(mapMalloyToFiles(src, INDEX)).toEqual(['dabstep.malloy']);
+    expect(referencedViews(src, INDEX)).toEqual([]);
+  });
+
+  it('returns no files for an empty / non-submission', () => {
+    expect(mapMalloyToFiles('', INDEX)).toEqual([]);
+    expect(identifiersIn('a a b a')).toEqual(['a', 'b']);
+  });
+});
+
+// --- triage (classifyMiss) ---------------------------------------------------
+
+function baseAnalysis(over: Partial<MissAnalysis>): MissAnalysis {
+  return {
+    taskId: 't',
+    submitted: true,
+    hitLimit: false,
+    malloySource: 'run: rules_lens -> { aggregate: m is avg(avg_fee_1000eur) }',
+    reExec: { ok: true, rowCount: 1 },
+    viewProbes: [],
+    implicatedFiles: ['dabstep.malloy'],
+    ...over,
+  };
+}
+
+describe('layer-vs-skill triage (classifyMiss)', () => {
+  it('NO SUBMISSION → answering, never the layer', () => {
+    const c = classifyMiss(baseAnalysis({ submitted: false, hitLimit: true, malloySource: null, reExec: null }));
+    expect(c.category).toBe('no_submission');
+    expect(c.suggestedOwner).toBe('answering');
+    expect(c.layerSuspected).toBe(false);
+  });
+
+  it('1290-style: query re-runs fine and returns rows → SKILL (agent inline logic), NOT layer', () => {
+    // The agent filtered `is_credit = true` and dropped the wildcard rules: the
+    // query is valid and returns a row, just the wrong one. The layer is fine.
+    const c = classifyMiss(baseAnalysis({ reExec: { ok: true, rowCount: 1 }, viewProbes: [] }));
+    expect(c.category).toBe('query_wrong_answer');
+    expect(c.suggestedOwner).toBe('skill');
+    expect(c.layerSuspected).toBe(false);
+  });
+
+  it('a referenced layer VIEW that errors on its own → LAYER (structural defect)', () => {
+    const c = classifyMiss(
+      baseAnalysis({
+        reExec: { ok: false, rowCount: 0, error: 'Referenced table not found' },
+        viewProbes: [{ source: 'fee_match', view: 'total_fees_by_merchant_year', file: 'c3_fee_assignment.malloy', ok: false, rowCount: 0, error: 'Referenced table not found' }],
+      }),
+    );
+    expect(c.category).toBe('layer_view_error');
+    expect(c.suggestedOwner).toBe('layer');
+    expect(c.layerSuspected).toBe(true);
+    // the broken view's file is surfaced first.
+    expect(c.implicatedFiles[0]).toBe('c3_fee_assignment.malloy');
+  });
+
+  it('submitted query errors but every referenced view runs clean → SKILL (inline query bug)', () => {
+    const c = classifyMiss(
+      baseAnalysis({
+        reExec: { ok: false, rowCount: 0, error: "Unknown function 'lpad'" },
+        viewProbes: [{ source: 'fee_match', view: 'total_fees_by_merchant_year', file: 'c3_fee_assignment.malloy', ok: true, rowCount: 5 }],
+      }),
+    );
+    expect(c.category).toBe('query_compile_error');
+    expect(c.suggestedOwner).toBe('skill');
+    expect(c.layerSuspected).toBe(false);
+  });
+
+  it('query empty AND a referenced view empty on its own → LAYER-suspected (model confirms)', () => {
+    const c = classifyMiss(
+      baseAnalysis({
+        reExec: { ok: true, rowCount: 0 },
+        viewProbes: [{ source: 'fee_match', view: 'total_fees_by_merchant_year', file: 'c3_fee_assignment.malloy', ok: true, rowCount: 0 }],
+      }),
+    );
+    expect(c.category).toBe('layer_view_empty');
+    expect(c.suggestedOwner).toBe('layer');
+    expect(c.layerSuspected).toBe(true);
+  });
+
+  it('query empty but the views it used are non-empty → SKILL (agent over-filtered)', () => {
+    const c = classifyMiss(
+      baseAnalysis({
+        reExec: { ok: true, rowCount: 0 },
+        viewProbes: [{ source: 'fee_match', view: 'total_fees_by_merchant_year', file: 'c3_fee_assignment.malloy', ok: true, rowCount: 9 }],
+      }),
+    );
+    expect(c.category).toBe('query_wrong_answer');
+    expect(c.suggestedOwner).toBe('skill');
+    expect(c.layerSuspected).toBe(false);
+  });
+});
+
+// --- no leakage --------------------------------------------------------------
+
+describe('no leakage', () => {
+  it('the evidence block fed to the model never contains the gold answer', async () => {
+    // A fake runtime so analyzeMiss runs without credentials. The row carries a
+    // gold_answer — analyzeMiss must never surface it into the evidence.
+    const fakeRt = {
+      run: async () => ({ ok: true, rows: [{ x: 1 }] }),
+    } as unknown as MalloyRuntime;
+    const a = await analyzeMiss(
+      { task_id: '1290', question: 'avg fee for NexPay credit?', is_correct: false, submitted: true, malloy_source: 'run: rules_lens -> { aggregate: m is avg(avg_fee_1000eur) }', predicted_answer: '5.757053', gold_answer: '5.715872' } as never,
+      fakeRt,
+      INDEX,
+      new Map(),
+    );
+    const cls: MissClassification = classifyMiss(a);
+    const ev = evidenceBlock(a, cls);
+    expect(ev).toContain('1290');
+    expect(ev).toContain('avg fee for NexPay'); // the question (intent) is allowed
+    expect(ev).toContain('5.757053'); // the agent's OWN predicted output is structural evidence
+    expect(ev).not.toContain('5.715872'); // the GOLD answer must never appear
+  });
+});

--- a/projects/agentic-malloy/src/layer-improve.ts
+++ b/projects/agentic-malloy/src/layer-improve.ts
@@ -42,8 +42,19 @@ import {
   DATA_DIR,
 } from './layer-build.js';
 import * as cl from './controllog.js';
+import {
+  loadControllog,
+  correlateRun,
+  taskTrace,
+  toolErrorStats,
+  answerShape,
+  DEFAULT_CONTROLLOG_DIR,
+  type TaskTrace,
+  type ToolErrorStat,
+} from './run-log.js';
 
 const TABLES = ['payments', 'fees', 'merchants', 'acquirer_countries', 'merchant_category_codes'];
+const SKILL_PATH = path.join(MODELS_DIR, '..', '..', 'src', 'skill.md');
 
 // ---------------------------------------------------------------------------
 // Miss rows (the --from JSONL shape) — see cli.ts runEvalTask's `row`.
@@ -395,61 +406,175 @@ export function evidenceBlock(a: MissAnalysis, cls: MissClassification): string 
 }
 
 // ---------------------------------------------------------------------------
-// Model triage verdict (only for layer-SUSPECTED misses) — may downgrade.
+// Trace evidence (the MANNER-of-failure inputs) — derived from the run's tool
+// trace, structural-only (NO gold answer).
 // ---------------------------------------------------------------------------
 
-export interface TriageVerdict {
+/** Summarize one task's tool trace for a model prompt — the agent's OWN actions
+ *  (tool calls, args, ok/error), how it explored the layer, and its answer shape.
+ *  No gold answer; the predicted answer is the agent's own output. */
+export function traceBlock(trace: TaskTrace | null, predicted: unknown, usedNamedView: boolean): string {
+  const shape = answerShape(predicted);
+  const lines: string[] = [];
+  if (trace) {
+    lines.push(`Tool-call trace (the agent's own actions, in order):`);
+    for (const s of trace.steps) {
+      const a = s.args !== undefined ? ` ${JSON.stringify(s.args).slice(0, 120)}` : '';
+      const out = !s.ok ? `: ${(s.output ?? '').slice(0, 160)}` : '';
+      lines.push(`  ${s.name}${a} -> ${s.ok ? 'ok' : 'ERROR'}${out}`);
+    }
+    lines.push(`Explored the layer (list_malloy_files/get_file): ${trace.exploredLayer ? 'yes' : 'NO'}. run_malloy errors: ${trace.runMalloyErrors}. submit errors: ${trace.submitErrors}.`);
+  } else {
+    lines.push(`(no tool trace available for this task — judging from the submitted Malloy + answer shape only)`);
+  }
+  lines.push(`Reused a NAMED layer view/measure in the final answer: ${usedNamedView ? 'yes' : 'NO'}.`);
+  lines.push(`Submitted answer shape: ${shape.kind}${shape.count > 1 ? ` (${shape.count} items)` : ''}.`);
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Model verdict per miss: WHERE the fix belongs (owner) + the MANNER of failure
+// + a recommended fix. Structural evidence + trace only — NO gold answer.
+// ---------------------------------------------------------------------------
+
+export type FailureManner =
+  | 'overspecified' // answer too broad/precise vs. the question (extra rows/columns/precision)
+  | 'underspecified' // answer too narrow vs. the question (missing rows/dimensions)
+  | 'hallucination' // invented entities/fields/values not in the data or layer
+  | 'layer_not_used' // the layer had an answer-shaped view but the agent wrote raw/inline instead
+  | 'wrong_logic' // correct shape, wrong computation (filter/grain/ranking/missed wildcard)
+  | 'gave_up' // never submitted (turn budget / thrash)
+  | 'other';
+
+export interface MissVerdict {
   owner: MissOwner;
+  manner: FailureManner;
   file: string | null;
-  defect: string;
+  defect: string; // one-line STRUCTURAL defect, only when owner==='layer'
+  fix: { kind: 'skill' | 'linter' | 'layer' | 'model'; detail: string };
   rationale: string;
 }
 
-const TRIAGE_SYSTEM = `You are triaging a FAILED data question against a Malloy semantic layer. Decide WHERE the fix belongs:
-- "layer": a STRUCTURAL defect in a layer source/view itself (it errors at execution, or a matching/aggregating view returns 0/empty over rows that exist, or it computes at the wrong grain). The fix is a minimal edit to the layer file, justified ONLY by the manual + the data's actual encodings — NOT by any specific answer value.
-- "skill": the layer is fine; the answering agent wrote the wrong per-query Malloy (under-filtered, wrong field, wrong grain, missed a wildcard branch, bad inline syntax) or never submitted. The fix belongs in the answering SKILL / prompt, not the layer.
-- "model": neither — a model-capability / reasoning gap on a hard compositional question that no layer or skill edit cleanly fixes.
+const MISS_SYSTEM = `You are triaging a FAILED data question answered against a Malloy semantic layer. You must report (a) the MANNER of failure, (b) WHERE the fix belongs, and (c) the fix.
 
-You are given STRUCTURAL evidence only (failing Malloy, execution diagnostics, per-view probes, the column profile, the manual). You are NOT given the gold answer and MUST NOT ask for it or tune anything to a value. A layer verdict is justified ONLY when a NAMED layer view, exercised on its own, is itself broken (errors or is wrongly empty/at the wrong grain). If the submitted query runs and returns rows and the wrongness is in the agent's own filter/field/ranking, that is "skill", not "layer".
+(a) manner — exactly one of:
+- "overspecified": the answer is broader / more precise than asked (extra rows, extra columns, too many decimals, a list where one value was wanted).
+- "underspecified": the answer is narrower than asked (missing rows/dimensions, one value where a list was wanted, dropped a category).
+- "hallucination": the answer (or the Malloy) references entities, fields, columns, or values that do not exist in the data or the layer.
+- "layer_not_used": the layer already exposes an answer-shaped view/measure for this question, but the agent ignored it and hand-wrote raw/inline logic (or never opened the right file).
+- "wrong_logic": right shape, wrong computation — a wrong filter, wrong grain, wrong ranking, or a missed wildcard/NULL branch in the agent's OWN inline query.
+- "gave_up": the agent never submitted (ran out of turns / thrashed).
+- "other".
 
-Return ONLY a JSON object: {"owner":"layer|skill|model","file":"<implicated .malloy file or null>","defect":"<one-sentence structural description, or empty>","rationale":"<one sentence>"}.`;
+(b) owner — where the fix belongs:
+- "layer": a STRUCTURAL defect in a layer source/view itself (errors at execution, or a matching/aggregating view is wrongly empty over rows that exist, or wrong grain). Justified ONLY when a NAMED layer view, run on its own, is itself broken — never because the agent's own inline query was wrong.
+- "skill": the layer is fine; fix the answering SKILL/prompt (the agent under-filtered, used the wrong field/grain, missed a wildcard, didn't reuse an existing view, or wrote bad inline Malloy).
+- "model": a model-capability/reasoning gap on a hard compositional question that no layer or skill edit cleanly fixes.
 
-export async function triageVerdict(opts: {
+(c) fix.kind ∈ {skill, linter, layer, model} with a one-line GENERAL detail (a reusable rule — NEVER a DABstep-specific fact or a target value).
+
+CONSTRAINTS: you are given STRUCTURAL evidence and the agent's own trace ONLY. You are NOT given the gold answer and MUST NOT tune anything to a value. If the submitted query runs and returns rows and the wrongness is in the agent's own filter/field/ranking, the owner is "skill", not "layer".
+
+Return ONLY JSON: {"manner":"...","owner":"layer|skill|model","file":"<implicated .malloy file or null>","defect":"<one-line structural defect or empty>","fix":{"kind":"skill|linter|layer|model","detail":"<general rule>"},"rationale":"<one sentence>"}.`;
+
+interface ModelCallMeta {
+  cost: number;
+  promptTokens: number;
+  completionTokens: number;
+  cachedTokens: number;
+  cacheWriteTokens: number;
+  raw: string;
+}
+
+export async function missVerdict(opts: {
   evidence: string;
-  implicatedFileSrc: string;
-  implicatedFile: string;
+  trace: string;
+  implicatedFileSrc: string | null;
+  implicatedFile: string | null;
   profiles: string;
   manual: string;
   model: string;
   reasoningEffort?: string;
   provider?: string;
-}): Promise<TriageVerdict & { cost: number; promptTokens: number; completionTokens: number; cachedTokens: number; cacheWriteTokens: number; raw: string }> {
-  const user = `## Failure evidence (structural — NO gold answer)\n${opts.evidence}\n\n## The implicated layer file \`${opts.implicatedFile}\`\n\`\`\`malloy\n${opts.implicatedFileSrc}\n\`\`\`\n\n## Column profiles (actual encodings + domains — ground truth)\n${opts.profiles}\n\n## The Merchant Manual\n${opts.manual}\n\nReturn the triage JSON now.`;
+}): Promise<MissVerdict & ModelCallMeta> {
+  const fileBlock = opts.implicatedFile && opts.implicatedFileSrc
+    ? `## The implicated layer file \`${opts.implicatedFile}\`\n\`\`\`malloy\n${opts.implicatedFileSrc}\n\`\`\`\n\n`
+    : '';
+  const user = `## Failure evidence (structural — NO gold answer)\n${opts.evidence}\n\n## The agent's run trace\n${opts.trace}\n\n${fileBlock}## Column profiles (actual encodings + domains — ground truth)\n${opts.profiles}\n\n## The Merchant Manual\n${opts.manual}\n\nReturn the triage JSON now.`;
   const resp = await complete({
     model: opts.model,
-    systemPrompt: TRIAGE_SYSTEM,
+    systemPrompt: MISS_SYSTEM,
     userPrompt: user,
     reasoningEffort: opts.reasoningEffort,
     provider: opts.provider,
-    maxTokens: 2000,
+    maxTokens: 2500,
   });
-  let v: TriageVerdict = { owner: 'skill', file: opts.implicatedFile, defect: '', rationale: 'parse failure → defaulted to skill (no layer edit)' };
+  const meta: ModelCallMeta = { cost: resp.cost ?? 0, promptTokens: resp.promptTokens, completionTokens: resp.completionTokens, cachedTokens: resp.cachedTokens, cacheWriteTokens: resp.cacheWriteTokens, raw: resp.text };
+  // Safe default: skill / other, no layer edit.
+  let v: MissVerdict = { owner: 'skill', manner: 'other', file: opts.implicatedFile, defect: '', fix: { kind: 'skill', detail: '' }, rationale: 'parse failure → defaulted to skill (no layer edit)' };
   try {
     const m = resp.text.match(/\{[\s\S]*\}/);
-    const parsed = JSON.parse(m ? m[0] : resp.text) as Partial<TriageVerdict>;
+    const parsed = JSON.parse(m ? m[0] : resp.text) as Partial<MissVerdict>;
     const owner = parsed.owner;
-    if (owner === 'layer' || owner === 'skill' || owner === 'model') {
-      v = {
-        owner,
-        file: typeof parsed.file === 'string' && parsed.file ? parsed.file : opts.implicatedFile,
-        defect: String(parsed.defect ?? ''),
-        rationale: String(parsed.rationale ?? ''),
-      };
-    }
+    const manner = parsed.manner;
+    const fix = parsed.fix as MissVerdict['fix'] | undefined;
+    v = {
+      owner: owner === 'layer' || owner === 'skill' || owner === 'model' || owner === 'answering' ? owner : 'skill',
+      manner: (['overspecified', 'underspecified', 'hallucination', 'layer_not_used', 'wrong_logic', 'gave_up', 'other'] as FailureManner[]).includes(manner as FailureManner) ? (manner as FailureManner) : 'other',
+      file: typeof parsed.file === 'string' && parsed.file ? parsed.file : opts.implicatedFile,
+      defect: String(parsed.defect ?? ''),
+      fix: { kind: fix && ['skill', 'linter', 'layer', 'model'].includes(fix.kind) ? fix.kind : 'skill', detail: String(fix?.detail ?? '') },
+      rationale: String(parsed.rationale ?? ''),
+    };
   } catch {
-    /* keep the safe skill default */
+    /* keep the safe default */
   }
-  return { ...v, cost: resp.cost ?? 0, promptTokens: resp.promptTokens, completionTokens: resp.completionTokens, cachedTokens: resp.cachedTokens, cacheWriteTokens: resp.cacheWriteTokens, raw: resp.text };
+  return { ...v, ...meta };
+}
+
+// ---------------------------------------------------------------------------
+// Tool-error meta-analysis: a tool that errors too often (>15%) gets a model
+// diagnosis of the SYSTEMIC cause + where the fix belongs.
+// ---------------------------------------------------------------------------
+
+export interface ToolDiagnosis {
+  cause: string;
+  fixKind: 'skill' | 'linter' | 'layer' | 'unknown';
+  detail: string; // a GENERAL rule (no DABstep facts)
+  file: string | null; // layer file, only when fixKind==='layer'
+}
+
+const TOOL_DIAG_SYSTEM = `A tool in an LLM data-analysis loop is FAILING TOO OFTEN across a run. Given the tool's role and a sample of its error outputs, diagnose the SYSTEMIC cause and say where the durable fix belongs:
+- "skill": the answering prompt/SKILL should teach the agent to avoid this (e.g. "don't use select: in a grouping query", "filter wildcard rules with (col = x or col is null)").
+- "linter": a deterministic pre-submit transform should auto-fix it (e.g. strip stray \`import\` lines, normalize a known function name).
+- "layer": a layer view/source is itself broken and the agent keeps tripping on it (rare).
+The detail MUST be a GENERAL, reusable rule — never a dataset-specific fact or a target answer value.
+Return ONLY JSON: {"cause":"<one line>","fixKind":"skill|linter|layer|unknown","detail":"<general rule>","file":"<layer .malloy file or null>"}.`;
+
+export async function diagnoseToolError(opts: {
+  stat: ToolErrorStat;
+  manual: string;
+  model: string;
+  reasoningEffort?: string;
+  provider?: string;
+}): Promise<ToolDiagnosis & ModelCallMeta> {
+  const user = `## Tool failing too often\nTool: ${opts.stat.tool}\nError rate: ${(opts.stat.rate * 100).toFixed(1)}% (${opts.stat.errors}/${opts.stat.calls} calls)\n\n## Sample error outputs\n${opts.stat.samples.map((s, i) => `${i + 1}. ${s}`).join('\n') || '(none captured)'}\n\nDiagnose the systemic cause and the fix location. Return the JSON now.`;
+  const resp = await complete({ model: opts.model, systemPrompt: TOOL_DIAG_SYSTEM, userPrompt: user, reasoningEffort: opts.reasoningEffort, provider: opts.provider, maxTokens: 1200 });
+  const meta: ModelCallMeta = { cost: resp.cost ?? 0, promptTokens: resp.promptTokens, completionTokens: resp.completionTokens, cachedTokens: resp.cachedTokens, cacheWriteTokens: resp.cacheWriteTokens, raw: resp.text };
+  let d: ToolDiagnosis = { cause: '', fixKind: 'unknown', detail: '', file: null };
+  try {
+    const m = resp.text.match(/\{[\s\S]*\}/);
+    const parsed = JSON.parse(m ? m[0] : resp.text) as Partial<ToolDiagnosis>;
+    d = {
+      cause: String(parsed.cause ?? ''),
+      fixKind: ['skill', 'linter', 'layer', 'unknown'].includes(parsed.fixKind as string) ? (parsed.fixKind as ToolDiagnosis['fixKind']) : 'unknown',
+      detail: String(parsed.detail ?? ''),
+      file: typeof parsed.file === 'string' && parsed.file ? parsed.file : null,
+    };
+  } catch {
+    /* keep unknown */
+  }
+  return { ...d, ...meta };
 }
 
 // ---------------------------------------------------------------------------
@@ -659,10 +784,21 @@ export interface MissReport {
   taskId: string;
   category: MissCategory;
   owner: MissOwner;
+  /** the MANNER of failure (over/under-specified, hallucination, layer-not-used, …). */
+  manner: FailureManner;
   implicatedFiles: string[];
   note: string;
-  /** model triage rationale (layer-suspected misses only). */
-  verdict?: TriageVerdict;
+  rationale: string;
+  /** the model's recommended fix (kind + a general rule). */
+  fix?: { kind: 'skill' | 'linter' | 'layer' | 'model'; detail: string };
+  /** trace-derived signals (when a controllog trace was correlated). */
+  trace?: { exploredLayer: boolean; usedNamedView: boolean; runMalloyErrors: number; toolCalls: number };
+}
+
+export interface ToolHealthFinding extends ToolErrorStat {
+  diagnosis?: ToolDiagnosis;
+  /** how the finding was acted on. */
+  action: 'routed_to_layer_repair' | 'recommended_skill_fix' | 'applied_skill_fix' | 'recommended_linter_fix' | 'reported_only';
 }
 
 export interface ImproveResult {
@@ -672,10 +808,32 @@ export interface ImproveResult {
   toHash: string;
   editedFiles: string[];
   misses: MissReport[];
+  /** run-level tool-error meta-analysis (flagged tools first). */
+  toolHealth: ToolHealthFinding[];
+  /** controllog correlation: how many of the run's rows we could trace. */
+  trace: { runId: string | null; matched: number; total: number };
+  /** any skill.md rule appended (under --apply-skill-fixes). */
+  skillFixesApplied: string[];
   cost: number;
   /** human-readable summary of where each miss belongs. */
   summary: string;
   diagnostics?: string;
+}
+
+/** Deterministic manner when no model verdict is taken (e.g. --no-manner on a
+ *  clearly-skill miss). Coarser than the model's label, but honest. */
+function deterministicManner(cls: MissClassification): FailureManner {
+  switch (cls.category) {
+    case 'no_submission':
+      return 'gave_up';
+    case 'layer_view_error':
+    case 'layer_view_empty':
+    case 'query_compile_error':
+    case 'query_wrong_answer':
+      return 'wrong_logic';
+    default:
+      return 'other';
+  }
 }
 
 export async function improveLayer(opts: {
@@ -686,31 +844,49 @@ export async function improveLayer(opts: {
   maxRounds?: number;
   /** connect the runtime to MotherDuck (md:<db>) instead of the local compile DB. */
   motherduckDb?: string;
+  /** analyze the MANNER of every miss via the trace (default true). Off → model
+   *  call only for layer-suspected misses (the cheap deterministic-only path). */
+  manner?: boolean;
+  /** append general robustness rules diagnosed from tool errors to src/skill.md. */
+  applySkillFixes?: boolean;
+  /** flag a tool when its error rate exceeds this (default 0.15). */
+  toolErrorThreshold?: number;
+  controllogDir?: string;
   runId?: string;
 }): Promise<ImproveResult> {
   const maxRounds = opts.maxRounds ?? 4;
+  const mannerEnabled = opts.manner !== false;
   const fromHash = await hashLayerOnDisk();
   const databasePath = opts.motherduckDb ? `md:${opts.motherduckDb}` : undefined;
 
   if (opts.runId) {
     cl.runMetadata({
       runId: opts.runId,
-      resolvedConfig: { phase: 'improve', model: opts.model, from: path.basename(opts.fromPath), from_hash: fromHash, provider: opts.provider ?? null, reasoning: opts.reasoningEffort ?? null, substrate: opts.motherduckDb ? 'motherduck' : 'local' },
+      resolvedConfig: { phase: 'improve', model: opts.model, from: path.basename(opts.fromPath), from_hash: fromHash, provider: opts.provider ?? null, reasoning: opts.reasoningEffort ?? null, substrate: opts.motherduckDb ? 'motherduck' : 'local', manner: mannerEnabled, apply_skill_fixes: !!opts.applySkillFixes },
       agentName: 'agent:asm-malloy-builder', datasetName: 'agentic_malloy', datasetVersion: 'layer-improve',
     });
   }
 
   const misses = await readMisses(opts.fromPath);
-  if (!misses.length) {
-    return { ok: true, editsApplied: false, fromHash, toHash: fromHash, editedFiles: [], misses: [], cost: 0, summary: 'No incorrect rows in the run — nothing to improve.' };
-  }
+  const emptyResult = (summary: string): ImproveResult => ({ ok: true, editsApplied: false, fromHash, toHash: fromHash, editedFiles: [], misses: [], toolHealth: [], trace: { runId: null, matched: 0, total: misses.length }, skillFixesApplied: [], cost: 0, summary });
+  if (!misses.length) return emptyResult('No incorrect rows in the run — nothing to improve.');
 
-  // Build the index + view→source map (needs one compiled describe()).
+  // Correlate the run to its controllog so we can read the per-task tool TRACE
+  // (the manner-of-failure evidence) + the run-level tool-error rates. Best
+  // effort: a low match → trace is omitted and we judge from the JSONL alone.
+  const allRows = (await readFile(opts.fromPath, 'utf8')).split('\n').filter((l) => l.trim()).map((l) => JSON.parse(l) as MissRow);
+  const events = await loadControllog(opts.controllogDir ?? DEFAULT_CONTROLLOG_DIR);
+  const corr = correlateRun(events, allRows);
+  const runId = corr.runId;
+  console.log(`  trace: ${runId ? `run ${runId.slice(0, 13)} (${corr.matched}/${corr.total} rows matched)` : 'no matching controllog run — JSONL-only evidence'}`);
+
   const index = await loadLayerIndex();
   const rt = new MalloyRuntime(databasePath ? { databasePath } : {});
   let totalCost = 0;
   const reports: MissReport[] = [];
   const editedFiles: string[] = [];
+  const skillFixesApplied: string[] = [];
+  let toolHealth: ToolHealthFinding[] = [];
   let diagnostics: string | undefined;
 
   try {
@@ -718,17 +894,6 @@ export async function improveLayer(opts: {
     const viewToSource = new Map<string, string>();
     for (const s of inv.sources) for (const v of inv.viewsBySource[s] ?? []) if (!viewToSource.has(v)) viewToSource.set(v, s);
 
-    // 1. Analyze + deterministically classify every miss.
-    const analyses: { a: MissAnalysis; cls: MissClassification }[] = [];
-    for (const row of misses) {
-      const a = await analyzeMiss(row, rt, index, viewToSource);
-      const cls = classifyMiss(a);
-      analyses.push({ a, cls });
-      console.log(`  miss ${a.taskId}: ${cls.category} → ${cls.suggestedOwner}${cls.layerSuspected ? ' (layer-suspected)' : ''}`);
-    }
-
-    // 2. Model verdict ONLY on layer-suspected misses; collect confirmed-layer
-    //    defects grouped by file. Everything else is reported, never edited.
     const profile = await columnProfiles();
     const profiles = TABLES.map((t) => `### ${t}\n${profile[t]}`).join('\n\n');
     const manual = existsSync(path.join(DATA_DIR, 'dabstep', 'context', 'manual.md'))
@@ -736,17 +901,30 @@ export async function improveLayer(opts: {
       : '(manual unavailable)';
     const primer = await readDoc('malloy-primer.md');
 
+    // 1. Per miss: deterministic classify + (model) MANNER/owner/fix verdict.
+    //    A layer EDIT is gated on BOTH the deterministic structural probe
+    //    (layerSuspected: a named view broke/empty) AND the model owner==='layer'
+    //    — the model cannot conjure a layer defect the data doesn't show.
     const defectsByFile = new Map<string, string[]>();
-    for (const { a, cls } of analyses) {
-      let verdict: TriageVerdict | undefined;
+    for (const row of misses) {
+      const a = await analyzeMiss(row, rt, index, viewToSource);
+      const cls = classifyMiss(a);
+      const trace = runId ? taskTrace(events, runId, a.taskId) : null;
+      const usedNamedView = a.malloySource ? referencedViews(a.malloySource, index).length > 0 : false;
+      console.log(`  miss ${a.taskId}: ${cls.category} → ${cls.suggestedOwner}${cls.layerSuspected ? ' (layer-suspected)' : ''}`);
+
       let owner: MissOwner = cls.suggestedOwner;
+      let manner: FailureManner = deterministicManner(cls);
+      let rationale = cls.note;
+      let fix: MissReport['fix'];
       let file = cls.implicatedFiles[0] ?? null;
 
-      if (cls.layerSuspected && file && existsSync(path.join(MODELS_DIR, file))) {
-        const v = await triageVerdict({
+      if (mannerEnabled || cls.layerSuspected) {
+        const v = await missVerdict({
           evidence: evidenceBlock(a, cls),
-          implicatedFileSrc: await readFile(path.join(MODELS_DIR, file), 'utf8'),
+          trace: traceBlock(trace, a.predictedAnswer, usedNamedView),
           implicatedFile: file,
+          implicatedFileSrc: file && existsSync(path.join(MODELS_DIR, file)) ? await readFile(path.join(MODELS_DIR, file), 'utf8') : null,
           profiles,
           manual,
           model: opts.model,
@@ -754,17 +932,67 @@ export async function improveLayer(opts: {
           provider: opts.provider,
         });
         totalCost += v.cost;
-        verdict = { owner: v.owner, file: v.file, defect: v.defect, rationale: v.rationale };
         owner = v.owner;
+        manner = v.manner;
+        rationale = v.rationale || cls.note;
+        fix = v.fix;
         if (v.owner === 'layer' && v.file && existsSync(path.join(MODELS_DIR, v.file))) file = v.file;
-        console.log(`    triage ${a.taskId}: model says ${v.owner}${v.owner === 'layer' ? ` (${file})` : ''} — ${v.rationale}`);
-        if (v.owner === 'layer' && file) {
+        console.log(`    verdict ${a.taskId}: manner=${v.manner} owner=${v.owner}${v.owner === 'layer' ? ` (${file})` : ''} — ${v.rationale}`);
+
+        // Layer edit only when the deterministic probe AND the model agree.
+        if (cls.layerSuspected && v.owner === 'layer' && file) {
           const list = defectsByFile.get(file) ?? [];
           list.push(`### Miss ${a.taskId}\n${evidenceBlock(a, cls)}\nModel-confirmed defect: ${v.defect}`);
           defectsByFile.set(file, list);
         }
+        if (opts.runId && fix && fix.kind !== 'layer') {
+          cl.event({ kind: 'improvement_recommendation', taskId: a.taskId, agentId: 'agent:asm-malloy-builder', runId: opts.runId, payload: { source: 'miss', manner, owner, fix_kind: fix.kind, detail: fix.detail, rationale } });
+        }
       }
-      reports.push({ taskId: a.taskId, category: cls.category, owner, implicatedFiles: cls.implicatedFiles, note: cls.note, verdict });
+
+      reports.push({
+        taskId: a.taskId, category: cls.category, owner, manner, implicatedFiles: cls.implicatedFiles, note: cls.note, rationale, fix,
+        trace: trace ? { exploredLayer: trace.exploredLayer, usedNamedView, runMalloyErrors: trace.runMalloyErrors, toolCalls: trace.toolCalls } : undefined,
+      });
+    }
+
+    // 2. Tool-error META-ANALYSIS: any tool failing > threshold gets a model
+    //    diagnosis. A layer-cause (a broken view) routes into the repair path;
+    //    skill/linter causes become recommendations (optionally applied to skill.md).
+    if (runId) {
+      const stats = toolErrorStats(events, runId, { threshold: opts.toolErrorThreshold ?? 0.15 });
+      const flagged = stats.filter((s) => s.flagged);
+      console.log(`  tool-error meta-analysis (run ${runId.slice(0, 13)}): ${flagged.length} tool(s) over ${(100 * (opts.toolErrorThreshold ?? 0.15)).toFixed(0)}% error rate${flagged.length ? ': ' + flagged.map((s) => `${s.tool} ${(s.rate * 100).toFixed(0)}%`).join(', ') : ''}`);
+      toolHealth = stats.map((s) => ({ ...s, action: 'reported_only' as ToolHealthFinding['action'] }));
+      for (const finding of toolHealth) {
+        if (!finding.flagged) continue;
+        const d = await diagnoseToolError({ stat: finding, manual, model: opts.model, reasoningEffort: opts.reasoningEffort, provider: opts.provider });
+        totalCost += d.cost;
+        finding.diagnosis = { cause: d.cause, fixKind: d.fixKind, detail: d.detail, file: d.file };
+        console.log(`    diagnose ${finding.tool}: ${d.fixKind} — ${d.cause}`);
+
+        // Route a LAYER cause into repair only if the named file actually has a
+        // currently-broken view (structural corroboration) — never edit a clean
+        // file on a tool-error guess.
+        if (d.fixKind === 'layer' && d.file && existsSync(path.join(MODELS_DIR, d.file)) && !(await validateModel(d.file)).ok) {
+          const list = defectsByFile.get(d.file) ?? [];
+          list.push(`### Recurring tool error (${finding.tool}, ${(finding.rate * 100).toFixed(0)}% of calls)\nCause: ${d.cause}\nSample errors:\n${finding.samples.map((x) => '  - ' + x).join('\n')}`);
+          defectsByFile.set(d.file, list);
+          finding.action = 'routed_to_layer_repair';
+        } else if (d.fixKind === 'skill' && opts.applySkillFixes && d.detail) {
+          await appendSkillRule(d.detail, `${finding.tool} errored ${(finding.rate * 100).toFixed(0)}% of the time: ${d.cause}`);
+          skillFixesApplied.push(d.detail);
+          finding.action = 'applied_skill_fix';
+        } else if (d.fixKind === 'skill') {
+          finding.action = 'recommended_skill_fix';
+        } else if (d.fixKind === 'linter') {
+          finding.action = 'recommended_linter_fix';
+        }
+        if (opts.runId) {
+          cl.event({ kind: 'improvement_recommendation', taskId: finding.tool, agentId: 'agent:asm-malloy-builder', runId: opts.runId, payload: { source: 'tool', tool: finding.tool, error_rate: finding.rate, calls: finding.calls, errors: finding.errors, fix_kind: d.fixKind, cause: d.cause, detail: d.detail, action: finding.action } });
+        }
+      }
+      if (opts.runId) cl.event({ kind: 'tool_health', agentId: 'agent:asm-malloy-builder', runId: opts.runId, payload: { stats: toolHealth.map((s) => ({ tool: s.tool, calls: s.calls, errors: s.errors, rate: s.rate, flagged: s.flagged, action: s.action })) } });
     }
 
     // 3. Repair each implicated file (one coherent pass per file), behind a
@@ -833,8 +1061,11 @@ export async function improveLayer(opts: {
       toHash,
       editedFiles,
       misses: reports,
+      toolHealth,
+      trace: corr,
+      skillFixesApplied,
       cost: totalCost,
-      summary: renderSummary(reports, editedFiles, fromHash, toHash, diagnostics),
+      summary: renderSummary(reports, toolHealth, editedFiles, skillFixesApplied, fromHash, toHash, diagnostics),
       diagnostics,
     };
   } finally {
@@ -842,19 +1073,55 @@ export async function improveLayer(opts: {
   }
 }
 
-function renderSummary(reports: MissReport[], editedFiles: string[], fromHash: string, toHash: string, diagnostics?: string): string {
+/** Append a GENERAL robustness rule (diagnosed from a recurring tool error) to a
+ *  clearly-marked section of src/skill.md. The skill is a tunable prompt, NOT the
+ *  layer — editing it does not affect malloy_provenance. Deduped by rule text. */
+async function appendSkillRule(rule: string, because: string): Promise<void> {
+  let skill = '';
+  try {
+    skill = await readFile(SKILL_PATH, 'utf8');
+  } catch {
+    return; // no skill.md → nothing to append to
+  }
+  if (skill.includes(rule.trim())) return; // already present
+  const HEADER = '## Auto-added robustness rules (layer-improve)';
+  const bullet = `- ${rule.trim()}  _(why: ${because})_`;
+  const next = skill.includes(HEADER) ? `${skill.trimEnd()}\n${bullet}\n` : `${skill.trimEnd()}\n\n${HEADER}\n${bullet}\n`;
+  await writeFile(SKILL_PATH, next);
+}
+
+const MANNER_LABEL: Record<FailureManner, string> = {
+  overspecified: 'over-specified', underspecified: 'under-specified', hallucination: 'hallucination',
+  layer_not_used: 'layer-not-used', wrong_logic: 'wrong-logic', gave_up: 'gave-up', other: 'other',
+};
+
+function renderSummary(reports: MissReport[], toolHealth: ToolHealthFinding[], editedFiles: string[], skillFixesApplied: string[], fromHash: string, toHash: string, diagnostics?: string): string {
   const lines: string[] = [];
   const byOwner = (o: MissOwner) => reports.filter((r) => r.owner === o);
-  lines.push(`Triaged ${reports.length} miss(es):`);
+  lines.push(`Triaged ${reports.length} miss(es) — owner · manner:`);
   for (const o of ['layer', 'skill', 'answering', 'model'] as MissOwner[]) {
     const rs = byOwner(o);
     if (!rs.length) continue;
     lines.push(`  ${o}: ${rs.map((r) => r.taskId).join(', ')}`);
     for (const r of rs) {
       const where = r.implicatedFiles.length ? ` [${r.implicatedFiles.join(', ')}]` : '';
-      lines.push(`    - ${r.taskId} (${r.category})${where}: ${r.verdict?.rationale || r.note}`);
+      const fix = r.fix && r.fix.kind !== 'layer' && r.fix.detail ? `  → ${r.fix.kind}: ${r.fix.detail}` : '';
+      lines.push(`    - ${r.taskId} · ${MANNER_LABEL[r.manner]} (${r.category})${where}: ${r.rationale}${fix}`);
     }
   }
+
+  const flagged = toolHealth.filter((s) => s.flagged);
+  if (flagged.length) {
+    lines.push(`\nTool-error meta-analysis — ${flagged.length} tool(s) over the error-rate threshold:`);
+    for (const s of flagged) {
+      lines.push(`  ${s.tool}: ${(s.rate * 100).toFixed(0)}% (${s.errors}/${s.calls})${s.diagnosis ? ` — ${s.diagnosis.fixKind}: ${s.diagnosis.cause}` : ''} [${s.action}]`);
+      if (s.diagnosis?.detail) lines.push(`     fix: ${s.diagnosis.detail}`);
+    }
+  } else if (toolHealth.length) {
+    lines.push(`\nTool-error meta-analysis: no tool over the error-rate threshold.`);
+  }
+  if (skillFixesApplied.length) lines.push(`\nApplied ${skillFixesApplied.length} robustness rule(s) to src/skill.md.`);
+
   if (editedFiles.length) {
     lines.push(`\nEdited (model_authored preserved): ${editedFiles.join(', ')}`);
     lines.push(`Layer hash ${fromHash} → ${toHash}. Re-run evaluate to measure.`);

--- a/projects/agentic-malloy/src/layer-improve.ts
+++ b/projects/agentic-malloy/src/layer-improve.ts
@@ -1,0 +1,867 @@
+/**
+ * layer-improve — a targeted, model-driven loop that takes an EXISTING
+ * model-authored Malloy layer plus an eval run's misses, identifies the
+ * implicated layer file(s) from the failure EVIDENCE (not the gold answer),
+ * makes minimal atomic edits to fix genuine STRUCTURAL defects, re-validates
+ * (compile + execute every view — the P0 gate), re-stamps provenance with an
+ * improve lineage, and preserves already-passing questions.
+ *
+ * Constitutional constraints (Phase-3 generalization depends on these):
+ *  - NO LEAKAGE / task-general: a repair prompt sees only STRUCTURAL evidence —
+ *    the failing Malloy, compiler/exec diagnostics, "this view returns 0/errors",
+ *    the column profile, and the manual. It NEVER sees the question's gold answer
+ *    and must not tune the layer to a specific train value. The fix improves the
+ *    layer's GENERAL correctness (per manual + data), exactly like layer-build.
+ *  - DON'T REGRESS: after editing, every view must still execute; if the final
+ *    all-views gate fails and can't be repaired, ALL edits are rolled back.
+ *  - HONEST / IDEMPOTENT: most current misses are answering-agent/skill issues,
+ *    NOT layer bugs. When no miss is structurally layer-caused, it edits NOTHING,
+ *    leaves provenance untouched, and reports where each fix belongs.
+ *
+ * The triage (layer defect vs. skill/answering vs. model-capability) is the hard,
+ * valuable part. It is deterministic-first (classifyMiss, a pure function over
+ * re-execution evidence — unit-tested), with a model verdict only on the
+ * layer-SUSPECTED minority (which may downgrade to skill).
+ */
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { complete } from './llm-client.js';
+import { MalloyRuntime } from './malloy-runtime.js';
+import {
+  DUCKDB_NOTES,
+  MODELS_DIR,
+  META_DIR,
+  columnProfiles,
+  hashLayerOnDisk,
+  parseEdits,
+  readDoc,
+  sourceNamesIn,
+  validateModel,
+  PROVENANCE_PATH,
+  DATA_DIR,
+} from './layer-build.js';
+import * as cl from './controllog.js';
+
+const TABLES = ['payments', 'fees', 'merchants', 'acquirer_countries', 'merchant_category_codes'];
+
+// ---------------------------------------------------------------------------
+// Miss rows (the --from JSONL shape) — see cli.ts runEvalTask's `row`.
+// ---------------------------------------------------------------------------
+
+export interface MissRow {
+  task_id: string | number;
+  question?: string;
+  guidelines?: string;
+  is_correct?: boolean;
+  correctness?: string;
+  match_source?: string;
+  submitted?: boolean;
+  hit_limit?: boolean;
+  malloy_source?: string | null;
+  compiled_sql?: string | null;
+  predicted_answer?: unknown;
+  failure_stage?: string | null;
+  failure_kind?: string | null;
+  error?: string | null;
+  // gold_answer IS present in the row but is DELIBERATELY never read here — no leakage.
+}
+
+/** Read a results JSONL and return only the incorrect rows (the misses). */
+export async function readMisses(fromPath: string): Promise<MissRow[]> {
+  const rows = (await readFile(fromPath, 'utf8'))
+    .split('\n')
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as MissRow);
+  return rows.filter((r) => r.is_correct === false);
+}
+
+// ---------------------------------------------------------------------------
+// Layer index — map a source/view NAME to the file that defines it. Pure over
+// the file bodies so the miss→file mapping is unit-testable without a runtime.
+// ---------------------------------------------------------------------------
+
+export interface LayerIndex {
+  /** source OR view name -> the .malloy file that defines it. */
+  fileOf: Map<string, string>;
+  /** every source name defined anywhere (for "is this token a source"). */
+  sources: Set<string>;
+  /** every view name defined anywhere. */
+  views: Set<string>;
+}
+
+const VIEW_DEF_RE = /^[ \t]*view:[ \t]*([A-Za-z_][A-Za-z0-9_]*)[ \t]+is\b/gm;
+
+/** Build the name→file index from a map of file -> body. Pure. */
+export function buildLayerIndex(bodyOf: Record<string, string>): LayerIndex {
+  const fileOf = new Map<string, string>();
+  const sources = new Set<string>();
+  const views = new Set<string>();
+  for (const [file, body] of Object.entries(bodyOf)) {
+    for (const s of sourceNamesIn(body)) {
+      sources.add(s);
+      if (!fileOf.has(s)) fileOf.set(s, file);
+    }
+    for (const m of body.matchAll(VIEW_DEF_RE)) {
+      views.add(m[1]);
+      if (!fileOf.has(m[1])) fileOf.set(m[1], file);
+    }
+  }
+  return { fileOf, sources, views };
+}
+
+/** Read the on-disk layer and build its index. */
+export async function loadLayerIndex(modelsDir = MODELS_DIR): Promise<LayerIndex> {
+  const bodyOf: Record<string, string> = {};
+  for (const f of (await readdir(modelsDir)).filter((f) => f.endsWith('.malloy'))) {
+    bodyOf[f] = await readFile(path.join(modelsDir, f), 'utf8');
+  }
+  return buildLayerIndex(bodyOf);
+}
+
+const IDENT_RE = /[A-Za-z_][A-Za-z0-9_]*/g;
+
+/** The distinct identifier tokens of a Malloy snippet (dedup, in order). Pure. */
+export function identifiersIn(src: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const m of src.matchAll(IDENT_RE)) {
+    if (!seen.has(m[0])) {
+      seen.add(m[0]);
+      out.push(m[0]);
+    }
+  }
+  return out;
+}
+
+/**
+ * Map a submitted Malloy snippet to the layer file(s) it implicates: the files
+ * that define any source/view NAME the snippet references. Pure + testable.
+ */
+export function mapMalloyToFiles(src: string, index: LayerIndex): string[] {
+  if (!src) return [];
+  const files: string[] = [];
+  for (const tok of identifiersIn(src)) {
+    const f = index.fileOf.get(tok);
+    if (f && !files.includes(f)) files.push(f);
+  }
+  return files;
+}
+
+/** Named layer views referenced in a snippet (token ∩ known view names). Pure. */
+export function referencedViews(src: string, index: LayerIndex): string[] {
+  return identifiersIn(src).filter((t) => index.views.has(t));
+}
+
+// ---------------------------------------------------------------------------
+// Per-miss analysis (re-execution evidence) + deterministic classification.
+// ---------------------------------------------------------------------------
+
+export interface ViewProbe {
+  source: string;
+  view: string;
+  file: string | undefined;
+  ok: boolean;
+  rowCount: number;
+  error?: string;
+}
+
+export interface MissAnalysis {
+  taskId: string;
+  question?: string;
+  guidelines?: string;
+  correctness?: string;
+  matchSource?: string;
+  predictedAnswer?: unknown;
+  /** whether the answering agent actually submitted a Malloy answer. */
+  submitted: boolean;
+  hitLimit: boolean;
+  malloySource: string | null;
+  /** re-running the submitted Malloy now (null when nothing was submitted). */
+  reExec: { ok: boolean; rowCount: number; error?: string } | null;
+  /** each named layer view the submission referenced, smoke-run on its own. */
+  viewProbes: ViewProbe[];
+  implicatedFiles: string[];
+}
+
+export type MissCategory =
+  | 'no_submission'
+  | 'query_wrong_answer'
+  | 'query_compile_error'
+  | 'layer_view_error'
+  | 'layer_view_empty'
+  | 'unknown';
+
+export type MissOwner = 'answering' | 'skill' | 'layer' | 'model';
+
+export interface MissClassification {
+  category: MissCategory;
+  /** does the EVIDENCE point at a structural layer defect worth a model verdict? */
+  layerSuspected: boolean;
+  /** the default fix location (a model verdict may override layerSuspected ones). */
+  suggestedOwner: MissOwner;
+  implicatedFiles: string[];
+  note: string;
+}
+
+/**
+ * Deterministically classify a miss from its re-execution evidence — the hard,
+ * valuable triage, made testable by being a PURE function over MissAnalysis.
+ *
+ * Decision tree (the key insight: a NAMED layer surface, run on its own, is the
+ * structural-defect probe — it needs no gold answer):
+ *   - nothing submitted .................................. answering (turn budget)
+ *   - submitted, a referenced view ERRORS on its own ..... LAYER (regression)
+ *   - submitted re-runs fine, returns rows ............... skill (agent's inline logic)
+ *   - submitted re-runs fine but empty, AND a referenced
+ *     view is ALSO empty on its own ...................... LAYER-suspected (model confirms)
+ *   - submitted re-runs fine but empty, no empty view .... skill (agent over-filtered)
+ *   - submitted FAILS to re-run, referenced views clean .. skill (agent's inline Malloy)
+ *   - submitted FAILS, no views referenced ............... skill (agent's inline Malloy)
+ */
+export function classifyMiss(a: MissAnalysis): MissClassification {
+  const files = a.implicatedFiles;
+  if (!a.submitted || a.hitLimit || !a.malloySource) {
+    return {
+      category: 'no_submission',
+      layerSuspected: false,
+      suggestedOwner: 'answering',
+      implicatedFiles: files,
+      note: 'agent never submitted a Malloy answer (hit the turn limit / thrash) — an answering-loop / turn-budget issue, not a layer defect. A layer may help only if it lacks an answer-shaped view for this question shape (soft note).',
+    };
+  }
+
+  const brokenView = a.viewProbes.find((p) => !p.ok);
+  const emptyView = a.viewProbes.find((p) => p.ok && p.rowCount === 0);
+  const reExec = a.reExec;
+
+  if (brokenView) {
+    // A named layer view fails to EXECUTE on its own → a structural layer defect
+    // (the build gate should have caught it; treat as a regression to fix).
+    return {
+      category: 'layer_view_error',
+      layerSuspected: true,
+      suggestedOwner: 'layer',
+      implicatedFiles: brokenView.file ? [brokenView.file, ...files.filter((f) => f !== brokenView.file)] : files,
+      note: `named layer view \`${brokenView.source} -> ${brokenView.view}\` fails to execute on its own: ${brokenView.error?.slice(0, 200)}`,
+    };
+  }
+
+  if (reExec && !reExec.ok) {
+    // Submitted Malloy errors, but every referenced named view runs clean → the
+    // fault is in the agent's INLINE composition, not the layer.
+    return {
+      category: 'query_compile_error',
+      layerSuspected: false,
+      suggestedOwner: 'skill',
+      implicatedFiles: files,
+      note: `the agent's submitted Malloy fails to compile/execute, but the layer views it referenced run clean on their own — the defect is in the agent's inline query (a skill/answering issue): ${reExec.error?.slice(0, 200)}`,
+    };
+  }
+
+  // From here the submitted Malloy re-ran successfully.
+  if (reExec && reExec.rowCount === 0 && emptyView) {
+    // The query returned nothing AND a named layer view is itself empty → suspect
+    // the layer view (a matching/aggregating view that returns nothing over rows
+    // that exist is usually a wildcard-encoding or domain bug). Model confirms.
+    return {
+      category: 'layer_view_empty',
+      layerSuspected: true,
+      suggestedOwner: 'layer',
+      implicatedFiles: emptyView.file ? [emptyView.file, ...files.filter((f) => f !== emptyView.file)] : files,
+      note: `named layer view \`${emptyView.source} -> ${emptyView.view}\` returns 0 rows on its own — a matching/aggregating view that is empty over rows that exist is usually a structural (wildcard/domain) bug.`,
+    };
+  }
+
+  if (reExec && reExec.rowCount === 0) {
+    return {
+      category: 'query_wrong_answer',
+      layerSuspected: false,
+      suggestedOwner: 'skill',
+      implicatedFiles: files,
+      note: 'the submitted Malloy runs but returns 0 rows while the layer views it uses are non-empty — the agent likely over-filtered (a skill/answering issue).',
+    };
+  }
+
+  return {
+    category: 'query_wrong_answer',
+    layerSuspected: false,
+    suggestedOwner: 'skill',
+    implicatedFiles: files,
+    note: 'the submitted Malloy compiles, executes, and returns rows — the layer surfaces it used work; the wrong answer comes from the agent\'s inline logic (filter / field / grain / ranking), a skill/answering issue, not a layer defect.',
+  };
+}
+
+/**
+ * Gather re-execution evidence for one miss: re-run the submitted Malloy and
+ * smoke each named layer view it referenced. Uses the runtime + index; the
+ * derived classification (classifyMiss) is a separate pure step.
+ */
+export async function analyzeMiss(
+  row: MissRow,
+  rt: MalloyRuntime,
+  index: LayerIndex,
+  viewToSource: Map<string, string>,
+): Promise<MissAnalysis> {
+  const taskId = String(row.task_id);
+  const malloySource = (row.malloy_source ?? '').trim() || null;
+  const submitted = !!row.submitted && !!malloySource;
+  const hitLimit = !!row.hit_limit;
+
+  let reExec: MissAnalysis['reExec'] = null;
+  const viewProbes: ViewProbe[] = [];
+
+  if (malloySource) {
+    const r = await rt.run(malloySource, 50);
+    reExec = r.ok
+      ? { ok: true, rowCount: r.rows?.length ?? 0 }
+      : { ok: false, rowCount: 0, error: (r.diagnostics ?? []).map((d) => d.message).join('\n') };
+
+    // Smoke each referenced named view on its own (the structural-defect probe).
+    for (const view of referencedViews(malloySource, index)) {
+      const source = viewToSource.get(view);
+      if (!source) continue;
+      const pr = await rt.run(`run: ${source} -> ${view}`, 1);
+      viewProbes.push({
+        source,
+        view,
+        file: index.fileOf.get(view),
+        ok: pr.ok,
+        rowCount: pr.rows?.length ?? 0,
+        error: pr.ok ? undefined : (pr.diagnostics ?? []).map((d) => d.message).join('\n'),
+      });
+    }
+  }
+
+  return {
+    taskId,
+    question: row.question,
+    guidelines: row.guidelines,
+    correctness: row.correctness,
+    matchSource: row.match_source,
+    predictedAnswer: row.predicted_answer,
+    submitted,
+    hitLimit,
+    malloySource,
+    reExec,
+    viewProbes,
+    implicatedFiles: malloySource ? mapMalloyToFiles(malloySource, index) : [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Structural evidence string (NO gold answer — leakage-free) for model prompts.
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the STRUCTURAL evidence for a miss into a prompt block. Deliberately
+ * excludes the gold answer and any train-specific target value: only the
+ * question intent, the failing Malloy, the re-execution diagnostics, and the
+ * per-view probes. `predicted_answer` is the agent's OWN output (e.g. a view
+ * that produced 0), which is structural evidence, not the gold.
+ */
+export function evidenceBlock(a: MissAnalysis, cls: MissClassification): string {
+  const lines: string[] = [];
+  lines.push(`Question [${a.taskId}]: ${a.question ?? '(unavailable)'}`);
+  if (a.guidelines) lines.push(`Answer guidelines: ${a.guidelines}`);
+  lines.push(`Scoring verdict: ${a.correctness ?? 'incorrect'} (match_source=${a.matchSource ?? 'none'})`);
+  if (a.malloySource) {
+    lines.push(`\nThe answering agent submitted this Malloy:\n${a.malloySource}`);
+    if (a.predictedAnswer !== undefined && a.predictedAnswer !== null) {
+      lines.push(`It produced (the agent's OWN output, NOT the gold answer): ${String(a.predictedAnswer).slice(0, 300)}`);
+    }
+    if (a.reExec) {
+      lines.push(
+        a.reExec.ok
+          ? `Re-running it now: OK, ${a.reExec.rowCount} row(s).`
+          : `Re-running it now: EXECUTION ERROR:\n${a.reExec.error}`,
+      );
+    }
+  } else {
+    lines.push(`\nThe answering agent did NOT submit a Malloy answer (hit the turn limit).`);
+  }
+  if (a.viewProbes.length) {
+    lines.push(`\nLayer views it referenced, each run ON ITS OWN:`);
+    for (const p of a.viewProbes) {
+      lines.push(
+        p.ok
+          ? `  - ${p.source} -> ${p.view}  [${p.file ?? '?'}]: OK, ${p.rowCount} row(s)${p.rowCount === 0 ? ' (EMPTY)' : ''}`
+          : `  - ${p.source} -> ${p.view}  [${p.file ?? '?'}]: ERROR: ${p.error?.slice(0, 300)}`,
+      );
+    }
+  }
+  lines.push(`\nDeterministic triage: ${cls.category} — ${cls.note}`);
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Model triage verdict (only for layer-SUSPECTED misses) — may downgrade.
+// ---------------------------------------------------------------------------
+
+export interface TriageVerdict {
+  owner: MissOwner;
+  file: string | null;
+  defect: string;
+  rationale: string;
+}
+
+const TRIAGE_SYSTEM = `You are triaging a FAILED data question against a Malloy semantic layer. Decide WHERE the fix belongs:
+- "layer": a STRUCTURAL defect in a layer source/view itself (it errors at execution, or a matching/aggregating view returns 0/empty over rows that exist, or it computes at the wrong grain). The fix is a minimal edit to the layer file, justified ONLY by the manual + the data's actual encodings — NOT by any specific answer value.
+- "skill": the layer is fine; the answering agent wrote the wrong per-query Malloy (under-filtered, wrong field, wrong grain, missed a wildcard branch, bad inline syntax) or never submitted. The fix belongs in the answering SKILL / prompt, not the layer.
+- "model": neither — a model-capability / reasoning gap on a hard compositional question that no layer or skill edit cleanly fixes.
+
+You are given STRUCTURAL evidence only (failing Malloy, execution diagnostics, per-view probes, the column profile, the manual). You are NOT given the gold answer and MUST NOT ask for it or tune anything to a value. A layer verdict is justified ONLY when a NAMED layer view, exercised on its own, is itself broken (errors or is wrongly empty/at the wrong grain). If the submitted query runs and returns rows and the wrongness is in the agent's own filter/field/ranking, that is "skill", not "layer".
+
+Return ONLY a JSON object: {"owner":"layer|skill|model","file":"<implicated .malloy file or null>","defect":"<one-sentence structural description, or empty>","rationale":"<one sentence>"}.`;
+
+export async function triageVerdict(opts: {
+  evidence: string;
+  implicatedFileSrc: string;
+  implicatedFile: string;
+  profiles: string;
+  manual: string;
+  model: string;
+  reasoningEffort?: string;
+  provider?: string;
+}): Promise<TriageVerdict & { cost: number; promptTokens: number; completionTokens: number; cachedTokens: number; cacheWriteTokens: number; raw: string }> {
+  const user = `## Failure evidence (structural — NO gold answer)\n${opts.evidence}\n\n## The implicated layer file \`${opts.implicatedFile}\`\n\`\`\`malloy\n${opts.implicatedFileSrc}\n\`\`\`\n\n## Column profiles (actual encodings + domains — ground truth)\n${opts.profiles}\n\n## The Merchant Manual\n${opts.manual}\n\nReturn the triage JSON now.`;
+  const resp = await complete({
+    model: opts.model,
+    systemPrompt: TRIAGE_SYSTEM,
+    userPrompt: user,
+    reasoningEffort: opts.reasoningEffort,
+    provider: opts.provider,
+    maxTokens: 2000,
+  });
+  let v: TriageVerdict = { owner: 'skill', file: opts.implicatedFile, defect: '', rationale: 'parse failure → defaulted to skill (no layer edit)' };
+  try {
+    const m = resp.text.match(/\{[\s\S]*\}/);
+    const parsed = JSON.parse(m ? m[0] : resp.text) as Partial<TriageVerdict>;
+    const owner = parsed.owner;
+    if (owner === 'layer' || owner === 'skill' || owner === 'model') {
+      v = {
+        owner,
+        file: typeof parsed.file === 'string' && parsed.file ? parsed.file : opts.implicatedFile,
+        defect: String(parsed.defect ?? ''),
+        rationale: String(parsed.rationale ?? ''),
+      };
+    }
+  } catch {
+    /* keep the safe skill default */
+  }
+  return { ...v, cost: resp.cost ?? 0, promptTokens: resp.promptTokens, completionTokens: resp.completionTokens, cachedTokens: resp.cachedTokens, cacheWriteTokens: resp.cacheWriteTokens, raw: resp.text };
+}
+
+// ---------------------------------------------------------------------------
+// Repair a single layer file with minimal atomic edits (mirrors layer-build's
+// edit-mode authorStage), then re-validate (compile + execute the file's views).
+// ---------------------------------------------------------------------------
+
+const REPAIR_SYSTEM_HEADER = `You are a Malloy expert REPAIRING one file of an existing semantic layer. A view/source in this file has a STRUCTURAL defect (it errors at execution, or returns 0/empty over rows that exist, or computes at the wrong grain). Fix the DEFECT generically — make the layer correct per the manual + the data's actual encodings (the column profile).
+
+ABSOLUTE RULE: do NOT tune anything to a specific answer value. You are given NO gold answers. A correct fix is one that makes the view structurally sound for ANY input (correct join scope, correct wildcard/domain handling, correct grain), not one that nudges a number. Make the MINIMAL edits that fix ONLY the described defect — do not rewrite, reorder, or restructure anything else, and do not change views that already work.`;
+
+export interface RepairResult {
+  ok: boolean;
+  file: string;
+  rounds: number;
+  applied: number;
+  diag?: string;
+  cost: number;
+  promptTokens: number;
+  completionTokens: number;
+  cachedTokens: number;
+  cacheWriteTokens: number;
+}
+
+export async function repairFileStage(opts: {
+  file: string; // e.g. c3_fee_assignment.malloy
+  defects: string; // merged structural evidence + defect descriptions for this file
+  profiles: string;
+  manual: string;
+  primer: string;
+  model: string;
+  reasoningEffort?: string;
+  provider?: string;
+  maxRounds: number;
+  runId?: string;
+}): Promise<RepairResult> {
+  const agg = { cost: 0, promptTokens: 0, completionTokens: 0, cachedTokens: 0, cacheWriteTokens: 0 };
+  const modelPath = path.join(MODELS_DIR, opts.file);
+  let current = await readFile(modelPath, 'utf8');
+  let diag = '';
+  let totalApplied = 0;
+  const system = `${REPAIR_SYSTEM_HEADER}\n\n=== MALLOY PRIMER ===\n${opts.primer}\n\n${DUCKDB_NOTES}`;
+
+  for (let round = 1; round <= opts.maxRounds; round++) {
+    const t0 = Date.now();
+    const errSuffix = diag ? `\n\n## Your previous edits still left this failing — fix it:\n${diag}` : '';
+    const resp = await complete({
+      model: opts.model,
+      systemPrompt: system,
+      userPrompt:
+        `## Structural defect(s) to fix in ${opts.file}\n${opts.defects}\n\n` +
+        `## Column profiles (actual encodings + domains — ground truth; prefer over prose)\n${opts.profiles}\n\n` +
+        `## The Merchant Manual\n${opts.manual}\n\n` +
+        `=== current ${opts.file} ===\n${current}\n\n` +
+        `Return ONLY a JSON array of minimal edits: [{"old":"<text copied VERBATIM from the file, unique>","new":"<replacement>"}]. ` +
+        `Each "old" must appear exactly once in the file. Fix ONLY the described structural defect (typed raw escapes fn!returntype, wildcard branch on every match field, materialize join attributes as real columns before a join_many, qualify join keys).${errSuffix}`,
+      reasoningEffort: opts.reasoningEffort,
+      provider: opts.provider,
+      maxTokens: 12000,
+    });
+    const wallMs = Date.now() - t0;
+    agg.cost += resp.cost ?? 0;
+    agg.promptTokens += resp.promptTokens;
+    agg.completionTokens += resp.completionTokens;
+    agg.cachedTokens += resp.cachedTokens;
+    agg.cacheWriteTokens += resp.cacheWriteTokens;
+
+    const edits = parseEdits(resp.text);
+    let patched = current;
+    let applied = 0;
+    for (const e of edits) {
+      const i = patched.indexOf(e.old);
+      if (i >= 0) {
+        patched = patched.slice(0, i) + e.new + patched.slice(i + e.old.length);
+        applied++;
+      }
+    }
+
+    if (opts.runId) {
+      const ex = cl.newId();
+      cl.modelPrompt({ taskId: opts.file, runId: opts.runId, provider: 'openrouter', model: opts.model, promptTokens: resp.promptTokens, exchangeId: ex, role: 'builder', payload: { phase: 'build', stage: `improve:${opts.file}`, round, mode: 'edit' } });
+      cl.modelCompletion({ taskId: opts.file, runId: opts.runId, provider: 'openrouter', model: opts.model, completionTokens: resp.completionTokens, wallMs, exchangeId: ex, costMoney: resp.cost, role: 'builder', payload: { phase: 'build', stage: `improve:${opts.file}`, round, mode: 'edit', applied, response: resp.text.slice(0, 8000), cached_tokens: resp.cachedTokens, cache_write_tokens: resp.cacheWriteTokens } });
+    }
+
+    if (applied === 0) {
+      console.log(`  … improve ${opts.file} round ${round}: no edits applied`);
+      // No applicable edit: if we already have a failing diag, keep trying; else give up.
+      if (round === opts.maxRounds) return { ok: false, file: opts.file, rounds: round, applied: totalApplied, diag: diag || 'model returned no applicable edits', ...agg };
+      continue;
+    }
+    totalApplied += applied;
+    await writeFile(modelPath, patched + (patched.endsWith('\n') ? '' : '\n'));
+    current = patched;
+    console.log(`  … improve ${opts.file} round ${round}: applied ${applied}/${edits.length} edit(s)`);
+
+    const cv0 = Date.now();
+    const v = await validateModel(opts.file); // compile whole model + execute this file's views
+    if (opts.runId) {
+      const callId = cl.newId();
+      cl.toolCall({ taskId: opts.file, runId: opts.runId, name: 'compile_check', callId, arguments: { round, mode: 'edit' }, model: opts.model });
+      cl.toolResult({ taskId: opts.file, runId: opts.runId, name: 'compile_check', callId, ok: v.ok, durationMs: Date.now() - cv0, model: opts.model, output: v.ok ? 'ok' : v.diag.slice(0, 1500) });
+    }
+    if (v.ok) {
+      console.log(`  ✓ improve ${opts.file} (round ${round}, $${agg.cost.toFixed(4)})`);
+      return { ok: true, file: opts.file, rounds: round, applied: totalApplied, ...agg };
+    }
+    console.log(`  ✗ improve ${opts.file} round ${round}:\n${v.diag.split('\n').slice(0, 6).map((l) => '      ' + l).join('\n')}`);
+    diag = v.diag;
+  }
+  return { ok: false, file: opts.file, rounds: opts.maxRounds, applied: totalApplied, diag, ...agg };
+}
+
+// ---------------------------------------------------------------------------
+// Full all-views gate (the strongest no-regression check) + layer snapshot.
+// ---------------------------------------------------------------------------
+
+/** Execute EVERY view of EVERY source against the runtime; return the first
+ *  failure. Catches edits that ripple beyond the edited file. */
+export async function executeAllViews(rt: MalloyRuntime): Promise<{ ok: boolean; diag: string }> {
+  const inv = await rt.describe(); // compile check (throws on compile error → caller catches)
+  for (const s of inv.sources) {
+    for (const view of inv.viewsBySource[s] ?? []) {
+      const r = await rt.run(`run: ${s} -> ${view}`, 1);
+      if (!r.ok) {
+        return { ok: false, diag: `\`${s} -> ${view}\` fails to execute:\n${(r.diagnostics ?? []).map((d) => d.message).join('\n')}` };
+      }
+    }
+  }
+  return { ok: true, diag: '' };
+}
+
+type Snapshot = { models: Record<string, string>; meta: Record<string, string> };
+
+async function snapshotLayer(): Promise<Snapshot> {
+  const models: Record<string, string> = {};
+  for (const f of (await readdir(MODELS_DIR)).filter((f) => f.endsWith('.malloy'))) {
+    models[f] = await readFile(path.join(MODELS_DIR, f), 'utf8');
+  }
+  const meta: Record<string, string> = {};
+  try {
+    for (const f of (await readdir(META_DIR)).filter((f) => f.endsWith('.yaml'))) {
+      meta[f] = await readFile(path.join(META_DIR, f), 'utf8');
+    }
+  } catch {
+    /* no _meta */
+  }
+  return { models, meta };
+}
+
+async function restoreLayer(snap: Snapshot): Promise<void> {
+  for (const [f, body] of Object.entries(snap.models)) await writeFile(path.join(MODELS_DIR, f), body);
+  for (const [f, body] of Object.entries(snap.meta)) await writeFile(path.join(META_DIR, f), body);
+}
+
+// ---------------------------------------------------------------------------
+// Provenance re-stamp (preserve model_authored + manual_included; add lineage).
+// ---------------------------------------------------------------------------
+
+interface ProvenanceFile {
+  malloy_provenance?: string;
+  malloy_model_hash?: string;
+  manual_included?: boolean | null;
+  authoring_model?: string | null;
+  improve_round?: number;
+  improve_lineage?: Array<Record<string, unknown>>;
+  [k: string]: unknown;
+}
+
+async function restampProvenance(opts: { fromHash: string; toHash: string; model: string; editedFiles: string[]; fromRun: string }): Promise<void> {
+  let prev: ProvenanceFile = {};
+  try {
+    prev = JSON.parse(await readFile(PROVENANCE_PATH, 'utf8')) as ProvenanceFile;
+  } catch {
+    /* none */
+  }
+  const round = (prev.improve_round ?? 0) + 1;
+  const lineage = Array.isArray(prev.improve_lineage) ? prev.improve_lineage.slice() : [];
+  lineage.push({
+    from_hash: opts.fromHash,
+    to_hash: opts.toHash,
+    round,
+    improve_model: opts.model,
+    edited_files: opts.editedFiles,
+    from_run: path.basename(opts.fromRun),
+    at: new Date().toISOString(),
+  });
+  const next: ProvenanceFile = {
+    ...prev,
+    // model_authored is PRESERVED — the edits are model-made, atomic, and
+    // execution-gated (same discipline as layer-build); no human touched the layer.
+    malloy_provenance: 'model_authored',
+    malloy_model_hash: opts.toHash,
+    // manual_included + authoring_model carry forward so the official gate still passes.
+    manual_included: prev.manual_included ?? null,
+    authoring_model: prev.authoring_model ?? null,
+    improve_round: round,
+    improve_lineage: lineage,
+  };
+  await writeFile(PROVENANCE_PATH, JSON.stringify(next, null, 2) + '\n');
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+export interface MissReport {
+  taskId: string;
+  category: MissCategory;
+  owner: MissOwner;
+  implicatedFiles: string[];
+  note: string;
+  /** model triage rationale (layer-suspected misses only). */
+  verdict?: TriageVerdict;
+}
+
+export interface ImproveResult {
+  ok: boolean;
+  editsApplied: boolean;
+  fromHash: string;
+  toHash: string;
+  editedFiles: string[];
+  misses: MissReport[];
+  cost: number;
+  /** human-readable summary of where each miss belongs. */
+  summary: string;
+  diagnostics?: string;
+}
+
+export async function improveLayer(opts: {
+  fromPath: string;
+  model: string;
+  reasoningEffort?: string;
+  provider?: string;
+  maxRounds?: number;
+  /** connect the runtime to MotherDuck (md:<db>) instead of the local compile DB. */
+  motherduckDb?: string;
+  runId?: string;
+}): Promise<ImproveResult> {
+  const maxRounds = opts.maxRounds ?? 4;
+  const fromHash = await hashLayerOnDisk();
+  const databasePath = opts.motherduckDb ? `md:${opts.motherduckDb}` : undefined;
+
+  if (opts.runId) {
+    cl.runMetadata({
+      runId: opts.runId,
+      resolvedConfig: { phase: 'improve', model: opts.model, from: path.basename(opts.fromPath), from_hash: fromHash, provider: opts.provider ?? null, reasoning: opts.reasoningEffort ?? null, substrate: opts.motherduckDb ? 'motherduck' : 'local' },
+      agentName: 'agent:asm-malloy-builder', datasetName: 'agentic_malloy', datasetVersion: 'layer-improve',
+    });
+  }
+
+  const misses = await readMisses(opts.fromPath);
+  if (!misses.length) {
+    return { ok: true, editsApplied: false, fromHash, toHash: fromHash, editedFiles: [], misses: [], cost: 0, summary: 'No incorrect rows in the run — nothing to improve.' };
+  }
+
+  // Build the index + view→source map (needs one compiled describe()).
+  const index = await loadLayerIndex();
+  const rt = new MalloyRuntime(databasePath ? { databasePath } : {});
+  let totalCost = 0;
+  const reports: MissReport[] = [];
+  const editedFiles: string[] = [];
+  let diagnostics: string | undefined;
+
+  try {
+    const inv = await rt.describe();
+    const viewToSource = new Map<string, string>();
+    for (const s of inv.sources) for (const v of inv.viewsBySource[s] ?? []) if (!viewToSource.has(v)) viewToSource.set(v, s);
+
+    // 1. Analyze + deterministically classify every miss.
+    const analyses: { a: MissAnalysis; cls: MissClassification }[] = [];
+    for (const row of misses) {
+      const a = await analyzeMiss(row, rt, index, viewToSource);
+      const cls = classifyMiss(a);
+      analyses.push({ a, cls });
+      console.log(`  miss ${a.taskId}: ${cls.category} → ${cls.suggestedOwner}${cls.layerSuspected ? ' (layer-suspected)' : ''}`);
+    }
+
+    // 2. Model verdict ONLY on layer-suspected misses; collect confirmed-layer
+    //    defects grouped by file. Everything else is reported, never edited.
+    const profile = await columnProfiles();
+    const profiles = TABLES.map((t) => `### ${t}\n${profile[t]}`).join('\n\n');
+    const manual = existsSync(path.join(DATA_DIR, 'dabstep', 'context', 'manual.md'))
+      ? await readFile(path.join(DATA_DIR, 'dabstep', 'context', 'manual.md'), 'utf8')
+      : '(manual unavailable)';
+    const primer = await readDoc('malloy-primer.md');
+
+    const defectsByFile = new Map<string, string[]>();
+    for (const { a, cls } of analyses) {
+      let verdict: TriageVerdict | undefined;
+      let owner: MissOwner = cls.suggestedOwner;
+      let file = cls.implicatedFiles[0] ?? null;
+
+      if (cls.layerSuspected && file && existsSync(path.join(MODELS_DIR, file))) {
+        const v = await triageVerdict({
+          evidence: evidenceBlock(a, cls),
+          implicatedFileSrc: await readFile(path.join(MODELS_DIR, file), 'utf8'),
+          implicatedFile: file,
+          profiles,
+          manual,
+          model: opts.model,
+          reasoningEffort: opts.reasoningEffort,
+          provider: opts.provider,
+        });
+        totalCost += v.cost;
+        verdict = { owner: v.owner, file: v.file, defect: v.defect, rationale: v.rationale };
+        owner = v.owner;
+        if (v.owner === 'layer' && v.file && existsSync(path.join(MODELS_DIR, v.file))) file = v.file;
+        console.log(`    triage ${a.taskId}: model says ${v.owner}${v.owner === 'layer' ? ` (${file})` : ''} — ${v.rationale}`);
+        if (v.owner === 'layer' && file) {
+          const list = defectsByFile.get(file) ?? [];
+          list.push(`### Miss ${a.taskId}\n${evidenceBlock(a, cls)}\nModel-confirmed defect: ${v.defect}`);
+          defectsByFile.set(file, list);
+        }
+      }
+      reports.push({ taskId: a.taskId, category: cls.category, owner, implicatedFiles: cls.implicatedFiles, note: cls.note, verdict });
+    }
+
+    // 3. Repair each implicated file (one coherent pass per file), behind a
+    //    snapshot so we can roll back if the final all-views gate regresses.
+    if (defectsByFile.size > 0) {
+      const snap = await snapshotLayer();
+      let allOk = true;
+      for (const [file, defects] of defectsByFile) {
+        const r = await repairFileStage({
+          file,
+          defects: defects.join('\n\n'),
+          profiles,
+          manual,
+          primer,
+          model: opts.model,
+          reasoningEffort: opts.reasoningEffort,
+          provider: opts.provider,
+          maxRounds,
+          runId: opts.runId,
+        });
+        totalCost += r.cost;
+        if (r.ok && r.applied > 0) editedFiles.push(file);
+        else {
+          allOk = false;
+          diagnostics = `repair of ${file} failed: ${r.diag}`;
+          break;
+        }
+      }
+
+      // Final P0 gate: every view of every source must still execute. Use a
+      // FRESH runtime (the analysis `rt` cached the pre-edit model text); this
+      // mirrors validateModel's credential-free local compile+execute gate.
+      if (allOk) {
+        const gateRt = new MalloyRuntime();
+        try {
+          const gate = await executeAllViews(gateRt);
+          if (!gate.ok) {
+            allOk = false;
+            diagnostics = `post-edit all-views gate failed: ${gate.diag}`;
+          }
+        } catch (e) {
+          allOk = false;
+          diagnostics = `post-edit compile failed: ${e instanceof Error ? e.message : String(e)}`;
+        } finally {
+          await gateRt.close();
+        }
+      }
+
+      if (!allOk) {
+        console.log(`  ✗ edits did not pass the no-regression gate — rolling back all changes.`);
+        await restoreLayer(snap);
+        editedFiles.length = 0;
+      }
+    }
+
+    const editsApplied = editedFiles.length > 0;
+    const toHash = editsApplied ? await hashLayerOnDisk() : fromHash;
+    if (editsApplied) {
+      await restampProvenance({ fromHash, toHash, model: opts.model, editedFiles, fromRun: opts.fromPath });
+    }
+
+    return {
+      ok: editsApplied || !diagnostics,
+      editsApplied,
+      fromHash,
+      toHash,
+      editedFiles,
+      misses: reports,
+      cost: totalCost,
+      summary: renderSummary(reports, editedFiles, fromHash, toHash, diagnostics),
+      diagnostics,
+    };
+  } finally {
+    await rt.close();
+  }
+}
+
+function renderSummary(reports: MissReport[], editedFiles: string[], fromHash: string, toHash: string, diagnostics?: string): string {
+  const lines: string[] = [];
+  const byOwner = (o: MissOwner) => reports.filter((r) => r.owner === o);
+  lines.push(`Triaged ${reports.length} miss(es):`);
+  for (const o of ['layer', 'skill', 'answering', 'model'] as MissOwner[]) {
+    const rs = byOwner(o);
+    if (!rs.length) continue;
+    lines.push(`  ${o}: ${rs.map((r) => r.taskId).join(', ')}`);
+    for (const r of rs) {
+      const where = r.implicatedFiles.length ? ` [${r.implicatedFiles.join(', ')}]` : '';
+      lines.push(`    - ${r.taskId} (${r.category})${where}: ${r.verdict?.rationale || r.note}`);
+    }
+  }
+  if (editedFiles.length) {
+    lines.push(`\nEdited (model_authored preserved): ${editedFiles.join(', ')}`);
+    lines.push(`Layer hash ${fromHash} → ${toHash}. Re-run evaluate to measure.`);
+  } else {
+    lines.push(`\nNo layer files edited — no miss was a structural layer defect.`);
+    if (diagnostics) lines.push(`(attempt blocked: ${diagnostics})`);
+    lines.push(`The fixes above belong in the answering skill/prompt or are model-capability limits, not the layer.`);
+  }
+  return lines.join('\n');
+}

--- a/projects/agentic-malloy/src/run-log.test.ts
+++ b/projects/agentic-malloy/src/run-log.test.ts
@@ -1,0 +1,118 @@
+/**
+ * run-log unit tests — the controllog reader that supplies layer-improve's
+ * deeper triage: correlating a results JSONL to its controllog run, the per-task
+ * tool TRACE (manner-of-failure evidence), per-tool error rates (the >15%
+ * meta-analysis trigger), and answer-shape (over/under-specification, gold-free).
+ * Pure functions over synthetic events — no controllog on disk needed.
+ */
+import { describe, it, expect } from 'vitest';
+import { correlateRun, taskTrace, toolErrorStats, answerShape, parseEvents, type ControllogEvent } from './run-log.js';
+
+function evalEvent(runId: string, taskId: string, malloy: string | null, predicted: string): ControllogEvent {
+  return { kind: 'evaluation_result', run_id: runId, actor_task_id: taskId, payload_json: { question_id: taskId, malloy_source: malloy, predicted_result: predicted } };
+}
+function toolCall(runId: string, taskId: string, callId: string, name: string, args: unknown): ControllogEvent {
+  return { kind: 'tool_call', run_id: runId, actor_task_id: taskId, payload_json: { call_id: callId, name, arguments: args } };
+}
+function toolResult(runId: string, taskId: string, callId: string, name: string, status: 'ok' | 'error', output?: string): ControllogEvent {
+  return { kind: 'tool_result', run_id: runId, actor_task_id: taskId, payload_json: { call_id: callId, name, status, output } };
+}
+
+describe('correlateRun', () => {
+  it('picks the run whose evaluation_result events best match the JSONL rows', () => {
+    const rows = [
+      { task_id: '1', malloy_source: 'run: a -> b', predicted_answer: 'x' },
+      { task_id: '2', malloy_source: 'run: c -> d', predicted_answer: 'y' },
+      { task_id: '3', malloy_source: null, predicted_answer: 'z' }, // non-submission → matched by predicted
+    ];
+    const events: ControllogEvent[] = [
+      evalEvent('R1', '1', 'run: a -> b', 'x'),
+      evalEvent('R1', '2', 'run: c -> d', 'y'),
+      evalEvent('R1', '3', null, 'z'),
+      evalEvent('R2', '1', 'run: a -> b', 'x'), // R2 only matches one row
+    ];
+    const c = correlateRun(events, rows);
+    expect(c.runId).toBe('R1');
+    expect(c.matched).toBe(3);
+    expect(c.total).toBe(3);
+  });
+
+  it('returns null when nothing matches', () => {
+    const c = correlateRun([evalEvent('R1', '9', 'run: z', 'q')], [{ task_id: '1', malloy_source: 'run: a', predicted_answer: 'x' }]);
+    expect(c.runId).toBeNull();
+    expect(c.matched).toBe(0);
+  });
+});
+
+describe('toolErrorStats (>15% trigger)', () => {
+  const events: ControllogEvent[] = [
+    // run_malloy: 10 calls, 2 errors = 20% → flagged (rate>15% AND calls>=5)
+    ...Array.from({ length: 8 }, (_, i) => toolResult('R1', 't', `m${i}`, 'run_malloy', 'ok')),
+    toolResult('R1', 't', 'm8', 'run_malloy', 'error', 'Use of select is not allowed in a grouping query'),
+    toolResult('R1', 't', 'm9', 'run_malloy', 'error', 'Use of select is not allowed in a grouping query'),
+    // query: 4 calls, 2 errors = 50% but <5 calls → NOT flagged
+    toolResult('R1', 't', 'q0', 'query', 'ok'),
+    toolResult('R1', 't', 'q1', 'query', 'ok'),
+    toolResult('R1', 't', 'q2', 'query', 'error', 'binder error'),
+    toolResult('R1', 't', 'q3', 'query', 'error', 'binder error'),
+    // list_malloy_files: 6 clean calls
+    ...Array.from({ length: 6 }, (_, i) => toolResult('R1', 't', `l${i}`, 'list_malloy_files', 'ok')),
+    // a different run's errors must not bleed in
+    toolResult('R2', 't', 'x0', 'run_malloy', 'error', 'other run'),
+  ];
+
+  it('flags only tools over the threshold with enough calls', () => {
+    const stats = toolErrorStats(events, 'R1', { threshold: 0.15, minCalls: 5 });
+    const rm = stats.find((s) => s.tool === 'run_malloy')!;
+    const q = stats.find((s) => s.tool === 'query')!;
+    const l = stats.find((s) => s.tool === 'list_malloy_files')!;
+    expect(rm.calls).toBe(10);
+    expect(rm.errors).toBe(2);
+    expect(rm.rate).toBeCloseTo(0.2);
+    expect(rm.flagged).toBe(true);
+    expect(rm.samples).toContain('Use of select is not allowed in a grouping query'); // deduped
+    expect(rm.samples.length).toBe(1);
+    expect(q.flagged).toBe(false); // 50% but only 4 calls
+    expect(l.flagged).toBe(false);
+  });
+});
+
+describe('taskTrace', () => {
+  it('joins tool_call args to tool_result status and derives signals', () => {
+    const events: ControllogEvent[] = [
+      toolCall('R1', '5', 'c0', 'list_malloy_files', {}),
+      toolResult('R1', '5', 'c0', 'list_malloy_files', 'ok'),
+      toolCall('R1', '5', 'c1', 'get_file', { files: ['dabstep.malloy'] }),
+      toolResult('R1', '5', 'c1', 'get_file', 'ok'),
+      toolCall('R1', '5', 'c2', 'run_malloy', { source: 'run: x' }),
+      toolResult('R1', '5', 'c2', 'run_malloy', 'error', 'compile error'),
+      toolCall('R1', '5', 'c3', 'submit_answer', { source: 'run: y' }),
+      toolResult('R1', '5', 'c3', 'submit_answer', 'ok'),
+      toolResult('R1', '6', 'z', 'run_malloy', 'error'), // a different task
+    ];
+    const t = taskTrace(events, 'R1', '5');
+    expect(t.toolCalls).toBe(4);
+    expect(t.exploredLayer).toBe(true);
+    expect(t.runMalloyErrors).toBe(1);
+    expect(t.submitErrors).toBe(0);
+    expect(t.steps[1]).toMatchObject({ name: 'get_file', ok: true, args: { files: ['dabstep.malloy'] } });
+    expect(t.steps[2]).toMatchObject({ name: 'run_malloy', ok: false, output: 'compile error' });
+  });
+});
+
+describe('answerShape (gold-free over/under-specification signal)', () => {
+  it('classifies scalars, lists, bracketed lists, and empties', () => {
+    expect(answerShape('5.715872')).toEqual({ kind: 'scalar', count: 1 });
+    expect(answerShape('a, b, c')).toEqual({ kind: 'list', count: 3 });
+    expect(answerShape('[B]')).toEqual({ kind: 'bracketed-list', count: 1 });
+    expect(answerShape('[a, b]')).toEqual({ kind: 'bracketed-list', count: 2 });
+    expect(answerShape('')).toEqual({ kind: 'none', count: 0 });
+    expect(answerShape(null)).toEqual({ kind: 'none', count: 0 });
+  });
+});
+
+describe('parseEvents', () => {
+  it('skips malformed lines', () => {
+    expect(parseEvents('{"kind":"a"}\nnot json\n{"kind":"b"}\n')).toHaveLength(2);
+  });
+});

--- a/projects/agentic-malloy/src/run-log.ts
+++ b/projects/agentic-malloy/src/run-log.ts
@@ -1,0 +1,206 @@
+/**
+ * run-log — read the controllog a previous eval emitted (results/controllog/
+ * events.jsonl) and reconstruct, per run, the evidence layer-improve's deeper
+ * triage needs:
+ *   - which controllog run a results JSONL corresponds to (correlateRun), since
+ *     the JSONL itself records no run_id — we match evaluation_result events by
+ *     (task_id, submitted Malloy / predicted answer);
+ *   - the per-task TOOL TRACE (the manner-of-failure evidence): the ordered tool
+ *     calls, their args, and ok/error status (taskTrace);
+ *   - run-level TOOL-ERROR rates for the meta-analysis (toolErrorStats).
+ *
+ * Everything here is pure over already-parsed events so it is unit-testable
+ * without a live controllog; loadControllog is the thin IO wrapper.
+ */
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+export const DEFAULT_CONTROLLOG_DIR = path.join(REPO_ROOT, 'results', 'controllog');
+
+export interface ControllogEvent {
+  kind?: string;
+  run_id?: string | null;
+  actor_task_id?: string | null;
+  payload_json?: Record<string, unknown>;
+}
+
+/** Parse an events.jsonl text blob (one JSON event per line). Pure. */
+export function parseEvents(text: string): ControllogEvent[] {
+  return text
+    .split('\n')
+    .filter((l) => l.trim())
+    .map((l) => {
+      try {
+        return JSON.parse(l) as ControllogEvent;
+      } catch {
+        return null;
+      }
+    })
+    .filter((e): e is ControllogEvent => e !== null);
+}
+
+export async function loadControllog(dir = DEFAULT_CONTROLLOG_DIR): Promise<ControllogEvent[]> {
+  const file = path.join(dir, 'events.jsonl');
+  if (!existsSync(file)) return [];
+  return parseEvents(await readFile(file, 'utf8'));
+}
+
+export interface RunCorrelation {
+  runId: string | null;
+  matched: number;
+  total: number;
+}
+
+/**
+ * Find the controllog run_id whose evaluation_result events best match the
+ * results-JSONL rows, by (task_id, malloy_source) — falling back to
+ * (task_id, predicted_answer) for non-submissions. Returns the best run plus how
+ * many of the file's rows it covers, so the caller can decide whether the trace
+ * is trustworthy (a low match → fall back to JSONL-only evidence). Pure.
+ */
+export function correlateRun(
+  events: ControllogEvent[],
+  rows: Array<{ task_id: string | number; malloy_source?: string | null; predicted_answer?: unknown }>,
+): RunCorrelation {
+  const rowKey = (taskId: string, malloy: string | null | undefined, pred: unknown) =>
+    malloy ? `m:${taskId}:${malloy}` : `p:${taskId}:${String(pred ?? '')}`;
+  const want = new Set(rows.map((r) => rowKey(String(r.task_id), r.malloy_source ?? null, r.predicted_answer)));
+
+  const perRun = new Map<string, Set<string>>(); // run_id -> matched row keys
+  for (const e of events) {
+    if (e.kind !== 'evaluation_result' || !e.run_id) continue;
+    const p = e.payload_json ?? {};
+    const taskId = String(p.question_id ?? e.actor_task_id ?? '');
+    const k = rowKey(taskId, (p.malloy_source as string | null) ?? null, p.predicted_result);
+    if (want.has(k)) {
+      const s = perRun.get(e.run_id) ?? new Set<string>();
+      s.add(k);
+      perRun.set(e.run_id, s);
+    }
+  }
+  let runId: string | null = null;
+  let matched = 0;
+  for (const [rid, s] of perRun) {
+    if (s.size > matched) {
+      matched = s.size;
+      runId = rid;
+    }
+  }
+  return { runId, matched, total: rows.length };
+}
+
+export interface ToolStep {
+  name: string;
+  ok: boolean;
+  args?: unknown;
+  output?: string;
+}
+
+export interface TaskTrace {
+  taskId: string;
+  steps: ToolStep[];
+  /** the agent navigated the layer (list_malloy_files / get_file). */
+  exploredLayer: boolean;
+  runMalloyErrors: number;
+  submitErrors: number;
+  toolCalls: number;
+}
+
+/** Reconstruct one task's tool trace for a run by joining tool_call args to
+ *  tool_result status/output via call_id. Pure. */
+export function taskTrace(events: ControllogEvent[], runId: string, taskId: string): TaskTrace {
+  const argsByCall = new Map<string, { name: string; args: unknown }>();
+  for (const e of events) {
+    if (e.kind === 'tool_call' && e.run_id === runId && String(e.actor_task_id) === taskId) {
+      const p = e.payload_json ?? {};
+      argsByCall.set(String(p.call_id), { name: String(p.name), args: p.arguments });
+    }
+  }
+  const steps: ToolStep[] = [];
+  let runMalloyErrors = 0;
+  let submitErrors = 0;
+  let exploredLayer = false;
+  for (const e of events) {
+    if (e.kind !== 'tool_result' || e.run_id !== runId || String(e.actor_task_id) !== taskId) continue;
+    const p = e.payload_json ?? {};
+    const name = String(p.name);
+    const ok = p.status === 'ok';
+    const call = argsByCall.get(String(p.call_id));
+    steps.push({ name, ok, args: call?.args, output: p.output !== undefined ? String(p.output) : undefined });
+    if (name === 'list_malloy_files' || name === 'get_file') exploredLayer = true;
+    if (!ok && name === 'run_malloy') runMalloyErrors++;
+    if (!ok && name === 'submit_answer') submitErrors++;
+  }
+  return { taskId, steps, exploredLayer, runMalloyErrors, submitErrors, toolCalls: steps.length };
+}
+
+export interface ToolErrorStat {
+  tool: string;
+  calls: number;
+  errors: number;
+  rate: number; // 0..1
+  /** distinct sample error outputs (deduped, trimmed). */
+  samples: string[];
+  flagged: boolean; // rate > threshold AND calls >= minCalls
+}
+
+/**
+ * Per-tool error rate across a whole run (the meta-analysis input). A tool is
+ * flagged when its error rate exceeds `threshold` (default 15%) and it was
+ * called at least `minCalls` times (so a 1-of-2 fluke isn't flagged). Pure.
+ */
+export function toolErrorStats(
+  events: ControllogEvent[],
+  runId: string,
+  opts: { threshold?: number; minCalls?: number; maxSamples?: number } = {},
+): ToolErrorStat[] {
+  const threshold = opts.threshold ?? 0.15;
+  const minCalls = opts.minCalls ?? 5;
+  const maxSamples = opts.maxSamples ?? 4;
+  const calls = new Map<string, number>();
+  const errors = new Map<string, number>();
+  const samples = new Map<string, Set<string>>();
+  for (const e of events) {
+    if (e.kind !== 'tool_result' || e.run_id !== runId) continue;
+    const p = e.payload_json ?? {};
+    const name = String(p.name);
+    calls.set(name, (calls.get(name) ?? 0) + 1);
+    if (p.status !== 'ok') {
+      errors.set(name, (errors.get(name) ?? 0) + 1);
+      const set = samples.get(name) ?? new Set<string>();
+      if (set.size < maxSamples && p.output !== undefined) set.add(String(p.output).slice(0, 240));
+      samples.set(name, set);
+    }
+  }
+  const out: ToolErrorStat[] = [];
+  for (const [tool, n] of calls) {
+    const err = errors.get(tool) ?? 0;
+    const rate = n ? err / n : 0;
+    out.push({ tool, calls: n, errors: err, rate, samples: [...(samples.get(tool) ?? [])], flagged: rate > threshold && n >= minCalls });
+  }
+  out.sort((a, b) => b.rate - a.rate || b.calls - a.calls);
+  return out;
+}
+
+export type AnswerShapeKind = 'none' | 'scalar' | 'list' | 'bracketed-list';
+
+export interface AnswerShape {
+  kind: AnswerShapeKind;
+  count: number; // number of comma-separated items (1 for a scalar)
+}
+
+/** Coarse shape of a predicted answer string — feeds over/under-specification
+ *  reasoning WITHOUT the gold answer (it's the agent's own output). Pure. */
+export function answerShape(predicted: unknown): AnswerShape {
+  if (predicted === null || predicted === undefined || String(predicted).trim() === '') return { kind: 'none', count: 0 };
+  const s = String(predicted).trim();
+  const bracketed = /^\[.*\]$/.test(s);
+  const inner = bracketed ? s.slice(1, -1) : s;
+  const items = inner.split(',').map((x) => x.trim()).filter(Boolean);
+  if (bracketed) return { kind: 'bracketed-list', count: items.length };
+  if (items.length > 1) return { kind: 'list', count: items.length };
+  return { kind: 'scalar', count: 1 };
+}

--- a/projects/agentic-malloy/src/skill.md
+++ b/projects/agentic-malloy/src/skill.md
@@ -111,3 +111,7 @@ Plain SQL tools are for *exploration only* and never produce the answer.
 - A concept the data/manual does not define → `Not Applicable`. An empty result
   set for a real metric → the empty string, not `Not Applicable` (and a NULL inside a
   list is a bug to filter out, not a value to emit).
+
+## Auto-added robustness rules (layer-improve)
+- Teach Malloy operator rules: use `group_by`+`aggregate` (not `select`) in grouping queries; use `aggregate:` (not `calculate:`) for sums/avgs/counts — `calculate:` is only for window ops over already-grouped rows; to pick the max-of-aggregate row, compute the aggregate in an inner query then filter/top in an outer stage rather than using HAVING with a window; cast with `field::type` using the bare type keyword (string/number/date), not function-call syntax like `string_type(...)`.  _(why: submit_answer errored 42% of the time: Agent repeatedly misuses Malloy query operators (select in grouping, calculate with aggregates, HAVING with window funcs, bad cast syntax))_
+- Teach Malloy query shape: use 'select:' only for projection of scalar/dimension fields (no aggregates, no group_by in the same view); use 'group_by:' + 'aggregate:' together for grouped queries; aggregates must be defined via 'aggregate:' (not 'select:'); only reference aliases defined in the current query scope; ensure function arg types match (e.g. round(number, number) takes scalars, not a source).  _(why: run_malloy errored 22% of the time: Agent confuses Malloy's select vs group_by/aggregate semantics and references undefined aliases)_

--- a/projects/agentic-malloy/src/upload.ts
+++ b/projects/agentic-malloy/src/upload.ts
@@ -7,6 +7,13 @@
  * STRUCTs (the dive does `payload_json.field` struct access — a plain JSON column
  * would break it). controllog appends every run to one events.jsonl, so a full
  * rebuild each upload is idempotent and keeps all runs for cross-run comparison.
+ *
+ * `map_inference_threshold=-1` is REQUIRED: payload_json holds many distinct keys
+ * across event kinds (model/tool/eval/run_metadata/improvement_recommendation/…),
+ * and past DuckDB's default MAP-inference threshold read_json_auto flips the column
+ * STRUCT→MAP(VARCHAR, JSON). Under a MAP every value is JSON, so the dive's numeric
+ * aggregations (`avg(payload_json.duration_ms)`, cost_usd, tokens, …) fail with
+ * "avg(JSON)". Disabling MAP inference keeps it a STRUCT with typed fields.
  */
 import { DuckDBInstance } from '@duckdb/node-api';
 import { existsSync } from 'node:fs';
@@ -36,13 +43,13 @@ export async function uploadControllog(opts: {
     await conn.run("ATTACH 'md:'");
     await conn.run(`CREATE DATABASE IF NOT EXISTS ${db}`);
     await conn.run(
-      `CREATE OR REPLACE TABLE ${db}.main.events AS SELECT * FROM read_json_auto('${eventsPath}', format='newline_delimited')`,
+      `CREATE OR REPLACE TABLE ${db}.main.events AS SELECT * FROM read_json_auto('${eventsPath}', format='newline_delimited', map_inference_threshold=-1)`,
     );
     const events = Number((await conn.runAndReadAll(`SELECT count(*) AS n FROM ${db}.main.events`)).getRowObjects()[0].n);
     let postings = 0;
     if (existsSync(postingsPath)) {
       await conn.run(
-        `CREATE OR REPLACE TABLE ${db}.main.postings AS SELECT * FROM read_json_auto('${postingsPath}', format='newline_delimited')`,
+        `CREATE OR REPLACE TABLE ${db}.main.postings AS SELECT * FROM read_json_auto('${postingsPath}', format='newline_delimited', map_inference_threshold=-1)`,
       );
       postings = Number((await conn.runAndReadAll(`SELECT count(*) AS n FROM ${db}.main.postings`)).getRowObjects()[0].n);
     }


### PR DESCRIPTION
Builds `asm-malloy layer-improve --from <run.jsonl>` — the Phase-1 targeted-repair step (PLAN.md), deferred until now. Stacks on #56 (base = `malloy-vs-context-experiment`); the diff here is just the 5 commits below.

## What it does
Takes the existing model-authored layer + an eval run's misses, triages each, and edits the layer **only** for genuine structural defects — keeping provenance `model_authored`.

### Triage — deterministic-first, then model
- Re-runs each miss's submitted Malloy through the runtime and **smoke-runs every named layer view it referenced**. A pure `classifyMiss()` decides from that evidence alone: a named view that errors / is wrongly empty on its own ⇒ **layer** defect; a query that re-runs fine but returns wrong rows ⇒ **skill**; no submission ⇒ **answering**. A layer *edit* requires BOTH the structural probe AND a model verdict of `layer` — the model can't conjure a defect the data doesn't show.

### Manner of failure (from the logs)
- Correlates the run to its controllog by `(task_id, submitted Malloy)` (the JSONL has no run_id), pulls each miss's **tool trace**, and a model verdict labels *how* it failed: `overspecified` · `underspecified` · `hallucination` · `layer_not_used` · `wrong_logic` · `gave_up` — with a recommended fix location. Answer-shape + "did it reuse a named view" feed over/under-specification reasoning, all gold-free. `--no-manner` restores the cheap deterministic-only path.

### Tool-error meta-analysis
- Aggregates per-tool error rate; any tool over `--tool-error-threshold` (default 0.15, min 5 calls) gets a model diagnosis of the *systemic* cause + fix location. Layer-cause routes into repair (only if a view is actually broken); skill/linter causes are appended to a marked section of `src/skill.md` **by default** (it only fires for a flagged tool, so it stays sparing) — `--no-apply-skill-fixes` to only recommend. The skill is a tunable prompt, not the layer, so this never touches `malloy_provenance`.

## Constitutional constraints (Phase-3 critical)
- **No leakage:** prompts see only structural evidence (failing Malloy, exec diagnostics, "view returns 0/errors", column profile, manual, the agent's own trace) — **never the gold answer**, never tuned to a train value.
- **Don't regress:** minimal atomic `{old,new}` edits, re-validated by the P0 gate (compile + execute every view); a post-edit all-views failure **rolls back every edit** and leaves provenance untouched.
- **Honest / idempotent:** when no miss is a structural defect, it edits nothing, leaves the hash/provenance alone, and reports where each fix belongs; on a real edit it re-hashes + re-stamps `model_authored` with an `improve_lineage` + emits a controllog build run. `--re-eval` re-runs the same task-ids.

## Also in this PR
- **Upload fix** (`map_inference_threshold=-1`): controllog `payload_json` had flipped STRUCT→`MAP(VARCHAR, JSON)` as event kinds grew, breaking the dive's numeric aggregations (`avg(JSON)`). Now stays a typed STRUCT.
- **`src/skill.md`**: 2 general Malloy-usage robustness rules auto-applied by a `layer-improve` pass over the gemini run (no DABstep facts; layer untouched).

## Results
- **Official 26/26 (100%)** — sonnet author / opus fixer, `run_class=official`, model_authored layer `f2163373`, clean committed tree, $3.40 (up from the prior official 25/26).
- `layer-improve` on the gemini-3-flash arm fixed the targeted misses (22/26 → 23/26) and the applied skill rules dropped the flagged tool-error rates (`submit_answer` 42%→19%, `run_malloy` 22%→18%; total tool errors ~halved).

## Verification
- `npx tsc --noEmit` clean; **75/75 vitest** (new: miss→file mapping, layer-vs-skill triage, run-log correlation / tool-error stats / trace reconstruction / answer-shape, and no-leakage tests for the evidence + trace blocks).
- Live no-op proven on the official run (1290 → skill, $0, layer + provenance unchanged) and end-to-end on the gemini run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)