### PR TITLE
agentic-malloy: layer-improve leak guards (full-run train check · official dirty-tree refusal · opt-in skill writes)

### DIFF
--- a/projects/agentic-malloy/README.md
+++ b/projects/agentic-malloy/README.md
@@ -110,19 +110,22 @@ human) complement to the rule above: it triages a run's misses and edits the lay
   tool over **15%** (`--tool-error-threshold`) gets a model diagnosis of the
   *systemic* cause + where the durable fix belongs. A layer-cause routes into the
   repair path (only if a view is actually broken); skill/linter causes become
-  precise recommendations. A diagnosed `skill` rule is appended to a marked section
-  of `src/skill.md` **by default** (it only ever fires for a tool over the >15%
-  threshold, so it stays sparing) — `--no-apply-skill-fixes` to only recommend. The
-  skill is a tunable prompt, not the layer, so this never touches `malloy_provenance`.
+  precise recommendations. A diagnosed `skill` rule is **recommend-only by default**;
+  `--apply-skill-fixes` (opt-in) appends it to a marked section of `src/skill.md` so a
+  default run never mutates a tracked file. The skill is a tunable prompt, not the
+  layer, so this never touches `malloy_provenance` — but because it's still an
+  uncommitted prompt change, an `evaluate --run-class official` **refuses to run on a
+  dirty tracked tree** (commit first), so an official number can't be scored on it.
 - **No leakage.** A repair prompt sees only the failing Malloy, exec diagnostics,
   "this view returns 0/errors", the column profile, and the manual — **never the
   gold answer**, and it must not tune to a train value. Fixes are general
   (join scope, wildcard/domain handling, grain), exactly like `layer-build`.
 - **Train-only edits.** A layer edit (and a skill-fix application) is **refused**
-  when the `--from` run includes any held-out/test task — checked against
-  `data/split.json`, not the row's recorded split. This stops held-out traces from
-  tuning the layer while still passing the official gate; such runs are
-  triaged/reported only.
+  when ANY task in the `--from` run (passers included, not just the misses) is
+  outside the train split — checked against `data/split.json`, not the row's
+  recorded split. The full-run check matters because the tool-error meta-analysis
+  spans every row, so a held-out passer's trace must not influence a write. Such
+  runs are triaged/reported only.
 - **Don't regress.** Edits are minimal atomic `{old,new}` patches, re-validated by
   the same P0 gate (compile + execute every view). If the post-edit all-views gate
   fails, **every edit is rolled back** and provenance is left untouched.

--- a/projects/agentic-malloy/src/cli.ts
+++ b/projects/agentic-malloy/src/cli.ts
@@ -400,6 +400,13 @@ async function cmdEvaluate(flags: Record<string, string | boolean>) {
     if (prov.manual_included !== true) reasons.push(`layer built without the manual (manual_included=${prov.manual_included})`);
     if (author !== resolveModel('sonnet')) reasons.push(`author must be sonnet (got ${author})`);
     if (fixer !== resolveModel('opus')) reasons.push(`fixer must be opus (got ${fixer})`);
+    // An official number must be REPRODUCIBLE from the recorded commit_sha. A dirty
+    // tracked tree (e.g. layer-improve having modified src/skill.md, or any layer
+    // edit) means the scored prompt/layer state isn't committed — refuse, don't
+    // just warn. This closes "--re-eval --run-class official scores on a dirty
+    // prompt state". (Smoke runs still only warn — see below.)
+    const dirty = gitDirtyTrackedFiles();
+    if (dirty.length) reasons.push(`uncommitted tracked changes (${dirty.length}) — an official run must be reproducible; commit first (layer-improve may have edited src/skill.md):\n      ${dirty.slice(0, 8).join('\n      ')}${dirty.length > 8 ? `\n      … and ${dirty.length - 8} more` : ''}`);
     if (reasons.length) {
       throw new Error(`Refusing an OFFICIAL run:\n  - ${reasons.join('\n  - ')}\nUse --run-class smoke for experiments.`);
     }
@@ -454,15 +461,14 @@ async function cmdEvaluate(flags: Record<string, string | boolean>) {
   const scorer = new ScoreClient();
 
   // Reproducibility: the recorded commit_sha only describes this run if the
-  // tracked code is committed. Warn loudly on uncommitted tracked changes (an
-  // official run that backs the claim should be clean).
+  // tracked code is committed. Official runs REFUSE a dirty tree (above); smoke
+  // runs warn loudly but proceed.
   const commitSha = gitOutput('rev-parse HEAD');
   const dirtyFiles = gitDirtyTrackedFiles();
   if (dirtyFiles.length) {
     console.warn(`\n⚠️  ${dirtyFiles.length} uncommitted tracked change(s) — this run is NOT reproducible from commit ${commitSha?.slice(0, 8) ?? '(unknown)'}:`);
     for (const f of dirtyFiles.slice(0, 20)) console.warn(`     ${f}`);
     if (dirtyFiles.length > 20) console.warn(`     … and ${dirtyFiles.length - 20} more`);
-    if (runClass === 'official') console.warn(`   ▶ OFFICIAL run with a dirty tree — commit your changes for a reproducible result.`);
     console.warn('');
   }
 
@@ -587,11 +593,12 @@ async function cmdLayerImprove(flags: Record<string, string | boolean>) {
   // same data, matches the build gate). --md re-executes against MotherDuck.
   const motherduckDb = flags.md ? ((flags.database as string) || process.env.MD_DATABASE || 'agentic_malloy') : undefined;
   // --no-manner skips the per-miss failure-MANNER model call (cheaper; model
-  // call then fires only for layer-suspected misses). Tool-error robustness rules
-  // are appended to src/skill.md BY DEFAULT (only ever triggered by a tool over
-  // the >15% error threshold, so it stays sparing); --no-apply-skill-fixes opts out.
+  // call then fires only for layer-suspected misses). --apply-skill-fixes is
+  // OPT-IN: by default a diagnosed tool-error rule is only RECOMMENDED, not
+  // written to src/skill.md — a default run never mutates a tracked file, and an
+  // official re-eval can't silently score on an uncommitted prompt change.
   const manner = !flags['no-manner'];
-  const applySkillFixes = !flags['no-apply-skill-fixes'];
+  const applySkillFixes = !!flags['apply-skill-fixes'];
   const toolErrorThreshold = flags['tool-error-threshold'] ? Number(flags['tool-error-threshold']) : undefined;
 
   // Wrap in a controllog session so the improve pass shows in the dive's Build tab.
@@ -676,11 +683,11 @@ async function main() {
       console.log('  load [--motherduck --database agentic_malloy]');
       console.log('  layer-build --model opus --reasoning medium [--no-manual] [--max-rounds 3] [--provider anthropic]');
       console.log('  layer-improve --from results/RUN.jsonl [--model opus --reasoning medium --max-rounds 4] \\');
-      console.log('           [--provider anthropic] [--md [--database agentic_malloy]] [--no-manner] [--no-apply-skill-fixes] \\');
+      console.log('           [--provider anthropic] [--md [--database agentic_malloy]] [--no-manner] [--apply-skill-fixes] \\');
       console.log('           [--tool-error-threshold 0.15] [--re-eval --author sonnet --fixer opus --run-class official]');
       console.log('           (triages a run\'s misses by MANNER of failure + runs a tool-error meta-analysis;');
-      console.log('            edits the layer ONLY for structural defects, never tunes to a gold answer;');
-      console.log('            tool-error robustness rules are appended to src/skill.md by default → --no-apply-skill-fixes to only recommend)');
+      console.log('            edits the layer ONLY for structural defects from TRAIN-only runs, never tunes to a gold answer;');
+      console.log('            tool-error rules are recommend-only unless --apply-skill-fixes; an official re-eval refuses a dirty tree)');
       console.log('  evaluate --split templates|test|all --task-id ID --author sonnet --fixer opus \\');
       console.log('           --run-class smoke|official --escalate-after 2 --concurrency 4 --limit N [--provider anthropic]');
       console.log('           (--provider pins the OpenRouter upstream; defaults to $OPENROUTER_PROVIDER)');

--- a/projects/agentic-malloy/src/layer-improve.ts
+++ b/projects/agentic-malloy/src/layer-improve.ts
@@ -28,7 +28,6 @@ import { columnProfiles, hashLayerOnDisk, readDoc, validateModel, MODELS_DIR, DA
 import * as cl from './controllog.js';
 import { MalloyRuntime } from './malloy-runtime.js';
 import {
-  readMisses,
   loadLayerIndex,
   analyzeMiss,
   classifyMiss,
@@ -131,14 +130,19 @@ export async function improveLayer(opts: {
   const fromHash = await hashLayerOnDisk();
   const databasePath = opts.motherduckDb ? `md:${opts.motherduckDb}` : undefined;
 
-  const misses = await readMisses(opts.fromPath);
+  // Read the FULL run (passers + misses). The train-only guard MUST consider
+  // every task_id, not just the misses: the tool-error meta-analysis spans the
+  // whole run, so a held-out PASSER's trace could otherwise influence a
+  // skill/layer write even when all the misses happen to be train.
+  const allRows = (await readFile(opts.fromPath, 'utf8')).split('\n').filter((l) => l.trim()).map((l) => JSON.parse(l) as MissRow);
+  const misses = allRows.filter((r) => r.is_correct === false);
 
   // P1 guard: a layer edit (or skill-fix application) must NEVER be driven by a
-  // run that includes held-out/test tasks — that would tune the layer on the
-  // generalization set while still passing the official gate. Check the actual
-  // task_ids against the train split.
+  // run that includes held-out/test tasks — that would tune the layer/skill on
+  // the generalization set while still passing the official gate. Checked over
+  // the WHOLE run against the train split.
   const trainIds = await loadTrainIds();
-  const nonTrain = nonTrainTaskIds(misses.map((m) => m.task_id), trainIds);
+  const nonTrain = nonTrainTaskIds(allRows.map((r) => r.task_id), trainIds);
   const trainOnly = nonTrain.length === 0;
 
   if (opts.runId) {
@@ -159,7 +163,6 @@ export async function improveLayer(opts: {
   // Correlate the run to its controllog so we can read the per-task tool TRACE
   // (the manner-of-failure evidence) + the run-level tool-error rates. Best
   // effort: a low match → trace is omitted and we judge from the JSONL alone.
-  const allRows = (await readFile(opts.fromPath, 'utf8')).split('\n').filter((l) => l.trim()).map((l) => JSON.parse(l) as MissRow);
   const events = await loadControllog(opts.controllogDir ?? DEFAULT_CONTROLLOG_DIR);
   const corr = correlateRun(events, allRows);
   const runId = corr.runId;


### PR DESCRIPTION
Addresses two further review findings (PR #56 review threads). Base = `malloy-vs-context-experiment`.

## P1 — train-only guard must cover the FULL run ([discussion r3432285278](https://github.com/motherduckdb/labs/pull/56#discussion_r3432285278))
**Before:** the train-only guard checked only the *incorrect* rows, but the tool-error meta-analysis spans the **whole run**. A run mixing train misses + held-out **passers** would pass the guard (misses all train) yet let the held-out passers' tool traces influence a skill/layer write.
**Fix:** the guard now checks **every** task_id in the `--from` file (passers included) against `data/split.json`; any held-out task disables all writes (triage/report-only). Verified live: a train miss + a held-out passer is refused.

## cli.ts:594 — default skill mutation + dirty official scoring
**Before:** `layer-improve` wrote `src/skill.md` **by default**, and `--re-eval --run-class official` could then score on that uncommitted prompt state (the dirty-tree check was only a warning).
**Fix, two parts:**
1. `--apply-skill-fixes` is now **opt-in** (default recommend-only) — a default `layer-improve` run never mutates a tracked file.
2. `evaluate --run-class official` now **refuses** (hard error, not a warning) on a dirty tracked tree, so an official number can never be scored on uncommitted skill/layer edits — commit first. (Smoke still warns and proceeds.) Verified live: an official run throws on a dirty tree.

## Verification
- `npx tsc --noEmit` clean; **80/80 vitest**.
- Live: full-run guard refuses a train-miss + held-out-passer run; official run throws on a dirty tree.

Note: this reverses the earlier "apply skill fixes by default" choice in favor of the reviewer's repeated P1 — `--apply-skill-fixes` still applies them when explicitly requested (and only for train-only runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)