### PR TITLE
agentic-malloy: layer-improve --re-eval downgrades to smoke after edits (fix self-contradictory official refusal)

### DIFF
--- a/projects/agentic-malloy/README.md
+++ b/projects/agentic-malloy/README.md
@@ -134,7 +134,10 @@ human) complement to the rule above: it triages a run's misses and edits the lay
   untouched, and reports where each fix belongs (skill / prompt / model-capability).
   On a successful edit it re-hashes, re-stamps `model_authored` with an
   `improve_lineage` (from/to hash, round, edited files, source run), and emits a
-  controllog build run. `--re-eval` then re-runs the same task-ids to measure.
+  controllog build run. `--re-eval` then re-runs the same task-ids to measure —
+  always as a **smoke** run (the just-edited layer/skill is uncommitted, and an
+  official run requires a clean tree), so commit the edits and run
+  `evaluate --run-class official` separately to record an official number.
 
 ## Harness status
 

--- a/projects/agentic-malloy/src/cli.ts
+++ b/projects/agentic-malloy/src/cli.ts
@@ -627,8 +627,16 @@ async function cmdLayerImprove(flags: Record<string, string | boolean>) {
       return;
     }
     const ids = (await readFile(fromPath, 'utf8')).split('\n').filter((l) => l.trim()).map((l) => String((JSON.parse(l) as { task_id: unknown }).task_id));
-    console.log(`\n▶ re-evaluating ${ids.length} task-id(s) from ${path.basename(fromPath)} to measure the improvement …`);
-    await cmdEvaluate({ ...flags, 'task-id': ids.join(','), from: undefined as unknown as string });
+    // A successful repair leaves the edited layer/skill UNCOMMITTED, and an
+    // official run refuses a dirty tree. So an in-process official re-eval is
+    // self-contradictory — measure now as SMOKE, and point the user at the
+    // commit-then-official flow for a recordable number.
+    const reEvalRunClass = (flags['run-class'] === 'official') ? 'smoke' : ((flags['run-class'] as string) || 'smoke');
+    if (flags['run-class'] === 'official') {
+      console.log(`\nℹ️  re-eval runs as SMOKE: the just-edited layer/provenance${res.skillFixesApplied.length ? '/skill' : ''} is uncommitted, and an official run requires a clean tree. To record an official number: commit the edits, then run \`asm-malloy evaluate --split ${(flags.split as string) || 'templates'} --run-class official\`.`);
+    }
+    console.log(`\n▶ re-evaluating ${ids.length} task-id(s) from ${path.basename(fromPath)} to measure the improvement (run_class=${reEvalRunClass}) …`);
+    await cmdEvaluate({ ...flags, 'run-class': reEvalRunClass, 'task-id': ids.join(','), from: undefined as unknown as string });
   }
 }
 
@@ -684,10 +692,11 @@ async function main() {
       console.log('  layer-build --model opus --reasoning medium [--no-manual] [--max-rounds 3] [--provider anthropic]');
       console.log('  layer-improve --from results/RUN.jsonl [--model opus --reasoning medium --max-rounds 4] \\');
       console.log('           [--provider anthropic] [--md [--database agentic_malloy]] [--no-manner] [--apply-skill-fixes] \\');
-      console.log('           [--tool-error-threshold 0.15] [--re-eval --author sonnet --fixer opus --run-class official]');
+      console.log('           [--tool-error-threshold 0.15] [--re-eval --author sonnet --fixer opus]');
       console.log('           (triages a run\'s misses by MANNER of failure + runs a tool-error meta-analysis;');
       console.log('            edits the layer ONLY for structural defects from TRAIN-only runs, never tunes to a gold answer;');
-      console.log('            tool-error rules are recommend-only unless --apply-skill-fixes; an official re-eval refuses a dirty tree)');
+      console.log('            tool-error rules are recommend-only unless --apply-skill-fixes;');
+      console.log('            --re-eval measures edits as SMOKE — commit, then `evaluate --run-class official` to record a number)');
       console.log('  evaluate --split templates|test|all --task-id ID --author sonnet --fixer opus \\');
       console.log('           --run-class smoke|official --escalate-after 2 --concurrency 4 --limit N [--provider anthropic]');
       console.log('           (--provider pins the OpenRouter upstream; defaults to $OPENROUTER_PROVIDER)');


### PR DESCRIPTION
Fixes the P2 from [discussion r3437562413](https://github.com/motherduckdb/labs/pull/56#discussion_r3437562413). Base = `malloy-vs-context-experiment`.

**Problem:** the new official dirty-tree gate (PR #63) made `layer-improve --re-eval --run-class official` self-contradictory — a *successful* repair leaves the edited layer/provenance (and skill, under `--apply-skill-fixes`) uncommitted, so the in-process re-eval then hard-refuses the dirty tree and exits non-zero *after* the repair already succeeded. And `--re-eval` only ever runs when edits were applied, so an official re-eval always hit this.

**Fix:** the in-process `--re-eval` now runs as **smoke** whenever `--run-class official` was requested, with a clear note pointing at the proper flow — commit the edits, then run `evaluate --run-class official` to record an official number. The official reproducibility guard is untouched; the contradiction is gone, and you still get an immediate post-edit measurement.

## Verification
- `npx tsc --noEmit` clean; **80/80 vitest**.

Design note: I chose **downgrade-to-smoke** over erroring early so the "improve + measure now" flow still works (an immediate smoke measurement is exactly what you want post-edit; the official number is locked separately after commit). If the reviewer prefers an early hard-error on `--re-eval --run-class official` instead, that's a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)