### PR TITLE
agentic-malloy: B2/I1 — closed-book view-degeneracy gate (catches wrong-grain views)

### DIFF
--- a/projects/agentic-malloy/src/layer-build.ts
+++ b/projects/agentic-malloy/src/layer-build.ts
@@ -26,6 +26,7 @@ import { fileURLToPath } from 'node:url';
 import { DuckDBInstance } from '@duckdb/node-api';
 import { complete } from './llm-client.js';
 import { MalloyRuntime } from './malloy-runtime.js';
+import { viewQualitySmells, smellSummary } from './view-quality.js';
 import * as cl from './controllog.js';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -288,10 +289,14 @@ export function sourceNamesIn(src: string): string[] {
  */
 export async function validateModel(
   modelFile?: string,
-  opts: { modelsDir?: string; dbPath?: string } = {},
-): Promise<{ ok: boolean; diag: string }> {
+  opts: { modelsDir?: string; dbPath?: string; checkQuality?: boolean } = {},
+): Promise<{ ok: boolean; diag: string; smellDiag?: string }> {
   const modelsDir = opts.modelsDir ?? MODELS_DIR;
   const rt = new MalloyRuntime({ ...(opts.dbPath ? { databasePath: opts.dbPath } : {}), modelsDir });
+  // With checkQuality, pull enough rows to judge a view's output distribution (the
+  // degeneracy detector); otherwise 1 row is enough to prove it executes.
+  const cap = opts.checkQuality ? 500 : 1;
+  const smellLines: string[] = [];
   try {
     const inv = await rt.describe(); // compile check (throws on compile error)
     if (modelFile && existsSync(path.join(modelsDir, modelFile))) {
@@ -299,7 +304,7 @@ export async function validateModel(
       for (const s of inv.sources) {
         if (!mine.has(s)) continue;
         for (const view of inv.viewsBySource[s] ?? []) {
-          const r = await rt.run(`run: ${s} -> ${view}`, 1);
+          const r = await rt.run(`run: ${s} -> ${view}`, cap);
           if (!r.ok) {
             const errText = (r.diagnostics ?? []).map((d) => d.message).join('\n');
             // Only the binder/scope class points to the join_many materialization
@@ -315,10 +320,18 @@ export async function validateModel(
               diag: `The view \`${s} -> ${view}\` COMPILES but FAILS TO EXECUTE — a view that cannot run is unusable. Fix the source so this query runs.${hint}\nExecution error:\n${errText}`,
             };
           }
+          // Executed OK. With checkQuality, also flag DEGENERATE output (B2): a
+          // view that runs but doesn't compute what its name implies (e.g. a
+          // ranking where most rows tie at the max because the grain folds in
+          // wildcard rows). Advisory — never fails execution; returned separately.
+          if (opts.checkQuality) {
+            const smells = viewQualitySmells(r.rows ?? []);
+            if (smells.length) smellLines.push(smellSummary(`${s} -> ${view}`, smells));
+          }
         }
       }
     }
-    return { ok: true, diag: '' };
+    return { ok: true, diag: '', ...(smellLines.length ? { smellDiag: smellLines.join('\n\n') } : {}) };
   } catch (e) {
     const problems = (e as { problems?: Array<{ message: string }> })?.problems;
     return { ok: false, diag: problems ? problems.map((p) => p.message).join('\n') : e instanceof Error ? e.message : String(e) };
@@ -386,6 +399,7 @@ async function authorStage(opts: {
   let current: string | null = null; // last-written malloy (for edit rounds)
   let metaWritten = false;
   let forceFull = false; // set when an edit round produced no applicable edits
+  let smellNudged = false; // B2: a degeneracy nudge is given at most once, then accepted
 
   for (let round = 1; round <= opts.maxRounds; round++) {
     const editMode = round > 1 && current !== null && !forceFull;
@@ -474,14 +488,24 @@ async function authorStage(opts: {
     }
 
     const cv0 = Date.now();
-    const v = await validateModel(opts.modelFile, { modelsDir: opts.modelsDir, dbPath: opts.dbPath }); // compile + execute the file's views
+    const v = await validateModel(opts.modelFile, { modelsDir: opts.modelsDir, dbPath: opts.dbPath, checkQuality: true }); // compile + execute + degeneracy check
     if (opts.runId) {
       const callId = cl.newId();
       cl.toolCall({ taskId: opts.label, runId: opts.runId, name: 'compile_check', callId, arguments: { round, mode }, model: opts.model });
-      cl.toolResult({ taskId: opts.label, runId: opts.runId, name: 'compile_check', callId, ok: v.ok, durationMs: Date.now() - cv0, model: opts.model, output: v.ok ? 'ok' : v.diag.slice(0, 1500) });
+      cl.toolResult({ taskId: opts.label, runId: opts.runId, name: 'compile_check', callId, ok: v.ok, durationMs: Date.now() - cv0, model: opts.model, output: v.ok ? (v.smellDiag ? `ok (degenerate: ${v.smellDiag.slice(0, 400)})` : 'ok') : v.diag.slice(0, 1500) });
     }
     if (v.ok) {
-      console.log(`  ✓ ${opts.label} (round ${round}, ${mode}, $${agg.cost.toFixed(4)})`);
+      // B2: the file executes. If a view is DEGENERATE (runs but doesn't compute
+      // what its name implies), nudge the author ONCE with the smell + the
+      // wildcard/grain fix — then accept (some skews are legitimate; never deadlock).
+      if (v.smellDiag && !smellNudged) {
+        smellNudged = true;
+        forceFull = true;
+        diag = `${v.smellDiag}\n\nThis is usually a WRONG-GRAIN bug: an aggregate that folds in "applies-to-all"/wildcard rows (which are common to every group and don't discriminate) collapses the ranking. FIX generically: rank/compare by the ENTITY-SPECIFIC rows, or expose BOTH a specific-only and an effective (incl. wildcard) measure so the answer can pick. Re-author this file to fix the degenerate view(s).`;
+        console.log(`  ⚠ ${opts.label} round ${round}: degenerate view — nudging once:\n${v.smellDiag.split('\n').slice(0, 4).map((l) => '      ' + l).join('\n')}`);
+        continue;
+      }
+      console.log(`  ✓ ${opts.label} (round ${round}, ${mode}, $${agg.cost.toFixed(4)})${v.smellDiag ? ' [accepted with degeneracy smell]' : ''}`);
       return { ok: true, ...agg };
     }
     console.log(`  ✗ ${opts.label} round ${round} (${mode}) error:\n${v.diag.split('\n').slice(0, 6).map((l) => '      ' + l).join('\n')}`);

--- a/projects/agentic-malloy/src/layer-build.ts
+++ b/projects/agentic-malloy/src/layer-build.ts
@@ -497,8 +497,10 @@ async function authorStage(opts: {
     if (v.ok) {
       // B2: the file executes. If a view is DEGENERATE (runs but doesn't compute
       // what its name implies), nudge the author ONCE with the smell + the
-      // wildcard/grain fix — then accept (some skews are legitimate; never deadlock).
-      if (v.smellDiag && !smellNudged) {
+      // wildcard/grain fix — but ONLY when a re-author round remains. Smells are
+      // ADVISORY: they must NEVER turn a passing build into a failure, so a smell
+      // that first appears on the final allowed round is accepted, not nudged.
+      if (v.smellDiag && !smellNudged && round < opts.maxRounds) {
         smellNudged = true;
         forceFull = true;
         diag = `${v.smellDiag}\n\nThis is usually a WRONG-GRAIN bug: an aggregate that folds in "applies-to-all"/wildcard rows (which are common to every group and don't discriminate) collapses the ranking. FIX generically: rank/compare by the ENTITY-SPECIFIC rows, or expose BOTH a specific-only and an effective (incl. wildcard) measure so the answer can pick. Re-author this file to fix the degenerate view(s).`;

--- a/projects/agentic-malloy/src/layer-improve.test.ts
+++ b/projects/agentic-malloy/src/layer-improve.test.ts
@@ -169,6 +169,24 @@ describe('layer-vs-skill triage (classifyMiss)', () => {
     expect(c.implicatedFiles[0]).toBe('c4_fee_scenarios.malloy');
   });
 
+  it('P1b: query ERRORS while a referenced view is degenerate → SKILL (query error wins, not layer)', () => {
+    // A degenerate referenced view must NOT steal the blame for the agent's own
+    // broken query — the query-error branch runs before the degeneracy branch.
+    const c = classifyMiss(
+      baseAnalysis({
+        reExec: { ok: false, rowCount: 0, error: "Unknown function 'lpad'" },
+        viewProbes: [{
+          source: 'c4_mcc_avg_fee', view: 'by_mcc_at_50000', file: 'c4_fee_scenarios.malloy',
+          ok: true, rowCount: 769,
+          smells: [{ code: 'extreme_tie', column: 'avg_fee_at_50000', message: '727/769 rows tie at the MAX' }],
+        }],
+      }),
+    );
+    expect(c.category).toBe('query_compile_error');
+    expect(c.suggestedOwner).toBe('skill');
+    expect(c.layerSuspected).toBe(false);
+  });
+
   it('submitted query errors but every referenced view runs clean → SKILL (inline query bug)', () => {
     const c = classifyMiss(
       baseAnalysis({

--- a/projects/agentic-malloy/src/layer-improve.test.ts
+++ b/projects/agentic-malloy/src/layer-improve.test.ts
@@ -150,6 +150,25 @@ describe('layer-vs-skill triage (classifyMiss)', () => {
     expect(c.implicatedFiles[0]).toBe('c3_fee_assignment.malloy');
   });
 
+  it('1442 case: query runs + returns rows but a referenced view is DEGENERATE → LAYER (wrong grain), not skill', () => {
+    // Previously this was query_wrong_answer/skill (reExec ok, rows > 0). The
+    // degeneracy smell promotes it to a wrong-grain LAYER defect (I1).
+    const c = classifyMiss(
+      baseAnalysis({
+        reExec: { ok: true, rowCount: 727 },
+        viewProbes: [{
+          source: 'c4_mcc_avg_fee', view: 'by_mcc_at_50000', file: 'c4_fee_scenarios.malloy',
+          ok: true, rowCount: 769,
+          smells: [{ code: 'extreme_tie', column: 'avg_fee_at_50000', message: '727/769 rows tie at the MAX of "avg_fee_at_50000" (284.99) — a ranking that does not rank' }],
+        }],
+      }),
+    );
+    expect(c.category).toBe('layer_view_degenerate');
+    expect(c.suggestedOwner).toBe('layer');
+    expect(c.layerSuspected).toBe(true);
+    expect(c.implicatedFiles[0]).toBe('c4_fee_scenarios.malloy');
+  });
+
   it('submitted query errors but every referenced view runs clean → SKILL (inline query bug)', () => {
     const c = classifyMiss(
       baseAnalysis({

--- a/projects/agentic-malloy/src/layer-improve.ts
+++ b/projects/agentic-malloy/src/layer-improve.ts
@@ -99,6 +99,7 @@ function deterministicManner(cls: MissClassification): FailureManner {
       return 'gave_up';
     case 'layer_view_error':
     case 'layer_view_empty':
+    case 'layer_view_degenerate':
     case 'query_compile_error':
     case 'query_wrong_answer':
       return 'wrong_logic';

--- a/projects/agentic-malloy/src/miss-analysis.ts
+++ b/projects/agentic-malloy/src/miss-analysis.ts
@@ -279,24 +279,11 @@ export function classifyMiss(a: MissAnalysis): MissClassification {
     };
   }
 
-  if (degenerateView) {
-    // A named layer view RUNS but is DEGENERATE on its own (e.g. a "ranking" where
-    // most groups tie at the max because the grain folds in wildcard rows — the
-    // 1442 case). It executes, so the binary error/empty probes miss it; the
-    // smells catch it. This is a wrong-GRAIN layer defect, not the agent's inline
-    // logic — exactly the class that was previously misfiled as "skill".
-    return {
-      category: 'layer_view_degenerate',
-      layerSuspected: true,
-      suggestedOwner: 'layer',
-      implicatedFiles: degenerateView.file ? [degenerateView.file, ...files.filter((f) => f !== degenerateView.file)] : files,
-      note: `named layer view \`${degenerateView.source} -> ${degenerateView.view}\` runs but is DEGENERATE — ${degenerateView.smells?.[0]?.message ?? 'no discriminating output'}. Likely a wrong-grain layer defect, not the agent's query.`,
-    };
-  }
-
   if (reExec && !reExec.ok) {
-    // Submitted Malloy errors, but every referenced named view runs clean → the
-    // fault is in the agent's INLINE composition, not the layer.
+    // Submitted Malloy ERRORS. The agent's own inline query is broken — that's a
+    // skill/answering issue regardless of any referenced view's quality, so this
+    // is checked BEFORE the degeneracy branch (a degenerate view must not steal
+    // the blame for the agent's broken query and misroute it to layer repair).
     return {
       category: 'query_compile_error',
       layerSuspected: false,
@@ -306,7 +293,22 @@ export function classifyMiss(a: MissAnalysis): MissClassification {
     };
   }
 
-  // From here the submitted Malloy re-ran successfully.
+  // From here the submitted Malloy re-ran successfully (so any defect is in the
+  // LAYER it built on, not the agent's query).
+  if (degenerateView) {
+    // A named layer view RUNS but is DEGENERATE on its own (e.g. a "ranking" where
+    // most groups tie at the max because the grain folds in wildcard rows — the
+    // 1442 case). It executes, so the binary error/empty probes miss it; the
+    // smells catch it. This is a wrong-GRAIN layer defect, not the agent's logic.
+    return {
+      category: 'layer_view_degenerate',
+      layerSuspected: true,
+      suggestedOwner: 'layer',
+      implicatedFiles: degenerateView.file ? [degenerateView.file, ...files.filter((f) => f !== degenerateView.file)] : files,
+      note: `named layer view \`${degenerateView.source} -> ${degenerateView.view}\` runs but is DEGENERATE — ${degenerateView.smells?.[0]?.message ?? 'no discriminating output'}. Likely a wrong-grain layer defect, not the agent's query.`,
+    };
+  }
+
   if (reExec && reExec.rowCount === 0 && emptyView) {
     // The query returned nothing AND a named layer view is itself empty → suspect
     // the layer view (a matching/aggregating view that returns nothing over rows

--- a/projects/agentic-malloy/src/miss-analysis.ts
+++ b/projects/agentic-malloy/src/miss-analysis.ts
@@ -12,6 +12,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 import { MalloyRuntime } from './malloy-runtime.js';
 import { MODELS_DIR, sourceNamesIn, DATA_DIR } from './layer-build.js';
+import { viewQualitySmells, type Smell } from './view-quality.js';
 
 // ---------------------------------------------------------------------------
 // Miss rows (the --from JSONL shape) — see cli.ts runEvalTask's `row`.
@@ -190,6 +191,9 @@ export interface ViewProbe {
   ok: boolean;
   rowCount: number;
   error?: string;
+  /** degeneracy smells from the view's OWN output (it runs but is meaningless —
+   *  e.g. a "ranking" where most rows tie at the max). Closed-book; see I1. */
+  smells?: Smell[];
 }
 
 export interface MissAnalysis {
@@ -216,6 +220,7 @@ export type MissCategory =
   | 'query_compile_error'
   | 'layer_view_error'
   | 'layer_view_empty'
+  | 'layer_view_degenerate'
   | 'unknown';
 
 export type MissOwner = 'answering' | 'skill' | 'layer' | 'model';
@@ -258,6 +263,7 @@ export function classifyMiss(a: MissAnalysis): MissClassification {
   }
 
   const brokenView = a.viewProbes.find((p) => !p.ok);
+  const degenerateView = a.viewProbes.find((p) => p.ok && (p.smells?.length ?? 0) > 0);
   const emptyView = a.viewProbes.find((p) => p.ok && p.rowCount === 0);
   const reExec = a.reExec;
 
@@ -270,6 +276,21 @@ export function classifyMiss(a: MissAnalysis): MissClassification {
       suggestedOwner: 'layer',
       implicatedFiles: brokenView.file ? [brokenView.file, ...files.filter((f) => f !== brokenView.file)] : files,
       note: `named layer view \`${brokenView.source} -> ${brokenView.view}\` fails to execute on its own: ${brokenView.error?.slice(0, 200)}`,
+    };
+  }
+
+  if (degenerateView) {
+    // A named layer view RUNS but is DEGENERATE on its own (e.g. a "ranking" where
+    // most groups tie at the max because the grain folds in wildcard rows — the
+    // 1442 case). It executes, so the binary error/empty probes miss it; the
+    // smells catch it. This is a wrong-GRAIN layer defect, not the agent's inline
+    // logic — exactly the class that was previously misfiled as "skill".
+    return {
+      category: 'layer_view_degenerate',
+      layerSuspected: true,
+      suggestedOwner: 'layer',
+      implicatedFiles: degenerateView.file ? [degenerateView.file, ...files.filter((f) => f !== degenerateView.file)] : files,
+      note: `named layer view \`${degenerateView.source} -> ${degenerateView.view}\` runs but is DEGENERATE — ${degenerateView.smells?.[0]?.message ?? 'no discriminating output'}. Likely a wrong-grain layer defect, not the agent's query.`,
     };
   }
 
@@ -340,9 +361,12 @@ export async function analyzeMiss(row: MissRow, rt: MalloyRuntime, index: LayerI
       : { ok: false, rowCount: 0, error: (r.diagnostics ?? []).map((d) => d.message).join('\n') };
 
     // Smoke each referenced named view on its own (the structural-defect probe),
-    // source-scoped so a shared view name hits the source actually queried.
+    // source-scoped so a shared view name hits the source actually queried. Pull
+    // enough rows (not just 1) so the degeneracy detector can judge the view's
+    // output distribution — a view that runs but doesn't discriminate is a
+    // wrong-grain LAYER defect the error/empty probes can't see (I1).
     for (const { source, view } of referencedViews(malloySource, index)) {
-      const pr = await rt.run(`run: ${source} -> ${view}`, 1);
+      const pr = await rt.run(`run: ${source} -> ${view}`, 500);
       viewProbes.push({
         source,
         view,
@@ -350,6 +374,7 @@ export async function analyzeMiss(row: MissRow, rt: MalloyRuntime, index: LayerI
         ok: pr.ok,
         rowCount: pr.rows?.length ?? 0,
         error: pr.ok ? undefined : (pr.diagnostics ?? []).map((d) => d.message).join('\n'),
+        smells: pr.ok ? viewQualitySmells(pr.rows ?? []) : undefined,
       });
     }
   }
@@ -409,6 +434,7 @@ export function evidenceBlock(a: MissAnalysis, cls: MissClassification): string 
           ? `  - ${p.source} -> ${p.view}  [${p.file ?? '?'}]: OK, ${p.rowCount} row(s)${p.rowCount === 0 ? ' (EMPTY)' : ''}`
           : `  - ${p.source} -> ${p.view}  [${p.file ?? '?'}]: ERROR: ${p.error?.slice(0, 300)}`,
       );
+      for (const s of p.smells ?? []) lines.push(`      ⚠ DEGENERATE: ${s.message}`);
     }
   }
   lines.push(`\nDeterministic triage: ${cls.category} — ${cls.note}`);

--- a/projects/agentic-malloy/src/view-quality.test.ts
+++ b/projects/agentic-malloy/src/view-quality.test.ts
@@ -49,6 +49,20 @@ describe('viewQualitySmells', () => {
     expect(viewQualitySmells(data)).toEqual([]);
   });
 
+  it('P2: does NOT flag a numeric integer DIMENSION (constant/low-spread) — only float measures', () => {
+    // year (int dimension) is constant, month (int dimension) is heavily tied — both
+    // are normal for a grouping key and must NOT trigger; the float measure is judged.
+    const data = [
+      ...Array.from({ length: 11 }, () => ({ year: 2023, month: 1, fee: 5.5 })),
+      { year: 2023, month: 2, fee: 99.9 },
+    ];
+    const s = viewQualitySmells(data);
+    expect(s.some((x) => x.column === 'year')).toBe(false); // integer dimension, not judged
+    expect(s.some((x) => x.column === 'month')).toBe(false); // integer dimension, not judged
+    // a genuinely degenerate FLOAT measure is still caught:
+    expect(viewQualitySmells(Array.from({ length: 12 }, () => ({ year: 2023, fee: 5.5 }))).some((x) => x.code === 'zero_variance' && x.column === 'fee')).toBe(true);
+  });
+
   it('handles bigint counts (MotherDuck) without misjudging', () => {
     const data = Array.from({ length: 10 }, (_, i) => ({ g: i, n: BigInt(i + 1) }));
     expect(viewQualitySmells(data)).toEqual([]); // 1..10 distinct → no smell

--- a/projects/agentic-malloy/src/view-quality.test.ts
+++ b/projects/agentic-malloy/src/view-quality.test.ts
@@ -1,0 +1,63 @@
+/**
+ * view-quality smells — the closed-book degeneracy detector (B2/I1). The marquee
+ * case is the real 1442 distribution: a per-MCC fee "ranking" where 727/769 rows
+ * tie at the max because the grain folds in wildcard rules — it executes but is
+ * meaningless. Also: all-zero (a never-firing measure, the original broken
+ * fee-match bug), zero-variance (wrong grain), all-null, and the no-false-positive
+ * guards (a small honest ranking, a legitimately varied ranking).
+ */
+import { describe, it, expect } from 'vitest';
+import { viewQualitySmells, smellSummary } from './view-quality.js';
+
+const rows = (vals: number[], col = 'fee') => vals.map((v) => ({ [col]: v, label: `g${v}` }));
+
+describe('viewQualitySmells', () => {
+  it('flags extreme_tie: the 1442 case (727/769 tie at the max)', () => {
+    const data = [
+      ...Array.from({ length: 727 }, () => ({ mcc: 1, fee: 284.99 })), // wildcard-dominated max
+      ...Array.from({ length: 42 }, (_, i) => ({ mcc: 2, fee: 100 + i })), // the few real ones
+    ];
+    const s = viewQualitySmells(data);
+    const tie = s.find((x) => x.code === 'extreme_tie' && x.column === 'fee')!;
+    expect(tie).toBeTruthy();
+    expect(tie.message).toMatch(/727\/769 rows tie at the MAX/);
+  });
+
+  it('flags all_zero: a measure that never fires (the broken fee-match bug)', () => {
+    const s = viewQualitySmells(rows(Array(20).fill(0)));
+    expect(s.map((x) => x.code)).toContain('all_zero');
+  });
+
+  it('flags zero_variance: identical value across all groups (wrong grain)', () => {
+    const s = viewQualitySmells(rows(Array(20).fill(7.5)));
+    expect(s.map((x) => x.code)).toContain('zero_variance');
+  });
+
+  it('flags all_null: a column that computes nothing', () => {
+    const data = Array.from({ length: 12 }, (_, i) => ({ id: i, total: null as number | null }));
+    expect(viewQualitySmells(data).map((x) => x.code)).toContain('all_null');
+  });
+
+  it('does NOT flag a legitimately varied ranking (no false positive)', () => {
+    // 20 distinct descending fees, a clean ranking with a unique max.
+    const data = rows(Array.from({ length: 20 }, (_, i) => 100 - i));
+    expect(viewQualitySmells(data)).toEqual([]);
+  });
+
+  it('does NOT judge tiny groupings (a 5-row scheme ranking is fine)', () => {
+    const data = rows([10, 10, 10, 10, 10]); // identical but < minRows
+    expect(viewQualitySmells(data)).toEqual([]);
+  });
+
+  it('handles bigint counts (MotherDuck) without misjudging', () => {
+    const data = Array.from({ length: 10 }, (_, i) => ({ g: i, n: BigInt(i + 1) }));
+    expect(viewQualitySmells(data)).toEqual([]); // 1..10 distinct → no smell
+  });
+
+  it('smellSummary renders the worst smells for a send-back', () => {
+    const s = viewQualitySmells(rows(Array(20).fill(0)));
+    const txt = smellSummary('c4 -> by_mcc_at_50000', s);
+    expect(txt).toMatch(/DEGENERATE/);
+    expect(txt).toMatch(/by_mcc_at_50000/);
+  });
+});

--- a/projects/agentic-malloy/src/view-quality.ts
+++ b/projects/agentic-malloy/src/view-quality.ts
@@ -1,0 +1,90 @@
+/**
+ * view-quality — closed-book "does this view MEAN what its name claims?" smells.
+ *
+ * The build's P0 gate proves a view EXECUTES; it does not prove the view is
+ * meaningful. A view named like a ranking that returns the same value for ~every
+ * group (e.g. a per-MCC fee that folds in wildcard/"applies-to-all" rows, so
+ * 727/769 MCCs tie at the max) compiles, runs, and is WRONG — a "ranking that
+ * does not rank." These heuristics catch that class from a view's OWN output, with
+ * NO gold answer and NO dataset knowledge — so they work for any dataset and are
+ * shared by `layer-build` (gate authored views) and `layer-improve` (triage which
+ * misses are really a wrong-grain LAYER defect vs. an answering-agent slip).
+ *
+ * Smells are ADVISORY: a flag means "this view probably doesn't compute what its
+ * name implies — look again," not a certainty. Callers nudge once / corroborate
+ * with other evidence rather than hard-failing on a single smell.
+ */
+export interface Smell {
+  code: 'all_null' | 'all_zero' | 'zero_variance' | 'extreme_tie';
+  column: string;
+  message: string;
+}
+
+function toNum(v: unknown): number | null {
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+  if (typeof v === 'bigint') return Number(v);
+  return null;
+}
+
+/**
+ * Inspect a view's executed rows for degeneracy smells. Pure.
+ *
+ *  - all_null      : a column is entirely NULL (computes nothing).
+ *  - all_zero      : a numeric column is 0 for every row (a measure that never fires).
+ *  - zero_variance : a numeric column is identical across all rows (does not
+ *                    discriminate between groups — usually the wrong grain).
+ *  - extreme_tie   : > `tieFraction` of rows share the MAX (or MIN) of a numeric
+ *                    column — a "ranking that does not rank" (the wildcard-grain bug).
+ *
+ * `minRows` guards against judging tiny groupings (a 5-row scheme ranking is not
+ * degenerate just because schemes are few). Only numeric columns are judged for
+ * zero/variance/tie; any column is judged for all-null.
+ */
+export function viewQualitySmells(
+  rows: Array<Record<string, unknown>>,
+  opts: { minRows?: number; tieFraction?: number } = {},
+): Smell[] {
+  const minRows = opts.minRows ?? 8;
+  const tieFraction = opts.tieFraction ?? 0.5;
+  const smells: Smell[] = [];
+  if (rows.length < minRows) return smells; // too few rows to judge meaningfully
+  const cols = Object.keys(rows[0] ?? {});
+  for (const c of cols) {
+    const raw = rows.map((r) => r[c]);
+    const nonNull = raw.filter((v) => v !== null && v !== undefined);
+    if (nonNull.length === 0) {
+      smells.push({ code: 'all_null', column: c, message: `column "${c}" is NULL for all ${rows.length} rows — computes nothing` });
+      continue;
+    }
+    const nums = nonNull.map(toNum);
+    const isNumeric = nums.every((n) => n !== null) && nums.length === nonNull.length;
+    if (!isNumeric) continue; // only numeric columns get the zero/variance/tie checks
+    const ns = nums as number[];
+    if (ns.every((n) => n === 0)) {
+      smells.push({ code: 'all_zero', column: c, message: `measure "${c}" is 0 for every row — it never fires (suspect a broken match/filter)` });
+      continue;
+    }
+    const distinct = new Set(ns);
+    if (distinct.size === 1) {
+      smells.push({ code: 'zero_variance', column: c, message: `"${c}" is identical (${ns[0]}) across all ${ns.length} rows — it does not discriminate between groups (suspect wrong grain)` });
+      continue;
+    }
+    const max = Math.max(...ns);
+    const min = Math.min(...ns);
+    const atMax = ns.filter((n) => n === max).length;
+    const atMin = ns.filter((n) => n === min).length;
+    if (atMax / ns.length > tieFraction) {
+      smells.push({ code: 'extreme_tie', column: c, message: `${atMax}/${ns.length} rows tie at the MAX of "${c}" (${max}) — a ranking that does not rank (suspect the grain folds in non-discriminating / wildcard rows)` });
+    } else if (atMin / ns.length > tieFraction) {
+      smells.push({ code: 'extreme_tie', column: c, message: `${atMin}/${ns.length} rows tie at the MIN of "${c}" (${min}) — a ranking that does not rank (suspect wrong grain)` });
+    }
+  }
+  return smells;
+}
+
+/** One-line summary of the worst smells, for a diagnostic/send-back message. */
+export function smellSummary(viewLabel: string, smells: Smell[]): string {
+  if (!smells.length) return '';
+  return `View \`${viewLabel}\` looks DEGENERATE (it executes but probably doesn't compute what its name implies):\n` +
+    smells.map((s) => `  - ${s.message}`).join('\n');
+}

--- a/projects/agentic-malloy/src/view-quality.ts
+++ b/projects/agentic-malloy/src/view-quality.ts
@@ -64,6 +64,14 @@ export function viewQualitySmells(
       smells.push({ code: 'all_zero', column: c, message: `measure "${c}" is 0 for every row — it never fires (suspect a broken match/filter)` });
       continue;
     }
+    // The variance/tie smells target MEASURES (a ranking that doesn't rank). A
+    // group-by KEY / numeric DIMENSION (mcc code, year, month, an id) is integer
+    // and legitimately repeats or is constant — judging it over-triggers. Without
+    // field-kind metadata, use a robust proxy: only continuous (non-integer)
+    // columns get these checks. Aggregates that matter here (avg/sum/rate/fee) are
+    // floats; all-zero (a never-firing integer count) is still caught above.
+    const isContinuous = ns.some((n) => !Number.isInteger(n));
+    if (!isContinuous) continue;
     const distinct = new Set(ns);
     if (distinct.size === 1) {
       smells.push({ code: 'zero_variance', column: c, message: `"${c}" is identical (${ns[0]}) across all ${ns.length} rows — it does not discriminate between groups (suspect wrong grain)` });


### PR DESCRIPTION
Stacked on #65 (base = `layer-builder-generic`). Adds the first piece of the build/improve quality plan: a **closed-book degeneracy detector** that catches views which *execute but are meaningless* — the actual root cause of the 1442 miss.

## The gap it closes
The P0 gate proves a view **runs**; it never proved a view is **meaningful**. The 1442 bug: `by_mcc_at_50000` averages in wildcard ("applies-to-all") rules for every MCC, so **727/769 MCCs tie at the max** — it compiles, runs, returns rows, and is wrong. `layer-improve` misfiled it as `skill` because the query executed.

## `src/view-quality.ts` (pure, unit-tested)
`viewQualitySmells()` flags degeneracy from a view's **own output**, no gold / no dataset knowledge:
- `all_null`, `all_zero` (a measure that never fires), `zero_variance` (wrong grain), `extreme_tie` (>50% of rows share the max/min = "a ranking that doesn't rank").
- `minRows` guard so honest small groupings (a 5-row scheme ranking) aren't judged → no false positives.

## B2 — build gate (`layer-build.ts`)
`validateModel(checkQuality)` pulls rows and returns a `smellDiag`; `authorStage` **nudges the author once** with the smell + the generic fix (*"wildcard rows are common to all groups and don't discriminate — rank by entity-specific rows, or expose specific + effective grains"*), then accepts (never deadlocks on a legitimately skewed view).

## I1 — improve triage (`miss-analysis.ts`)
View probes now pull 500 rows + attach smells; `classifyMiss` gains **`layer_view_degenerate`** — a referenced view that runs but is degenerate is a wrong-**grain** LAYER defect, not the agent's query. Fixes the 1442 misclassification (`query_wrong_answer`/skill → `layer_view_degenerate`/layer). `evidenceBlock` surfaces the smell to the verdict/repair.

## Verification
- `tsc` clean; **97/97 vitest** (+ view-quality smells incl. the real 727/769 distribution and the no-false-positive guards; the 1442 `classifyMiss` path).
- **Live:** the detector fires on the actual `88c28953` `by_mcc_at_50000` (727/769 tie) and stays clean on the legit `by_aci_at_100` / `by_card_scheme` views.

Next in the plan: the **glossary / ubiquitous-language pass** (extract→ground→bind→cover) so question vocabulary maps into the layer generically. This PR is the *verifier* that pass relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)