### PR TITLE
agentic-malloy: gitignore one-off _extract_*.mjs scratch

### DIFF
--- a/projects/agentic-malloy/.gitignore
+++ b/projects/agentic-malloy/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 results/*.jsonl
 results/controllog/
 .DS_Store
+# one-off trace-extraction scratch scripts
+_extract_*.mjs


### PR DESCRIPTION
Ignore the leftover one-off trace-extraction scripts (`_extract_tooltrace.mjs`, `_extract_traces.mjs`) so they stop showing as untracked. Trivial chore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)