### PR TITLE
agentic-malloy: per-view execution timeout in build/repair validation

### DIFF
--- a/projects/agentic-malloy/src/layer-build.ts
+++ b/projects/agentic-malloy/src/layer-build.ts
@@ -241,6 +241,12 @@ export function sourceNamesIn(src: string): string[] {
  * this repo's layer + the MalloyRuntime default DB (back-compat for callers that
  * pass only a file name).
  */
+/** Per-view execution budget during build/repair validation. A view that exceeds
+ *  this is almost always an intractable grain (a full cross-join over a large
+ *  candidate domain) — fail it FAST so the repair loop fixes it, rather than
+ *  wedging the whole build on one query. Generous for legitimate heavy views. */
+export const VIEW_VALIDATION_TIMEOUT_MS = 45_000;
+
 export async function validateModel(
   modelFile?: string,
   opts: { modelsDir?: string; dbPath?: string; checkQuality?: boolean } = {},
@@ -258,7 +264,7 @@ export async function validateModel(
       for (const s of inv.sources) {
         if (!mine.has(s)) continue;
         for (const view of inv.viewsBySource[s] ?? []) {
-          const r = await rt.run(`run: ${s} -> ${view}`, cap);
+          const r = await rt.run(`run: ${s} -> ${view}`, cap, VIEW_VALIDATION_TIMEOUT_MS);
           if (!r.ok) {
             const errText = (r.diagnostics ?? []).map((d) => d.message).join('\n');
             // Only the binder/scope class points to the join_many materialization

--- a/projects/agentic-malloy/src/layer-repair.ts
+++ b/projects/agentic-malloy/src/layer-repair.ts
@@ -13,7 +13,7 @@ import { readFile, readdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { complete } from './llm-client.js';
 import { MalloyRuntime } from './malloy-runtime.js';
-import { DUCKDB_NOTES, MODELS_DIR, META_DIR, parseEdits, validateModel, PROVENANCE_PATH } from './layer-build.js';
+import { DUCKDB_NOTES, MODELS_DIR, META_DIR, parseEdits, validateModel, PROVENANCE_PATH, VIEW_VALIDATION_TIMEOUT_MS } from './layer-build.js';
 import * as cl from './controllog.js';
 
 const REPAIR_SYSTEM_HEADER = `You are a Malloy expert REPAIRING one file of an existing semantic layer. A view/source in this file has a STRUCTURAL defect (it errors at execution, or returns 0/empty over rows that exist, or computes at the wrong grain). Fix the DEFECT generically — make the layer correct per the manual + the data's actual encodings (the column profile).
@@ -144,7 +144,7 @@ export async function executeAllViews(rt: MalloyRuntime): Promise<{ ok: boolean;
   const inv = await rt.describe(); // compile check (throws on compile error → caller catches)
   for (const s of inv.sources) {
     for (const view of inv.viewsBySource[s] ?? []) {
-      const r = await rt.run(`run: ${s} -> ${view}`, 1);
+      const r = await rt.run(`run: ${s} -> ${view}`, 1, VIEW_VALIDATION_TIMEOUT_MS);
       if (!r.ok) {
         return { ok: false, diag: `\`${s} -> ${view}\` fails to execute:\n${(r.diagnostics ?? []).map((d) => d.message).join('\n')}` };
       }

--- a/projects/agentic-malloy/src/malloy-runtime.ts
+++ b/projects/agentic-malloy/src/malloy-runtime.ts
@@ -176,14 +176,26 @@ export class MalloyRuntime {
    *  `rowLimit` caps exploration output (default 50). The SCORED answer must pass
    *  a large explicit cap (see ANSWER_ROW_LIMIT) — Malloy's own default caps at 50,
    *  which silently truncates list answers (a 155-row answer was being cut to 50). */
-  async run(querySrc: string, rowLimit = 50): Promise<RunResult> {
+  async run(querySrc: string, rowLimit = 50, timeoutMs?: number): Promise<RunResult> {
     try {
-      const model = await this.loadModelText();
-      const runnable = this.runtime.loadModel(model).loadQuery(querySrc);
-      const sql = await runnable.getSQL();
-      const result = await runnable.run({ rowLimit });
-      const rows = result.data.toObject() as Row[];
-      return { ok: true, sql, rows };
+      const exec = (async () => {
+        const model = await this.loadModelText();
+        const runnable = this.runtime.loadModel(model).loadQuery(querySrc);
+        const sql = await runnable.getSQL();
+        const result = await runnable.run({ rowLimit });
+        return { ok: true as const, sql, rows: result.data.toObject() as Row[] };
+      })();
+      // Bound execution: an intractable view (e.g. a full cross-join over a large
+      // candidate set) must fail FAST so a build/repair loop can fix it, rather than
+      // wedging the caller. The underlying query may keep running, but the caller
+      // proceeds. Only applied when a timeout is requested (build validation).
+      if (timeoutMs && timeoutMs > 0) {
+        const timeout = new Promise<never>((_, rej) =>
+          setTimeout(() => rej(new Error(`execution exceeded ${Math.round(timeoutMs / 1000)}s — likely an intractable grain (e.g. a full cross-join over a large candidate domain); reduce the materialized product or scope the candidate set`)), timeoutMs),
+        );
+        return await Promise.race([exec, timeout]);
+      }
+      return await exec;
     } catch (err) {
       return { ok: false, diagnostics: this.toDiagnostics(err) };
     }

--- a/projects/agentic-malloy/src/malloy-runtime.ts
+++ b/projects/agentic-malloy/src/malloy-runtime.ts
@@ -190,10 +190,20 @@ export class MalloyRuntime {
       // wedging the caller. The underlying query may keep running, but the caller
       // proceeds. Only applied when a timeout is requested (build validation).
       if (timeoutMs && timeoutMs > 0) {
-        const timeout = new Promise<never>((_, rej) =>
-          setTimeout(() => rej(new Error(`execution exceeded ${Math.round(timeoutMs / 1000)}s — likely an intractable grain (e.g. a full cross-join over a large candidate domain); reduce the materialized product or scope the candidate set`)), timeoutMs),
-        );
-        return await Promise.race([exec, timeout]);
+        // Hold the timer handle so we can clear it once the race settles — otherwise
+        // a successful fast run leaves the timer pending and keeps the event loop
+        // alive until it fires (a 114ms run kept the process up ~5.6s on a 5s timer).
+        // unref() is a belt-and-suspenders guard so the timer never blocks exit.
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const timeout = new Promise<never>((_, rej) => {
+          timer = setTimeout(() => rej(new Error(`execution exceeded ${Math.round(timeoutMs / 1000)}s — likely an intractable grain (e.g. a full cross-join over a large candidate domain); reduce the materialized product or scope the candidate set`)), timeoutMs);
+          timer.unref?.();
+        });
+        try {
+          return await Promise.race([exec, timeout]);
+        } finally {
+          if (timer) clearTimeout(timer);
+        }
       }
       return await exec;
     } catch (err) {


### PR DESCRIPTION
## Why
A `layer-build` can author an **intractable view** — a counterfactual that cross-joins the fact table with a large candidate domain (fact × hundreds-of-candidates × rules). `validateModel`/`executeAllViews` then execute it to check it runs, and **block indefinitely** (observed: a build wedged 20+ min at ~200% CPU validating one such view). One pathological view should never hang the whole build.

## Fix
- `MalloyRuntime.run(q, rowLimit, timeoutMs?)` races execution against a timer; without `timeoutMs` behavior is unchanged.
- Build + repair validation (`validateModel`, `executeAllViews`) bound each view at `VIEW_VALIDATION_TIMEOUT_MS` (45s). An over-budget view becomes a **repairable error** ("likely an intractable grain — reduce the materialized product / scope the candidate set") so the repair loop fixes it, instead of wedging.
- Generous enough that legitimate heavy views pass; only pathological grains trip it.

Surfaced by a (separate, negative) experiment on answer-shaped surfaces; the timeout guard is the clean, generally-useful keeper from it. tsc clean; runtime + layer-build tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)