### PR TITLE
agentic-malloy: steer-instead-of-escalate as the default (opus-free failover)

### DIFF
--- a/projects/agentic-malloy/docs/steer-vs-escalate-ab.md
+++ b/projects/agentic-malloy/docs/steer-vs-escalate-ab.md
@@ -1,0 +1,64 @@
+# Steer-instead-of-escalate: A/B result and decision
+
+**Phase 3 (efficiency).** Replaces the opus failover on the sonnet arm with an in-place,
+content-bearing steer on repeated compile errors. This doc records the experiment that
+justified making the steer the default.
+
+## Question
+
+On the sonnet arm, escalation to opus fired on ~2% of tasks (always "2 consecutive tool
+errors") and those tasks ended correct 83–91% of the time. But that figure does **not**
+isolate opus: `escalate()` simultaneously (a) switched to opus, (b) injected a fixer prompt,
+and (c) granted more turns. Reading the escalated trajectories, every trigger was a Malloy
+**compile** error (field-name guessing like `'transaction_date'`; SQL-habit grammar), and
+opus's "rescue" was either a clean re-author (it knew the field) or a switch to `submit_sql`
+— neither needs opus's intelligence. Hypothesis: **a steer on sonnet matches opus, opus-free.**
+
+## Design — 3 arms × 3 passes × the 27 historically-escalated tasks
+
+Union of the escalated task_ids across the three sonnet held-out runs (2334Z / 1819Z / 2000Z):
+`22,48,61,1308,1336,1366,1401,1433,1444,1449,1531,1574,1577,1584,1615,1643,1645,1646,1676,
+1679,1747,1763,1775,1826,2713,2728,2755`.
+
+- **A — control:** `--fixer opus` (current opus failover).
+- **B — ablation:** `--fixer sonnet` (same escalate structure + generic fixer prompt + extra
+  turns, **no model switch**). Isolates the value of opus itself.
+- **C — treatment:** the new in-place steer (`stuckAuthorSteer`), opus-free.
+
+## Result (81 task-runs / arm)
+
+| arm | accuracy | cost | $/task | mean elapsed | escalations | steers |
+|---|---|---|---|---|---|---|
+| A opus | 77/81 (95.1%) | $5.52 | $0.068 | 25.5s | 3 | 0 |
+| B sonnet-fixer | 75/81 (92.6%) | $4.79 | $0.059 | 24.9s | 2 | 0 |
+| **C steer (opus-free)** | **79/81 (97.5%)** | **$4.70** | **$0.058** | 24.8s | 0 | 1 |
+
+Per-pass: A 26/24/27 · B 26/26/23 · C 27/25/27.
+
+## Verdict
+
+1. **No accuracy regression from dropping opus.** Per-pass swings (23–27 every arm) exceed
+   the gap between arm means (25.7 / 25.0 / 26.3) — the arms are statistically
+   indistinguishable. Opus-free *tracks* opus.
+2. **Opus-free is ~15% cheaper** on this subset (no opus tokens); **latency is flat** (~25s,
+   consistent with escalation being ~2% of wall-clock — there is **no speed win**).
+3. On the 4 tasks that actually triggered the stuck path, opus-free solved all; opus itself
+   missed one (1643) on one pass.
+
+**Honest caveat:** the escalation/steer mechanism fired only **1–3 times per 81 runs** — most
+of the 27 "stuck" tasks authored cleanly this time. So this is primarily evidence of *no harm
+from dropping opus* plus *the steer handling every real trigger correctly*, **not** proof the
+steer is a large accuracy lever. The numbers are also small (81 runs/arm) and not significant.
+
+## Decision
+
+Make the in-place steer the **default** (opus-free). Restore the opus failover with
+`--no-steer`. The **official** baseline is unchanged — it is still sonnet-author / opus-failover,
+so an official run must pass `--no-steer` (the official gate enforces this).
+
+## Right-sizing / what's next
+
+This is a modest win: ~15% cheaper on the escalation-prone subset (~5% of fleet cost), no
+latency change — mostly it **de-risks** (removes the expensive-model dependency) and slightly
+improves accuracy. The real Phase-3 levers remain the **per-task baseline** (≈85% of cost =
+turns × re-sent context × cache) and the **SQL-exploration grind tail**.

--- a/projects/agentic-malloy/src/agentic-loop.test.ts
+++ b/projects/agentic-malloy/src/agentic-loop.test.ts
@@ -112,6 +112,32 @@ describe('runTask no-submit recovery', () => {
     expect(r.authorRecoveryUsed).toBe(false); // tool-error escalation, not the prose-recovery path
   });
 
+  it('steerInsteadOfEscalate: consecutive errors steer the AUTHOR in place — no model switch', async () => {
+    const state = { submitted: false };
+    const events: { kind: string }[] = [];
+    // Two consecutive run_malloy errors (would escalate by default); then a submit.
+    streamMock
+      .mockResolvedValueOnce(sseTurn({ tool: { name: 'run_malloy', input: { source: 'bad1' } } }))
+      .mockResolvedValueOnce(sseTurn({ tool: { name: 'run_malloy', input: { source: 'bad2' } } }))
+      .mockResolvedValueOnce(sseTurn({ tool: { name: 'submit_answer', input: { source: 'good' } } }));
+    dispatchMock.mockImplementation(async (_deps: unknown, name: string) => {
+      if (name === 'submit_answer') { state.submitted = true; return { content: 'Submitted. 1 row(s).', isError: false }; }
+      return { content: "Malloy compile error:\n  - 'transaction_date' is not defined", isError: true };
+    });
+
+    const r = await runTask({
+      ...baseOpts(state),
+      steerInsteadOfEscalate: true,
+      onEvent: (e) => events.push(e),
+    });
+
+    expect(r.escalated).toBe(false); // never failed over to the fixer model
+    expect(r.submitted).toBe(true);
+    expect(events.some((e) => e.kind === 'stuck_author_steer')).toBe(true);
+    // EVERY turn ran on the author model — the fixer model was never used.
+    for (const call of streamMock.mock.calls) expect(call[0].model).toBe('author-model');
+  });
+
   it('a stream failure ends the loop with a streamFailureReason (not a silent hit-limit)', async () => {
     const state = { submitted: false };
     streamMock.mockRejectedValueOnce(new Error('stream setup exploded'));

--- a/projects/agentic-malloy/src/agentic-loop.ts
+++ b/projects/agentic-malloy/src/agentic-loop.ts
@@ -24,6 +24,11 @@ export interface RunTaskOpts {
   escalateAfter: number;
   maxAuthorTurns: number;
   maxFixerTurns: number;
+  /** When true, the consecutive-compile-error trigger injects a content-bearing
+   *  steer and keeps the AUTHOR model (up to STEER_BUDGET times) instead of
+   *  failing over to the fixer model. The arm is opus-free only if the caller also
+   *  pins fixerModel === authorModel (the CLI flag does this). Default false. */
+  steerInsteadOfEscalate?: boolean;
   reasoningEffort?: string;
   provider?: string; // pin OpenRouter to a single upstream provider
   taskId: string;
@@ -57,6 +62,8 @@ export interface TaskResult {
   streamFailureReason: string | null;
   /** True if the author was given its one forced submit-now recovery turn. */
   authorRecoveryUsed: boolean;
+  /** In-place stuck-author steers issued (--steer-instead-of-escalate); 0 otherwise. */
+  steersUsed: number;
   /** Total OpenRouter stream-setup retries across all turns (telemetry). */
   retryCount: number;
   /** The full bundled conversation (OpenAI Responses-item shape: user / message /
@@ -116,6 +123,23 @@ function sameErrorSteer(sqlOn: boolean): string {
     (sqlOn
       ? 'Instead: use the `query` (SQL) tool to compute the answer directly, then call `submit_sql` with that SQL — it runs on MotherDuck and is scored exactly like a Malloy answer. Do NOT wrap SQL inside Malloy (`duckdb.sql(...)` is rejected).'
       : 'Instead: pivot to a DIFFERENT layer view or source that does not depend on the broken one, and submit_answer with that Malloy.')
+  );
+}
+
+// Shown (in --steer-instead-of-escalate mode) on N consecutive Malloy-authoring
+// errors INSTEAD of escalating to the fixer model. Operationalizes what opus did
+// when it "rescued" these tasks: read the exact field names rather than guessing,
+// apply the Malloy form named in the diagnostic, switch off a broken view, or fall
+// back to submit_sql. General (no dataset-specific nouns); flag-aware on SQL.
+function stuckAuthorSteer(n: number, sqlOn: boolean): string {
+  return (
+    `You've hit ${n} Malloy compile errors in a row — re-running the same shape will NOT clear them. Diagnose by cause, then fix:\n` +
+    "- \"'X' is not defined\": you are guessing a column name. Do NOT guess — call list_columns (or get_file on the source) and use the EXACT field names verbatim.\n" +
+    '- select / avg / aggregate / date-type errors: these are SQL habits Malloy rejects. Read the diagnostic literally — a reduction uses group_by: + aggregate:, never select:.\n' +
+    '- If the COMPILED SQL errors (a binder/scope error), the layer view itself is broken — switch to a DIFFERENT view or source.\n' +
+    (sqlOn
+      ? 'If Malloy keeps fighting you, compute the answer with the `query` (SQL) tool and call `submit_sql` — it runs on MotherDuck and is scored identically. Do NOT wrap SQL inside Malloy.'
+      : 'Pivot to a DIFFERENT layer view/source that does not depend on the broken one, and submit_answer with that Malloy.')
   );
 }
 
@@ -244,6 +268,8 @@ export async function runTask(opts: RunTaskOpts): Promise<TaskResult> {
   let authorRecoveryUsed = false; // the author's one forced submit-now turn
   let retryCount = 0;
   let prevMalloyErrSig: string | null = null; // last turn's run_malloy/submit error signature
+  let steersUsed = 0; // stuck-author steers issued (--steer-instead-of-escalate)
+  const STEER_BUDGET = 2; // after this many in-place steers, fall back to escalate()
   const usage: TaskUsage = { promptTokens: 0, completionTokens: 0, cost: 0, cachedTokens: 0, cacheWriteTokens: 0 };
   // Hard ceiling only; each role is bounded separately below so the expensive
   // fixer can never run past --max-fixer-turns regardless of when it escalated.
@@ -357,24 +383,30 @@ export async function runTask(opts: RunTaskOpts): Promise<TaskResult> {
     }
     messages.push({ role: 'user', content: toolResults });
 
-    // Repeated-IDENTICAL Malloy error → the agent is looping (often on a layer
-    // binder/scope bug it can't fix by rewriting). Steer it ONCE to the SQL
-    // fallback instead of letting it burn turns re-running the same thing.
+    if (deps.state.submitted) break;
+
     const errSig = malloyErr ? normErrSig(malloyErr) : null;
-    if (errSig && errSig === prevMalloyErrSig) {
+    consecutiveErrors = anyError ? consecutiveErrors + 1 : 0;
+    // Author max-turns escalation is handled at the top of the loop; here we act
+    // on repeated tool errors. Exactly one of these fires per turn:
+    //  1. steer-in-place (flagged): keep the author model, inject a steer, continue;
+    //  2. escalate to the fixer (default, or after the steer budget is spent);
+    //  3. one-shot same-error nudge when neither (1) nor (2) tripped this turn.
+    const stuck = role === 'author' && consecutiveErrors >= opts.escalateAfter;
+    if (stuck && opts.steerInsteadOfEscalate && steersUsed < STEER_BUDGET) {
+      messages.push({ role: 'user', content: stuckAuthorSteer(consecutiveErrors, sqlOn) });
+      opts.onEvent?.({ kind: 'stuck_author_steer', detail: errSig?.slice(0, 80) ?? null });
+      steersUsed++;
+      consecutiveErrors = 0; // give the author a fresh streak after the steer
+    } else if (stuck) {
+      escalate(`${consecutiveErrors} consecutive tool errors`);
+    } else if (errSig && errSig === prevMalloyErrSig) {
+      // Looping on the SAME error (often a layer binder/scope bug it can't fix by
+      // rewriting). One-shot nudge off the dead view.
       messages.push({ role: 'user', content: sameErrorSteer(sqlOn) });
       opts.onEvent?.({ kind: 'repeat_error_steer', detail: errSig.slice(0, 80) });
     }
     prevMalloyErrSig = errSig;
-
-    if (deps.state.submitted) break;
-
-    consecutiveErrors = anyError ? consecutiveErrors + 1 : 0;
-    // Author max-turns escalation is handled at the top of the loop; here we
-    // only escalate early on repeated tool errors.
-    if (role === 'author' && consecutiveErrors >= opts.escalateAfter) {
-      escalate(`${consecutiveErrors} consecutive tool errors`);
-    }
   }
 
   const hitLimit = !deps.state.submitted;
@@ -391,6 +423,7 @@ export async function runTask(opts: RunTaskOpts): Promise<TaskResult> {
     hitLimit,
     streamFailureReason,
     authorRecoveryUsed,
+    steersUsed,
     retryCount,
     trace,
   };

--- a/projects/agentic-malloy/src/cli.ts
+++ b/projects/agentic-malloy/src/cli.ts
@@ -193,6 +193,7 @@ export interface EvalTaskCtx {
   escalateAfter: number;
   maxAuthorTurns: number;
   maxFixerTurns: number;
+  steerInsteadOfEscalate: boolean;
   reasoning: string;
   provider?: string; // pinned OpenRouter upstream provider (or undefined)
   runClass: string;
@@ -260,6 +261,7 @@ export async function runEvalTask(q: Question, ctx: EvalTaskCtx): Promise<EvalTa
         toolSchemas: buildToolSchemas(deps), deps,
         authorModel: ctx.author, fixerModel: ctx.fixer,
         escalateAfter: ctx.escalateAfter, maxAuthorTurns: ctx.maxAuthorTurns, maxFixerTurns: ctx.maxFixerTurns,
+        steerInsteadOfEscalate: ctx.steerInsteadOfEscalate,
         reasoningEffort: ctx.reasoning, provider: ctx.provider, taskId: tid, runId: ctx.runId,
       });
     } catch (e) {
@@ -364,11 +366,12 @@ export async function runEvalTask(q: Question, ctx: EvalTaskCtx): Promise<EvalTa
 
   const row: Record<string, unknown> = {
     task_id: tid, level: q.level, split: ctx.split, author_model: ctx.author, fixer_model: ctx.fixer, run_class: ctx.runClass,
+    steer_instead_of_escalate: ctx.steerInsteadOfEscalate,
     question: q.question, guidelines: q.guidelines, gold_answer: q.answer,
     predicted_answer: scoreResp.predicted_answer, is_correct: scoreResp.is_correct, correctness: scoreResp.correctness,
     match_source: scoreResp.match_source, malloy_source: state.finalMalloy ?? null, compiled_sql: state.finalCompiledSql ?? null,
     translation_match: state.translationMatch ?? null, answer_kind: state.answerKind ?? null,
-    escalated: result?.escalated ?? false, fixer_turns: result?.fixerTurns ?? 0, tool_calls: result?.toolCallCount ?? 0,
+    escalated: result?.escalated ?? false, fixer_turns: result?.fixerTurns ?? 0, steers_used: result?.steersUsed ?? 0, tool_calls: result?.toolCallCount ?? 0,
     files_read: state.filesRead, lint_fixes: state.lintFixesTotal, elapsed_s: +(elapsedMs / 1000).toFixed(2),
     cost_usd: result?.usage.cost ?? 0, prompt_tokens: result?.usage.promptTokens ?? 0, completion_tokens: result?.usage.completionTokens ?? 0,
     cached_tokens: result?.usage.cachedTokens ?? 0, cache_write_tokens: result?.usage.cacheWriteTokens ?? 0, provider: ctx.provider ?? null,
@@ -391,7 +394,17 @@ export async function runEvalTask(q: Question, ctx: EvalTaskCtx): Promise<EvalTa
 async function cmdEvaluate(flags: Record<string, string | boolean>) {
   const split = (flags.split as string) || 'templates';
   const author = resolveModel((flags.author as string) || 'sonnet');
-  const fixer = resolveModel((flags.fixer as string) || 'opus');
+  // Steer-instead-of-escalate is the DEFAULT (opus-free): on repeated compile errors
+  // the AUTHOR is steered in place (see agentic-loop.ts) rather than failing over to a
+  // fixer model. The 27-task × 3-pass A/B showed it non-inferior to the opus failover
+  // (79/81 vs 77/81, within per-pass noise) at ~15% lower cost on that escalation-prone
+  // subset. Opt back into the opus failover with --no-steer (required for an official run).
+  const steerInsteadOfEscalate = !flags['no-steer'];
+  let fixer = resolveModel((flags.fixer as string) || (steerInsteadOfEscalate ? 'sonnet' : 'opus'));
+  if (steerInsteadOfEscalate) {
+    if (flags.fixer) console.warn(`⚠️  --fixer ${String(flags.fixer)} ignored: the in-place steer (default) is opus-free; pass --no-steer to use a fixer failover.`);
+    fixer = author; // no failover model in steer mode; any residual escalate() stays on the author
+  }
 
   // run_class is EXPLICIT (default smoke). It is NOT inferred from model flags —
   // that would mislabel runs (e.g. cheap gemini/gemini as "official"). Only an
@@ -409,7 +422,10 @@ async function cmdEvaluate(flags: Record<string, string | boolean>) {
     if (prov.malloy_provenance !== 'model_authored') reasons.push(`layer is ${prov.malloy_provenance} (${prov.reason}) — run a full \`layer-build\``);
     if (prov.manual_included !== true) reasons.push(`layer built without the manual (manual_included=${prov.manual_included})`);
     if (author !== resolveModel('sonnet')) reasons.push(`author must be sonnet (got ${author})`);
-    if (fixer !== resolveModel('opus')) reasons.push(`fixer must be opus (got ${fixer})`);
+    // The official baseline is the canonical sonnet-author / opus-FAILOVER tiering.
+    // The in-place steer is the everyday default, so an official run must opt out of it.
+    if (steerInsteadOfEscalate) reasons.push('the opus failover is required for an official run — pass --no-steer (the in-place steer is the default for smoke/experiment runs)');
+    else if (fixer !== resolveModel('opus')) reasons.push(`fixer must be opus (got ${fixer})`);
     // An official number must be REPRODUCIBLE from the recorded commit_sha. A dirty
     // tracked tree (e.g. layer-improve having modified src/skill.md, or any layer
     // edit) means the scored prompt/layer state isn't committed — refuse, don't
@@ -498,7 +514,7 @@ async function cmdEvaluate(flags: Record<string, string | boolean>) {
     console.warn('');
   }
 
-  console.log(`split=${split} · ${questions.length} q · author=${author} fixer=${fixer} · run_class=${runClass} · provenance=${prov.malloy_provenance} · db=${database} · conc=${concurrency} · sql_fallback=${allowSqlFallback ? 'on' : 'off'}${provider ? ` · provider=${provider}` : ''}`);
+  console.log(`split=${split} · ${questions.length} q · author=${author} fixer=${fixer} · run_class=${runClass} · provenance=${prov.malloy_provenance} · db=${database} · conc=${concurrency} · sql_fallback=${allowSqlFallback ? 'on' : 'off'}${steerInsteadOfEscalate ? ' · steer-instead-of-escalate (opus-free)' : ''}${provider ? ` · provider=${provider}` : ''}`);
 
   let correct = 0;
   let completed = 0;
@@ -515,7 +531,7 @@ async function cmdEvaluate(flags: Record<string, string | boolean>) {
 
   const ctx: EvalTaskCtx = {
     systemPrompt, runtime, localRuntime, store, symbols, kinds, viewNames, allowSqlFallback, scorer, database,
-    author, fixer, escalateAfter, maxAuthorTurns, maxFixerTurns, reasoning, provider,
+    author, fixer, escalateAfter, maxAuthorTurns, maxFixerTurns, steerInsteadOfEscalate, reasoning, provider,
     runClass, prov, runId, split,
   };
 
@@ -534,6 +550,7 @@ async function cmdEvaluate(flags: Record<string, string | boolean>) {
           max_author_turns: maxAuthorTurns,
           max_fixer_turns: maxFixerTurns,
           allow_sql_fallback: allowSqlFallback,
+          steer_instead_of_escalate: steerInsteadOfEscalate,
           reasoning,
           provider: provider ?? null,
           substrate: 'motherduck',

--- a/projects/agentic-malloy/src/eval-task.test.ts
+++ b/projects/agentic-malloy/src/eval-task.test.ts
@@ -22,7 +22,7 @@ function fakeTaskResult(over: Partial<TaskResult> = {}): TaskResult {
     submitted: true, escalated: false, escalationReason: null, authorTurns: 1, fixerTurns: 0,
     toolCallCount: 1, usage: { promptTokens: 1, completionTokens: 1, cost: 0, cachedTokens: 0, cacheWriteTokens: 0 },
     authorModel: 'a', fixerModel: 'f', hitLimit: false, streamFailureReason: null,
-    authorRecoveryUsed: false, retryCount: 0, trace: [], ...over,
+    authorRecoveryUsed: false, steersUsed: 0, retryCount: 0, trace: [], ...over,
   };
 }
 
@@ -37,7 +37,7 @@ function baseCtx(over: Partial<EvalTaskCtx>): EvalTaskCtx {
     allowSqlFallback: true,
     scorer: { score: async () => okScore },
     database: 'db', author: 'a', fixer: 'f',
-    escalateAfter: 2, maxAuthorTurns: 20, maxFixerTurns: 6, reasoning: 'off',
+    escalateAfter: 2, maxAuthorTurns: 20, maxFixerTurns: 6, steerInsteadOfEscalate: false, reasoning: 'off',
     runClass: 'smoke',
     prov: { malloy_provenance: 'model_authored', malloy_model_hash: 'h', manual_included: true, authoring_model: 'a', reason: 'r' },
     runId: 'r1', split: 'test',


### PR DESCRIPTION
## What

On the sonnet arm, repeated Malloy **compile** errors used to fail over to opus (the "fixer"). This makes the author **steer in place** instead — `stuckAuthorSteer()` operationalizes what opus actually did when it "rescued" these tasks: read the exact field names rather than guessing (`'transaction_date'` doesn't exist), apply the Malloy form named in the diagnostic, switch off a broken view, or fall back to `submit_sql` — keeping the author model (budgeted, `STEER_BUDGET=2`).

The steer is now the **default** (opus-free). `--no-steer` restores the opus failover; the **official** run gate requires `--no-steer`, so the canonical sonnet-author / opus-failover baseline is unchanged.

## Why — the A/B (3 arms × 3 passes × the 27 escalation-prone tasks)

| arm | accuracy | cost | $/task | mean elapsed |
|---|---|---|---|---|
| A — opus failover (control) | 77/81 (95.1%) | \$5.52 | \$0.068 | 25.5s |
| B — `--fixer sonnet` (ablation, no model switch) | 75/81 (92.6%) | \$4.79 | \$0.059 | 24.9s |
| **C — steer (opus-free)** | **79/81 (97.5%)** | **\$4.70** | **\$0.058** | 24.8s |

- **No accuracy regression from dropping opus** — per-pass swings (23–27 in every arm) exceed the gap between arm means; the arms are statistically indistinguishable.
- **~15% cheaper** on this subset; **latency flat** (escalation was ~2% of wall-clock — no speed win).
- On the 4 tasks that actually triggered the stuck path, opus-free solved all; opus itself missed one on one pass.

**Honest caveat:** the mechanism fired only 1–3×/81 runs, so this is primarily *no harm from dropping opus* + *the steer handles every real trigger correctly*, not proof the steer is a large accuracy lever. Numbers are small and not significant. Full write-up: `docs/steer-vs-escalate-ab.md`.

## Changes
- `agentic-loop.ts` — `stuckAuthorSteer()`; budgeted steer-vs-escalate fork; `steersUsed` on `TaskResult`
- `cli.ts` — steer default + `--no-steer`; official gate requires `--no-steer`; per-task `steer_instead_of_escalate` + `steers_used`
- tests cover the in-place-steer path (no model switch). `npm test` 215/215, typecheck clean.

## Right-sizing
Modest win — mostly de-risks (removes the expensive-model dependency). The real Phase-3 levers remain the per-task baseline (~85% of cost) and the SQL-exploration grind tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)