### PR TITLE
agentic-malloy: usage-report — substrate-value metrics for a run (Phase 2)

### DIFF
--- a/projects/agentic-malloy/README.md
+++ b/projects/agentic-malloy/README.md
@@ -55,7 +55,15 @@ npx tsx bin/asm-malloy.ts malloy-preflight  # compile + local run sanity check
 npx tsx bin/asm-malloy.ts evaluate --task-id 1711 --author sonnet --fixer opus
 npx tsx bin/asm-malloy.ts evaluate --split templates --run-class official
 npx tsx bin/asm-malloy.ts summary results/<file>.jsonl
+npx tsx bin/asm-malloy.ts usage-report results/<file>.jsonl   # substrate-value metrics (read-only, local)
 ```
+
+`usage-report` aggregates a completed run into the substrate-value metrics:
+answer-path economics (view-selection / authored-malloy / sql), **share-of-logic**
+(authored Malloy chars / authored Malloy+SQL chars), central-vs-per-query Malloy size
++ Malloy→SQL expansion, **view utilization** (how many layer views are actually
+reused), and the answer-time context-token breakdown. `--json <path>` writes the
+report object. Read-only and local — no MCP/eval spend.
 
 `evaluate` runs the two-model author→fixer loop, explores via MotherDuck MCP,
 executes the compiled Malloy answer on MotherDuck, scores via the Python sidecar,

--- a/projects/agentic-malloy/src/cli.ts
+++ b/projects/agentic-malloy/src/cli.ts
@@ -20,6 +20,8 @@ import { runTask } from './agentic-loop.js';
 import { resolveModel } from './llm-client.js';
 import { hashLayerOnDisk, PROVENANCE_PATH, META_DIR } from './layer-build.js';
 import { loadGlossaryArtifact, renderGlossaryForAnswering } from './glossary.js';
+import { loadLayerIndex } from './miss-analysis.js';
+import { computeUsageReport, formatUsageReport } from './usage-report.js';
 import { buildDabstepLayer } from './dabstep-build.js';
 import { improveLayer } from './layer-improve.js';
 import { uploadControllog } from './upload.js';
@@ -698,6 +700,33 @@ async function cmdSummary(file: string) {
   console.log('answer_kind:', kindStr);
 }
 
+/**
+ * usage-report: substrate-value metrics over a completed run's results JSONL —
+ * answer-path economics, share-of-logic, central-vs-per-query, view utilization, and
+ * the answer-time context-token breakdown. Read-only + local (loads the on-disk layer
+ * + skill/primer/glossary; no MCP/network). `--json <path>` writes the report object.
+ */
+async function cmdUsageReport(flags: Record<string, string | boolean>, file: string) {
+  if (!file) throw new Error('usage: asm-malloy usage-report <results.jsonl> [--json out.json]');
+  const rows = (await readFile(file, 'utf8')).split('\n').filter((l) => l.trim()).map((l) => JSON.parse(l));
+  const store = new MalloyStore();
+  await store.load();
+  const layerIndex = await loadLayerIndex();
+  const skill = await readFile(SKILL_PATH, 'utf8');
+  const primer = await readFile(path.join(REPO_ROOT, 'docs', 'malloy', 'malloy-primer.md'), 'utf8');
+  const glossaryBlock = renderGlossaryForAnswering(await loadGlossaryArtifact(META_DIR));
+  const report = computeUsageReport(rows, {
+    centralLayerChars: store.centralLayerChars(),
+    layerIndex,
+    contextChars: { skill: skill.length, primer: primer.length, glossary: glossaryBlock.length },
+  });
+  console.log(formatUsageReport(report, file));
+  if (typeof flags.json === 'string') {
+    await writeFile(flags.json, JSON.stringify(report, null, 2));
+    console.log(`\nwrote ${flags.json}`);
+  }
+}
+
 function loadDotEnv(): void {
   try {
     process.loadEnvFile(path.join(REPO_ROOT, '.env'));
@@ -725,8 +754,10 @@ async function main() {
       return cmdUpload(flags);
     case 'summary':
       return cmdSummary(rest[0]);
+    case 'usage-report':
+      return cmdUsageReport(flags, rest[0]);
     default:
-      console.log('usage: asm-malloy <load|malloy-preflight|layer-build|layer-improve|evaluate|upload|summary> [flags]');
+      console.log('usage: asm-malloy <load|malloy-preflight|layer-build|layer-improve|evaluate|upload|summary|usage-report> [flags]');
       console.log('  load [--motherduck --database agentic_malloy]');
       console.log('  layer-build --model opus --reasoning medium [--no-manual] [--max-rounds 3] [--provider anthropic]');
       console.log('  layer-improve --from results/RUN.jsonl [--model opus --reasoning medium --max-rounds 4] \\');
@@ -741,6 +772,7 @@ async function main() {
       console.log('           (--provider pins the OpenRouter upstream; defaults to $OPENROUTER_PROVIDER)');
       console.log('           (--no-sql-fallback disables submit_sql for a Malloy-only arm; SQL fallback is on by default)');
       console.log('  upload [--database agentic_malloy_logs]   # controllog JSONL -> MotherDuck for the dive');
+      console.log('  usage-report <results.jsonl> [--json out.json]   # substrate-value metrics for a run (read-only, local)');
   }
 }
 

--- a/projects/agentic-malloy/src/usage-report.test.ts
+++ b/projects/agentic-malloy/src/usage-report.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { computeUsageReport, type UsageRow } from './usage-report.js';
+import { buildLayerIndex } from './miss-analysis.js';
+
+// Tiny layer: source `s` with one view `v`, so referencedViews can resolve `s -> v`.
+const INDEX = buildLayerIndex({
+  't.malloy': 'source: s is duckdb.sql("""SELECT 1 as x""") extend {\n  view: v is { group_by: x }\n}',
+});
+
+const AUTH_SRC = 'x'.repeat(40); // authored-malloy per-query source
+const VIEW_SRC = 'run: s -> v + { limit: 1 }'; // references view v on source s
+const SQL_SRC = 'z'.repeat(51); // raw authored SQL (in compiled_sql for sql answers)
+
+function sampleRows(): UsageRow[] {
+  return [
+    { answer_kind: 'authored-malloy', malloy_source: AUTH_SRC, compiled_sql: 'y'.repeat(200), is_correct: true, tool_calls: 5, prompt_tokens: 100, completion_tokens: 10, cached_tokens: 80, cache_write_tokens: 20, cost_usd: 0.01 },
+    { answer_kind: 'view-selection', malloy_source: VIEW_SRC, compiled_sql: 'q'.repeat(60), is_correct: true, tool_calls: 6, prompt_tokens: 200, completion_tokens: 20, cached_tokens: 100, cache_write_tokens: 0, cost_usd: 0.02 },
+    { answer_kind: 'sql', malloy_source: null, compiled_sql: SQL_SRC, is_correct: false, tool_calls: 3, prompt_tokens: 50, completion_tokens: 5, cached_tokens: 50, cache_write_tokens: 0, cost_usd: 0.005 },
+    { answer_kind: null, malloy_source: null, compiled_sql: null, is_correct: false, tool_calls: 1, prompt_tokens: 30, completion_tokens: 0, cached_tokens: 0, cache_write_tokens: 0, cost_usd: 0.001 },
+  ];
+}
+
+describe('computeUsageReport', () => {
+  const r = computeUsageReport(sampleRows(), { centralLayerChars: 5000, layerIndex: INDEX, contextChars: { skill: 4000, primer: 2000, glossary: 2000 } });
+
+  it('counts tasks, accuracy, and per-kind split', () => {
+    expect(r.n).toBe(4);
+    expect(r.accuracy).toBe(50); // 2/4
+    const byKind = Object.fromEntries(r.byKind.map((k) => [k.kind, k]));
+    expect(byKind['authored-malloy'].n).toBe(1);
+    expect(byKind['view-selection'].n).toBe(1);
+    expect(byKind['sql'].n).toBe(1);
+    expect(byKind['none'].n).toBe(1);
+    expect(byKind['sql'].accuracy).toBe(0);
+    expect(byKind['authored-malloy'].accuracy).toBe(100);
+  });
+
+  it('computes share-of-logic from authored Malloy vs authored SQL chars', () => {
+    expect(r.shareOfLogic.malloyChars).toBe(AUTH_SRC.length + VIEW_SRC.length); // Malloy answers' malloy_source
+    expect(r.shareOfLogic.sqlChars).toBe(SQL_SRC.length); // sql answer's compiled_sql only
+    const expected = (AUTH_SRC.length + VIEW_SRC.length) / (AUTH_SRC.length + VIEW_SRC.length + SQL_SRC.length);
+    expect(r.shareOfLogic.ratio).toBeCloseTo(expected, 5);
+  });
+
+  it('null share-of-logic ratio when no authored logic', () => {
+    const none = computeUsageReport([{ answer_kind: null, malloy_source: null, compiled_sql: null }], { centralLayerChars: 1 });
+    expect(none.shareOfLogic.ratio).toBeNull();
+  });
+
+  it('central-vs-per-query: per-query Malloy size + Malloy→SQL expansion', () => {
+    expect(r.centralVsPerQuery.centralLayerChars).toBe(5000);
+    expect(r.centralVsPerQuery.perQueryMalloyMeanChars).toBe(Math.round((AUTH_SRC.length + VIEW_SRC.length) / 2));
+    // expansion = mean(200/40, 60/len(VIEW_SRC))
+    expect(r.centralVsPerQuery.malloyToSqlExpansion).toBeCloseTo((200 / AUTH_SRC.length + 60 / VIEW_SRC.length) / 2, 5);
+  });
+
+  it('view utilization resolves referenced views against the index', () => {
+    expect(r.viewUtilization).toBeDefined();
+    expect(r.viewUtilization!.totalViews).toBe(1);
+    expect(r.viewUtilization!.usedViews).toBe(1);
+    expect(r.viewUtilization!.utilizationPct).toBe(100);
+    expect(r.viewUtilization!.topViews[0]).toMatchObject({ view: 'v', count: 1 });
+  });
+
+  it('token + cost aggregates with cache hit rate', () => {
+    expect(r.tokens.totalPrompt).toBe(380);
+    expect(r.tokens.totalCached).toBe(230);
+    expect(r.tokens.cacheHitRate).toBeCloseTo((230 / 380) * 100, 5);
+    expect(r.tokens.totalCost).toBeCloseTo(0.036, 5);
+    expect(r.tokens.meanCostPerTask).toBeCloseTo(0.009, 5);
+  });
+
+  it('context breakdown present only when contextChars given; omitted otherwise', () => {
+    expect(r.context!.skillTok).toBe(1000); // 4000 chars / 4
+    expect(r.context!.totalTok).toBe(2000); // (4000+2000+2000)/4
+    const noCtx = computeUsageReport(sampleRows(), { centralLayerChars: 1 });
+    expect(noCtx.context).toBeUndefined();
+    expect(noCtx.viewUtilization).toBeUndefined();
+  });
+});

--- a/projects/agentic-malloy/src/usage-report.ts
+++ b/projects/agentic-malloy/src/usage-report.ts
@@ -1,0 +1,202 @@
+/**
+ * usage-report: substrate-value metrics over a completed eval run (the per-question
+ * results JSONL). Answers "is the Malloy layer earning its keep" — how much answer
+ * logic the agent authored as Malloy vs raw SQL, how thin the per-query Malloy is
+ * against the reusable central layer, which layer views actually get reused, and the
+ * answer-time context-token breakdown. Pure (no I/O) so it is unit-testable; the CLI
+ * (`cmdUsageReport`) does the file/store loading and calls these.
+ */
+import { referencedViews, type LayerIndex } from './miss-analysis.js';
+
+/** A results-JSONL row (loosely typed — only the fields the report reads). */
+export interface UsageRow {
+  answer_kind?: string | null;
+  malloy_source?: string | null;
+  compiled_sql?: string | null;
+  is_correct?: boolean;
+  tool_calls?: number;
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  cached_tokens?: number;
+  cache_write_tokens?: number;
+  cost_usd?: number;
+}
+
+export interface UsageReportCtx {
+  centralLayerChars: number;
+  /** Enables the view-utilization section (omit to skip it). */
+  layerIndex?: LayerIndex;
+  /** Answer-time prefix composition, in chars (skill + primer + glossary). */
+  contextChars?: { skill: number; primer: number; glossary: number };
+}
+
+export interface KindStat {
+  kind: string;
+  n: number;
+  pct: number;
+  accuracy: number; // 0–100
+  meanTools: number;
+  meanPromptTokens: number;
+  meanCost: number;
+}
+export interface UsageReport {
+  n: number;
+  accuracy: number; // 0–100
+  byKind: KindStat[];
+  shareOfLogic: { malloyChars: number; sqlChars: number; ratio: number | null }; // ratio 0–1, null if no authored logic
+  centralVsPerQuery: {
+    centralLayerChars: number;
+    perQueryMalloyMeanChars: number;
+    perQueryMalloyMedianChars: number;
+    malloyToSqlExpansion: number | null; // mean compiled_sql.len / malloy_source.len over Malloy answers
+  };
+  viewUtilization?: {
+    totalViews: number;
+    usedViews: number;
+    utilizationPct: number;
+    topViews: Array<{ view: string; source: string; count: number }>;
+  };
+  context?: { skillTok: number; primerTok: number; glossaryTok: number; centralLayerTok: number; totalTok: number };
+  tokens: {
+    totalPrompt: number;
+    totalCompletion: number;
+    totalCached: number;
+    totalCacheWrite: number;
+    cacheHitRate: number; // 0–100
+    totalCost: number;
+    meanCostPerTask: number;
+  };
+}
+
+const MALLOY_KINDS = new Set(['view-selection', 'authored-malloy']);
+const KIND_ORDER = ['view-selection', 'authored-malloy', 'sql', 'none'];
+const TOK = (chars: number) => Math.round(chars / 4); // ~4 chars/token (approx)
+
+const mean = (xs: number[]) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+const median = (xs: number[]) => {
+  if (!xs.length) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.floor(s.length / 2)];
+};
+const kindOf = (r: UsageRow) => r.answer_kind || 'none';
+
+export function computeUsageReport(rows: UsageRow[], ctx: UsageReportCtx): UsageReport {
+  const n = rows.length;
+  const num = (x: number | undefined) => x || 0;
+  const accuracy = n ? (rows.filter((r) => r.is_correct).length / n) * 100 : 0;
+
+  // Per-kind economics.
+  const groups = new Map<string, UsageRow[]>();
+  for (const r of rows) (groups.get(kindOf(r)) ?? groups.set(kindOf(r), []).get(kindOf(r))!).push(r);
+  const byKind: KindStat[] = [...groups.entries()]
+    .map(([kind, rs]) => ({
+      kind,
+      n: rs.length,
+      pct: n ? (rs.length / n) * 100 : 0,
+      accuracy: rs.length ? (rs.filter((r) => r.is_correct).length / rs.length) * 100 : 0,
+      meanTools: mean(rs.map((r) => num(r.tool_calls))),
+      meanPromptTokens: mean(rs.map((r) => num(r.prompt_tokens))),
+      meanCost: mean(rs.map((r) => num(r.cost_usd))),
+    }))
+    .sort((a, b) => (KIND_ORDER.indexOf(a.kind) - KIND_ORDER.indexOf(b.kind)) || b.n - a.n);
+
+  // Share-of-logic: authored Malloy chars vs authored SQL chars (compiled SQL of
+  // Malloy answers is machine-generated, NOT authored logic — excluded here).
+  const malloyRows = rows.filter((r) => MALLOY_KINDS.has(kindOf(r)) && r.malloy_source);
+  const sqlRows = rows.filter((r) => kindOf(r) === 'sql' && r.compiled_sql);
+  const malloyChars = malloyRows.reduce((a, r) => a + (r.malloy_source?.length ?? 0), 0);
+  const sqlChars = sqlRows.reduce((a, r) => a + (r.compiled_sql?.length ?? 0), 0);
+  const denom = malloyChars + sqlChars;
+
+  // Central layer vs per-query authored Malloy; Malloy→SQL expansion.
+  const perQ = malloyRows.map((r) => r.malloy_source!.length);
+  const expansions = malloyRows
+    .filter((r) => r.compiled_sql && r.malloy_source!.length > 0)
+    .map((r) => r.compiled_sql!.length / r.malloy_source!.length);
+
+  const report: UsageReport = {
+    n,
+    accuracy,
+    byKind,
+    shareOfLogic: { malloyChars, sqlChars, ratio: denom ? malloyChars / denom : null },
+    centralVsPerQuery: {
+      centralLayerChars: ctx.centralLayerChars,
+      perQueryMalloyMeanChars: Math.round(mean(perQ)),
+      perQueryMalloyMedianChars: median(perQ),
+      malloyToSqlExpansion: expansions.length ? mean(expansions) : null,
+    },
+    tokens: {
+      totalPrompt: rows.reduce((a, r) => a + num(r.prompt_tokens), 0),
+      totalCompletion: rows.reduce((a, r) => a + num(r.completion_tokens), 0),
+      totalCached: rows.reduce((a, r) => a + num(r.cached_tokens), 0),
+      totalCacheWrite: rows.reduce((a, r) => a + num(r.cache_write_tokens), 0),
+      cacheHitRate: 0,
+      totalCost: rows.reduce((a, r) => a + num(r.cost_usd), 0),
+      meanCostPerTask: 0,
+    },
+  };
+  report.tokens.cacheHitRate = report.tokens.totalPrompt ? (report.tokens.totalCached / report.tokens.totalPrompt) * 100 : 0;
+  report.tokens.meanCostPerTask = n ? report.tokens.totalCost / n : 0;
+
+  // View utilization (which layer views actually get reused).
+  if (ctx.layerIndex) {
+    const totalViews = [...ctx.layerIndex.viewsBySource.values()].reduce((a, s) => a + s.size, 0);
+    const counts = new Map<string, { view: string; source: string; count: number }>();
+    for (const r of malloyRows) {
+      for (const { source, view } of referencedViews(r.malloy_source!, ctx.layerIndex)) {
+        const key = `${source}.${view}`;
+        (counts.get(key) ?? counts.set(key, { view, source, count: 0 }).get(key)!).count++;
+      }
+    }
+    const topViews = [...counts.values()].sort((a, b) => b.count - a.count).slice(0, 10);
+    report.viewUtilization = {
+      totalViews,
+      usedViews: counts.size,
+      utilizationPct: totalViews ? (counts.size / totalViews) * 100 : 0,
+      topViews,
+    };
+  }
+
+  // Answer-time context-token breakdown (the static prefix the prompt re-sends).
+  if (ctx.contextChars) {
+    const c = ctx.contextChars;
+    const skillTok = TOK(c.skill), primerTok = TOK(c.primer), glossaryTok = TOK(c.glossary), centralLayerTok = TOK(ctx.centralLayerChars);
+    report.context = { skillTok, primerTok, glossaryTok, centralLayerTok, totalTok: skillTok + primerTok + glossaryTok };
+  }
+
+  return report;
+}
+
+export function formatUsageReport(r: UsageReport, label?: string): string {
+  const L: string[] = [];
+  const pct = (x: number) => `${x.toFixed(0)}%`;
+  if (label) L.push(label);
+  L.push(`tasks: ${r.n}   accuracy: ${r.accuracy.toFixed(1)}%`);
+  L.push('');
+  L.push('answer-path economics:');
+  L.push(`  ${'kind'.padEnd(16)}${'n'.padStart(5)}${'%'.padStart(6)}${'acc'.padStart(6)}${'meanTools'.padStart(11)}${'meanPromptTok'.padStart(15)}${'meanCost'.padStart(10)}`);
+  for (const k of r.byKind)
+    L.push(`  ${k.kind.padEnd(16)}${String(k.n).padStart(5)}${pct(k.pct).padStart(6)}${pct(k.accuracy).padStart(6)}${k.meanTools.toFixed(1).padStart(11)}${Math.round(k.meanPromptTokens).toLocaleString().padStart(15)}${('$' + k.meanCost.toFixed(4)).padStart(10)}`);
+  L.push('');
+  const sl = r.shareOfLogic;
+  L.push(`share-of-logic (authored Malloy / authored Malloy+SQL): ${sl.ratio == null ? 'n/a' : pct(sl.ratio * 100)}`);
+  L.push(`  authored Malloy: ${sl.malloyChars.toLocaleString()} chars   authored SQL: ${sl.sqlChars.toLocaleString()} chars`);
+  const cv = r.centralVsPerQuery;
+  L.push(`central layer: ${cv.centralLayerChars.toLocaleString()} chars   per-query Malloy: mean ${cv.perQueryMalloyMeanChars.toLocaleString()} / median ${cv.perQueryMalloyMedianChars.toLocaleString()} chars`
+    + (cv.malloyToSqlExpansion != null ? `   Malloy→SQL ×${cv.malloyToSqlExpansion.toFixed(1)}` : ''));
+  if (r.viewUtilization) {
+    const v = r.viewUtilization;
+    L.push('');
+    L.push(`view utilization: ${v.usedViews}/${v.totalViews} views used (${pct(v.utilizationPct)})`);
+    if (v.topViews.length) L.push('  top: ' + v.topViews.map((t) => `${t.view}×${t.count}`).join(', '));
+  }
+  if (r.context) {
+    const c = r.context;
+    L.push('');
+    L.push(`answer-time context (~tokens): skill ${c.skillTok.toLocaleString()} · primer ${c.primerTok.toLocaleString()} · glossary ${c.glossaryTok.toLocaleString()} = ${c.totalTok.toLocaleString()} prose prefix  (central layer ${c.centralLayerTok.toLocaleString()}, read on demand)`);
+  }
+  const t = r.tokens;
+  L.push('');
+  L.push(`tokens: prompt ${t.totalPrompt.toLocaleString()} (cache hit ${pct(t.cacheHitRate)}) · completion ${t.totalCompletion.toLocaleString()}   cost: $${t.totalCost.toFixed(2)} ($${t.meanCostPerTask.toFixed(4)}/task)`);
+  return L.join('\n');
+}


### PR DESCRIPTION
## What

`asm-malloy usage-report <results.jsonl> [--json out.json]` — the PLAN.md Phase-2 deliverable, automating the substrate-value analysis that was being done by hand all session.

Reports, for a completed run:
- **answer-path economics** — per answer_kind (view-selection / authored-malloy / sql): n, %, accuracy, mean tools / prompt-tokens / cost
- **share-of-logic** = authored Malloy chars / (authored Malloy + authored SQL) chars — of the logic the agent hand-wrote, how much was Malloy vs raw SQL
- **central-vs-per-query** Malloy size + Malloy→SQL expansion ratio
- **view utilization** — how many of the layer's views are actually reused (+ top views)
- **answer-time context-token breakdown** (skill / primer / glossary)
- token / cost / cache aggregates

## Design
- Pure aggregation in `src/usage-report.ts` (`computeUsageReport` / `formatUsageReport`), unit-tested (`usage-report.test.ts`, 7 cases).
- `cli.ts` `cmdUsageReport` loads the JSONL + on-disk layer (`centralLayerChars`, `loadLayerIndex`) + skill/primer/glossary, prints; `--json <path>` writes the object.
- **Read-only + local — no MCP/eval spend.** Reuses `referencedViews` (miss-analysis) and the glossary loaders.

## Validation
- 7 unit tests + 221-suite green, typecheck clean.
- End-to-end on `test_2026-06-25T2334Z.jsonl`: reproduces the hand-computed figures exactly (view 11% / authored 32% / sql 57%, per-kind acc 91/96/89%, cache 89%, \$29.76).
- Robust across run shapes (authored-heavy, sql-heavy, gemini). Immediately surfaced that **share-of-logic is config-dependent (15%→87% across runs)** and that **view utilization is stable (~12–17 of 84 views used)** — i.e. most authored layer views are never reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)