### PR TITLE
agentic-malloy: Phase-2/3 optimization — steer · usage-report · tool-prune + capstone

### DIFF
--- a/projects/agentic-malloy/README.md
+++ b/projects/agentic-malloy/README.md
@@ -55,7 +55,15 @@ npx tsx bin/asm-malloy.ts malloy-preflight  # compile + local run sanity check
 npx tsx bin/asm-malloy.ts evaluate --task-id 1711 --author sonnet --fixer opus
 npx tsx bin/asm-malloy.ts evaluate --split templates --run-class official
 npx tsx bin/asm-malloy.ts summary results/<file>.jsonl
+npx tsx bin/asm-malloy.ts usage-report results/<file>.jsonl   # substrate-value metrics (read-only, local)
 ```
+
+`usage-report` aggregates a completed run into the substrate-value metrics:
+answer-path economics (view-selection / authored-malloy / sql), **share-of-logic**
+(authored Malloy chars / authored Malloy+SQL chars), central-vs-per-query Malloy size
++ Malloy→SQL expansion, **view utilization** (how many layer views are actually
+reused), and the answer-time context-token breakdown. `--json <path>` writes the
+report object. Read-only and local — no MCP/eval spend.
 
 `evaluate` runs the two-model author→fixer loop, explores via MotherDuck MCP,
 executes the compiled Malloy answer on MotherDuck, scores via the Python sidecar,

--- a/projects/agentic-malloy/README.md
+++ b/projects/agentic-malloy/README.md
@@ -53,7 +53,7 @@ npx tsx src/spike-fees.ts   # reproduce task 1711's 29.93 via a Malloy fee match
 npx tsx bin/asm-malloy.ts load              # build the local compile DB
 npx tsx bin/asm-malloy.ts malloy-preflight  # compile + local run sanity check
 npx tsx bin/asm-malloy.ts evaluate --task-id 1711 --author sonnet --fixer opus
-npx tsx bin/asm-malloy.ts evaluate --split templates --run-class official
+npx tsx bin/asm-malloy.ts evaluate --split templates --run-class official --no-steer  # official requires --no-steer (opus failover; in-place steer is the smoke default)
 npx tsx bin/asm-malloy.ts summary results/<file>.jsonl
 npx tsx bin/asm-malloy.ts usage-report results/<file>.jsonl   # substrate-value metrics (read-only, local)
 ```
@@ -88,6 +88,10 @@ honest:
 - `evaluate --run-class official` **fails fast** unless that marker exists, says
   `model_authored`, AND the on-disk layer still hashes to the recorded
   `malloy_model_hash`. A hand-edit breaks the hash → the run is refused.
+- An official run also requires **`--no-steer`** (the canonical sonnet-author /
+  opus-**failover** tiering). The in-place steer is the opus-free *smoke* default;
+  the gate refuses an official run without `--no-steer` rather than silently coercing
+  it — same "refuse, don't coerce" pattern as the author/fixer-model checks.
 - **Never hand-edit `malloy/models/*` to improve answers.** If the layer misses
   questions, change the `layer-build` prompt / `skill.md` / `layer-build.ts` and
   **rerun `layer-build`** — then re-run `evaluate`. Hand-edits make the run

--- a/projects/agentic-malloy/README.md
+++ b/projects/agentic-malloy/README.md
@@ -149,7 +149,7 @@ human) complement to the rule above: it triages a run's misses and edits the lay
   controllog build run. `--re-eval` then re-runs the same task-ids to measure —
   always as a **smoke** run (the just-edited layer/skill is uncommitted, and an
   official run requires a clean tree), so commit the edits and run
-  `evaluate --run-class official` separately to record an official number.
+  `evaluate --run-class official --no-steer` separately to record an official number.
 
 ## Harness status
 

--- a/projects/agentic-malloy/docs/layer-rebuild-outcome.md
+++ b/projects/agentic-malloy/docs/layer-rebuild-outcome.md
@@ -1,0 +1,37 @@
+# Layer rebuild outcome — fixed the AVG defect, but net-negative (NOT promoted)
+
+A full `layer-build` regen (opus, 4 rounds, $3.68) was run to fix the c3 AVG-ranking
+defect at the source (the always-fail most-expensive-{ACI|MCC|scheme} template). New
+hash `a2a8a381` (old `d7a2545e`). **Result: parked on `agentic-malloy-layer-rebuild`,
+not merged — `main` keeps the old layer.**
+
+## What the rebuild fixed
+- Build gate findings **18 → 1**: the `name_vs_aggregation` views (`most_expensive_aci_on_100`
+  et al. ranking by AVG) are gone; the `aci` universe is data-derived; SUM surfaces exist
+  (`total_fees_paid is rules.sum(...)`, `sum_fee_at_{50,100,1000,50000}`).
+- The c3 file was restructured + renamed (`c3_average_fee_scenarios` → `c3_payments_enriched`).
+- Train reps **1442 ✓ / 1451 ✓**.
+
+## Why it's net-negative (train 24/26 → 22/26)
+- **No score gain from the fix.** The SQL bypass + skill conventions already passed 1442/1451
+  on the old layer, so fixing the AVG view recovered nothing on the score.
+- **Two real, structural regressions (not noise):**
+  - **2587 / 2634 / 2762 (steering)** — the regen **dropped ALL counterfactual/candidate
+    sources** (the old layer had `c5_payments_priced_card_scheme_counterfactual` + ACI/MCC
+    siblings; the new layer has zero). With no counterfactual view to reuse, the agent
+    hand-rolls wrong SQL. A capability regression.
+  - **1834 (total fees)** — the new `fees_by_merchant_month` view exposes BOTH a specific
+    and an effective fee column (from the wrong-grain "expose both" coaching); the agent
+    returned the whole row (`merchant,month,4573.00,3767.90`) instead of the effective
+    total `3767.90` — a shape error the richer view induced.
+
+## Lessons
+- **Full `layer-build` regen is lossy** — it fixed the targeted defect but silently dropped
+  the counterfactual modeling the prior layer had. The build prompt doesn't know to
+  preserve existing capabilities; a from-scratch regen is not a safe "patch."
+- **The substrate verdict holds / sharpens** — fixing the layer's structural defect did NOT
+  move the score, because the agent routes around the layer via SQL anyway. The layer's
+  value isn't being realized; the SQL escape + skill carry the load.
+- If the c3 defect is ever worth fixing on the live layer, it needs a **surgical** path
+  (targeted `layer-improve` edit that adds a SUM/total-fee ACI surface + fixes meta routing
+  WITHOUT dropping the counterfactual sources), not a full regen.

--- a/projects/agentic-malloy/docs/optimization-capstone.md
+++ b/projects/agentic-malloy/docs/optimization-capstone.md
@@ -1,0 +1,122 @@
+# Optimization capstone — what moved, what didn't, and every idea dispositioned
+
+Capstone for the Phase-2/3 optimization pass. It (1) states the substrate verdict with
+the numbers the session produced, (2) ledgers what shipped, and (3) gives a grounded
+disposition for **every** idea in the optimization-loop backlog and the Malloy-knowledge
+notes. The throughline: most backlog ideas target **authoring knowledge** or **submission
+token cost**, but profiling showed the bottleneck is neither — so several are correct
+solutions to a non-dominant problem.
+
+## TL;DR
+
+- **The substrate is barely used; SQL carries the load.** Share-of-logic (authored Malloy
+  chars / authored Malloy+SQL) is **config-dependent and often low** — 15% / 87% / 53%
+  across three held-out runs — and only **~12–17 of 84 layer views are ever referenced**.
+- **Efficiency is tapped without trading accuracy.** Every lever routes through *fewer
+  turns* or *smaller prefix*; both are low-yield (the prefix is cross-task cached) or
+  accuracy-costly (the author-first A/B: −24% tokens but −5.6 pts).
+- **Fixing the layer's defect doesn't move the score.** A full rebuild fixed the c3 AVG
+  defect (gate 18→1) but was net-negative (−2 train, dropped the counterfactual surfaces)
+  — because the agent routes around the layer via SQL anyway.
+- **Net shipped:** steer-instead-of-escalate (PR #74), usage-report (PR #75), unused-tool
+  prune (branch). Layer rebuild parked (`docs/layer-rebuild-outcome.md`).
+
+## 1. The substrate verdict (quantified)
+
+| metric | finding | source |
+|---|---|---|
+| share-of-logic | 15% (2334Z) · 87% (1819Z) · 53% (0155Z) — **config-dependent**, often SQL-dominated | usage-report |
+| view utilization | **12–17 of 84** views ever referenced (86% dead weight) | usage-report |
+| answer mix | sql 57% / authored 32% / view-selection 11% (2334Z) | usage-report |
+| view-selection cost | the **most expensive** answer path (99k tok vs authored 84k), **not** more accurate (91% vs 96%) | answer-path economics |
+| prompt-token composition | **static prefix 68%** (skill 4.3k + primer 2.1k + glossary 2.2k + tools ~1k), get_file 15%, list_views 10%; run_malloy/query echoes ~1–3% | per-tool token attribution |
+| cost composition | cache-write ~46% · cache-read ~31% · output ~22% (cache hit ~89% on sonnet) | JSONL cache fields |
+| escalation rescue | opus-vs-sonnet-fixer indistinguishable; the steer (opus-free) matched at lower cost | 3-arm A/B |
+| layer rebuild | fixes the AVG defect (gate 18→1) but **net −2 train**; full regen is **lossy** (dropped counterfactuals) | rebuild + train smoke |
+
+## 2. Session ledger
+
+| change | status |
+|---|---|
+| steer-instead-of-escalate (opus-free in-place steer) | **PR #74** (pushed) |
+| usage-report (substrate-value metrics) | **PR #75** (pushed) |
+| drop unused MCP tools (`list_databases`, `ask_docs_question`) | committed, `agentic-malloy-prune-unused-mcp-tools` (unpushed) |
+| author-first skill A/B | parked (−5.6 pts; load-bearing browse) |
+| layer rebuild `a2a8a381` | parked, `agentic-malloy-layer-rebuild` (net-negative; `docs/layer-rebuild-outcome.md`) |
+
+## 3. Optimization-loop backlog — every idea dispositioned
+
+| # | idea | status / finding |
+|---|---|---|
+| 1 | **Malloy MCP** | **Not pursued.** Knowledge-access lever, but authoring isn't the bottleneck — the SQL escape-hatch proof (cheap model transcribed the *same* wrong recipe into SQL) shows knowledge isn't the gap. |
+| 2 | **Enforce linter before submit** (so the model gets fixed Malloy back) | **Already shipped.** `lintMalloy` runs before every compile/run/submit (`tools.ts`); the *fixed* source is what compiles, and the applied fixes are surfaced to the model. |
+| 3 | **"fix Malloy" tool / incremental submission** (write-to-file, edit) | **Not pursued — premise off.** `submit_answer` already takes only the per-query `source` (not a "full model"), and `get_file` is cached (re-reads stub). Token attribution: submission/run_malloy echoes are **~1%** — the saving is negligible. |
+| 4 | **Validate the linter runs when building** | **Confirmed shipped.** The 2A build gates (`layerSourceGate`) run in the build loop and feed findings back to the builder (`layer-build.ts:473`); every view is compiled+executed by the P0 gate. |
+| 5 | **List-views tool** | **Shipped (#71) — but a net cost.** view-selection is the *most expensive* path, not more accurate; the catalog browse is paid by **83% of tasks for an 11% payoff**, and the catalog can misroute (root-cause §4). Built ≠ beneficial. |
+| 6 | **LSP (Malloy VS Code)** | **Not pursued.** Heavy lift; authoring competence isn't the gap. Lowest ROI on the list. |
+| 7 | **Malloy docs tool** (git/scrape/SQLite-search; use in builder+eval) | **Not pursued as a tool.** Over-engineered for the observed need; the lightweight version — a curated mental-model + cookbook + error recipes baked into the **primer/skill** — covers it without a tool or extra round-trips (see §5). |
+| 8 | **Recommend smaller Malloy files** | **Low priority / cautionary.** The rebuild *did* restructure files and the lesson was the opposite risk: full regen is **lossy**. Modularity guidance in the build prompt is fine but won't move the metric. |
+| 9 | **More succinct list-files; why list_files runs 3×** | **Characterized, minor.** The "3× browse" is the wasted-exploration pattern — 72% of tasks browse `list_views`/`get_file` without using a view. Real, but the bigger story is the prefix (68%); succinct list-files is a small lever. The author-first A/B tested skipping the browse (−24% tok / −5.6 pts). |
+| 10 | **More linter rules: reorder sources; where→having** | **where→having already shipped** (linter rule 7c, auto-split). **reorder-sources** not built — cosmetic, no correctness/cost value. |
+| 11 | **Reduce overfitting: builder refactor/summarize pass** | **Risky, not pursued.** The rebuild shows a from-scratch refactor is lossy (drops capabilities). The no-leakage + train-gate constraints already guard overfitting. |
+| 12 | **error_recipe_lookup tool (code→recipe; "Idea #2")** | **Partially shipped, not as a tool.** The triggers are a *small recurring set* of compile errors; the right home is the **skill/primer** (and the `stuckAuthorSteer` already feeds recipe-like guidance on the 2-consecutive-error trigger — PR #74). A separate deterministic tool is lower-value than inlining the recipes (§5/§6). |
+| 13 | **Compress the compiler output** (`{code, one-line, 3 lines, recipe}`) | **Low token value, modest friction value.** Compiler-error echoes are ~1% of tokens, so compression saves little; the *recipe* attached to the error (from §6) is what would cut error loops — and that belongs in the skill, not the wire format. |
+
+## 4. The finding that recontextualizes the list
+
+Items 1, 3, 6, 7, 12, 13 are all **authoring-knowledge or submission-token** levers. The
+session's evidence says both are non-dominant:
+
+- **Authoring isn't the gap** — the agent authors competently; when Malloy fights it, it
+  bails to SQL and is *fine* (sql path ~89% accurate). More Malloy knowledge/tooling
+  wouldn't change the misses, which are semantic (AVG-vs-SUM) or convention, not syntax.
+- **Submission/error tokens are ~1–3%** — the token cost is the **static prefix (68%)** and
+  the **get_file/list_views browse (25%)**, neither of which these ideas touch.
+
+So the backlog's center of gravity is mis-aimed at the measured bottleneck. The levers that
+*are* real — prefix size and turn count — are the ones we found are either cached-cheap or
+accuracy-costly to pull. That's why "efficiency is tapped."
+
+## 5. The Malloy-knowledge notes (mental model · cookbook · error recipes)
+
+These are **good content in the wrong container**. The mental model (§1), pattern cookbook
+(§5), and error-recipe table (§6) should live in **`docs/malloy/malloy-primer.md` +
+`src/skill.md`** (the answer-time context), not a docs tool — the author model then has them
+inline with zero round-trips. Caveat from the token attribution: the prefix is already 68%
+of prompt volume, so additions must earn their keep; it's cross-task **cached** (cheap
+reads), so ~1–2k of high-value recipe content is affordable if it cuts error loops.
+
+**§6 recipes mapped to current coverage** (so we add only what's missing):
+
+| recipe | current coverage |
+|---|---|
+| `Illegal reference, query expected` (`run: src`) | **auto-fixed** — linter prefixes bare pipelines with `run:` |
+| `select-of-view` / `group-by-aggregate` (select in a reduction) | **auto-fixed** — linter splits `select:`→`group_by:`+`aggregate:` (rule 7d) + skill rules |
+| `aggregate-in-where` → `having:` | **auto-fixed** — linter rule 7c |
+| `function-not-found` for list fns (`list_contains`/`len`) | **auto-fixed** — linter adds `!boolean`/`!number` raw-escape |
+| `restricted-construct-forbidden` / raw `duckdb.sql(...)` | **handled** — rejected + steered to `submit_sql` |
+| `field-not-found` (`'X' is not defined`) | **partial** — `stuckAuthorSteer` says "don't guess; call `list_columns`" (PR #74); not mechanical |
+| `invalid-symmetric-aggregate` (bare `max()`/`min()` needs arg/path) | **not covered** — the *rebuild itself* hit this (c4); good candidate for a new lint or a primer recipe |
+| `Unsupported keyword 'as'` (SQL aliasing) | **not covered** — trivially mechanical (`as`→`is`); add a lint rule |
+| fanout (`Cannot compute <fn> across join_many`) | **primer covers join_many**; not mechanical — keep as a primer recipe |
+| `output-name-conflict`, `join-with-without-primary-key`, `no-matching-function-overload`, ANTLR `no viable alternative` | **not covered** — judgment-needed; fold the §6 rows into the primer |
+
+**Actionable residue from §5/§6 (small, general, allowed):** (a) add two mechanical lint
+rules — `as`→`is` and bare `max()/min()` → require an arg/path; (b) fold the
+not-auto-fixed §6 rows + the §1 mental model into the primer as a condensed recipe block.
+Both are cheap and substrate-general. Neither will move the headline score (the misses
+aren't syntax), but they cut authoring friction/turns.
+
+## 6. Residual work (all optional — the experiment is well-characterized)
+
+1. **Surgical c3 fix** (instead of the lossy full regen): a targeted `layer-improve` edit
+   that adds a SUM/total-fee ACI surface + fixes meta routing **without** dropping the
+   counterfactual sources. Fixes the substrate honestly; **won't move the score** (SQL
+   masks it).
+2. **Fold §1/§6 into the primer + 2 mechanical lint rules** (§5 above) — cheap friction win.
+3. **Decide the open PRs/branches** — merge #74 (steer) + #75 (usage-report); fold the
+   tool-prune in; the layer-rebuild branch stays parked as a documented dead-end.
+
+The honest bottom line: the substrate's value isn't being realized — SQL + a tuned skill
+carry the benchmark, the layer is mostly unused, and the remaining levers are either
+cached-cheap, accuracy-costly, or score-neutral. This is a natural stopping point.

--- a/projects/agentic-malloy/docs/steer-vs-escalate-ab.md
+++ b/projects/agentic-malloy/docs/steer-vs-escalate-ab.md
@@ -1,0 +1,64 @@
+# Steer-instead-of-escalate: A/B result and decision
+
+**Phase 3 (efficiency).** Replaces the opus failover on the sonnet arm with an in-place,
+content-bearing steer on repeated compile errors. This doc records the experiment that
+justified making the steer the default.
+
+## Question
+
+On the sonnet arm, escalation to opus fired on ~2% of tasks (always "2 consecutive tool
+errors") and those tasks ended correct 83–91% of the time. But that figure does **not**
+isolate opus: `escalate()` simultaneously (a) switched to opus, (b) injected a fixer prompt,
+and (c) granted more turns. Reading the escalated trajectories, every trigger was a Malloy
+**compile** error (field-name guessing like `'transaction_date'`; SQL-habit grammar), and
+opus's "rescue" was either a clean re-author (it knew the field) or a switch to `submit_sql`
+— neither needs opus's intelligence. Hypothesis: **a steer on sonnet matches opus, opus-free.**
+
+## Design — 3 arms × 3 passes × the 27 historically-escalated tasks
+
+Union of the escalated task_ids across the three sonnet held-out runs (2334Z / 1819Z / 2000Z):
+`22,48,61,1308,1336,1366,1401,1433,1444,1449,1531,1574,1577,1584,1615,1643,1645,1646,1676,
+1679,1747,1763,1775,1826,2713,2728,2755`.
+
+- **A — control:** `--fixer opus` (current opus failover).
+- **B — ablation:** `--fixer sonnet` (same escalate structure + generic fixer prompt + extra
+  turns, **no model switch**). Isolates the value of opus itself.
+- **C — treatment:** the new in-place steer (`stuckAuthorSteer`), opus-free.
+
+## Result (81 task-runs / arm)
+
+| arm | accuracy | cost | $/task | mean elapsed | escalations | steers |
+|---|---|---|---|---|---|---|
+| A opus | 77/81 (95.1%) | $5.52 | $0.068 | 25.5s | 3 | 0 |
+| B sonnet-fixer | 75/81 (92.6%) | $4.79 | $0.059 | 24.9s | 2 | 0 |
+| **C steer (opus-free)** | **79/81 (97.5%)** | **$4.70** | **$0.058** | 24.8s | 0 | 1 |
+
+Per-pass: A 26/24/27 · B 26/26/23 · C 27/25/27.
+
+## Verdict
+
+1. **No accuracy regression from dropping opus.** Per-pass swings (23–27 every arm) exceed
+   the gap between arm means (25.7 / 25.0 / 26.3) — the arms are statistically
+   indistinguishable. Opus-free *tracks* opus.
+2. **Opus-free is ~15% cheaper** on this subset (no opus tokens); **latency is flat** (~25s,
+   consistent with escalation being ~2% of wall-clock — there is **no speed win**).
+3. On the 4 tasks that actually triggered the stuck path, opus-free solved all; opus itself
+   missed one (1643) on one pass.
+
+**Honest caveat:** the escalation/steer mechanism fired only **1–3 times per 81 runs** — most
+of the 27 "stuck" tasks authored cleanly this time. So this is primarily evidence of *no harm
+from dropping opus* plus *the steer handling every real trigger correctly*, **not** proof the
+steer is a large accuracy lever. The numbers are also small (81 runs/arm) and not significant.
+
+## Decision
+
+Make the in-place steer the **default** (opus-free). Restore the opus failover with
+`--no-steer`. The **official** baseline is unchanged — it is still sonnet-author / opus-failover,
+so an official run must pass `--no-steer` (the official gate enforces this).
+
+## Right-sizing / what's next
+
+This is a modest win: ~15% cheaper on the escalation-prone subset (~5% of fleet cost), no
+latency change — mostly it **de-risks** (removes the expensive-model dependency) and slightly
+improves accuracy. The real Phase-3 levers remain the **per-task baseline** (≈85% of cost =
+turns × re-sent context × cache) and the **SQL-exploration grind tail**.

--- a/projects/agentic-malloy/src/agentic-loop.test.ts
+++ b/projects/agentic-malloy/src/agentic-loop.test.ts
@@ -112,6 +112,32 @@ describe('runTask no-submit recovery', () => {
     expect(r.authorRecoveryUsed).toBe(false); // tool-error escalation, not the prose-recovery path
   });
 
+  it('steerInsteadOfEscalate: consecutive errors steer the AUTHOR in place — no model switch', async () => {
+    const state = { submitted: false };
+    const events: { kind: string }[] = [];
+    // Two consecutive run_malloy errors (would escalate by default); then a submit.
+    streamMock
+      .mockResolvedValueOnce(sseTurn({ tool: { name: 'run_malloy', input: { source: 'bad1' } } }))
+      .mockResolvedValueOnce(sseTurn({ tool: { name: 'run_malloy', input: { source: 'bad2' } } }))
+      .mockResolvedValueOnce(sseTurn({ tool: { name: 'submit_answer', input: { source: 'good' } } }));
+    dispatchMock.mockImplementation(async (_deps: unknown, name: string) => {
+      if (name === 'submit_answer') { state.submitted = true; return { content: 'Submitted. 1 row(s).', isError: false }; }
+      return { content: "Malloy compile error:\n  - 'transaction_date' is not defined", isError: true };
+    });
+
+    const r = await runTask({
+      ...baseOpts(state),
+      steerInsteadOfEscalate: true,
+      onEvent: (e) => events.push(e),
+    });
+
+    expect(r.escalated).toBe(false); // never failed over to the fixer model
+    expect(r.submitted).toBe(true);
+    expect(events.some((e) => e.kind === 'stuck_author_steer')).toBe(true);
+    // EVERY turn ran on the author model — the fixer model was never used.
+    for (const call of streamMock.mock.calls) expect(call[0].model).toBe('author-model');
+  });
+
   it('a stream failure ends the loop with a streamFailureReason (not a silent hit-limit)', async () => {
     const state = { submitted: false };
     streamMock.mockRejectedValueOnce(new Error('stream setup exploded'));

--- a/projects/agentic-malloy/src/agentic-loop.ts
+++ b/projects/agentic-malloy/src/agentic-loop.ts
@@ -24,6 +24,11 @@ export interface RunTaskOpts {
   escalateAfter: number;
   maxAuthorTurns: number;
   maxFixerTurns: number;
+  /** When true, the consecutive-compile-error trigger injects a content-bearing
+   *  steer and keeps the AUTHOR model (up to STEER_BUDGET times) instead of
+   *  failing over to the fixer model. The arm is opus-free only if the caller also
+   *  pins fixerModel === authorModel (the CLI flag does this). Default false. */
+  steerInsteadOfEscalate?: boolean;
   reasoningEffort?: string;
   provider?: string; // pin OpenRouter to a single upstream provider
   taskId: string;
@@ -57,6 +62,8 @@ export interface TaskResult {
   streamFailureReason: string | null;
   /** True if the author was given its one forced submit-now recovery turn. */
   authorRecoveryUsed: boolean;
+  /** In-place stuck-author steers issued (--steer-instead-of-escalate); 0 otherwise. */
+  steersUsed: number;
   /** Total OpenRouter stream-setup retries across all turns (telemetry). */
   retryCount: number;
   /** The full bundled conversation (OpenAI Responses-item shape: user / message /
@@ -116,6 +123,23 @@ function sameErrorSteer(sqlOn: boolean): string {
     (sqlOn
       ? 'Instead: use the `query` (SQL) tool to compute the answer directly, then call `submit_sql` with that SQL — it runs on MotherDuck and is scored exactly like a Malloy answer. Do NOT wrap SQL inside Malloy (`duckdb.sql(...)` is rejected).'
       : 'Instead: pivot to a DIFFERENT layer view or source that does not depend on the broken one, and submit_answer with that Malloy.')
+  );
+}
+
+// Shown (in --steer-instead-of-escalate mode) on N consecutive Malloy-authoring
+// errors INSTEAD of escalating to the fixer model. Operationalizes what opus did
+// when it "rescued" these tasks: read the exact field names rather than guessing,
+// apply the Malloy form named in the diagnostic, switch off a broken view, or fall
+// back to submit_sql. General (no dataset-specific nouns); flag-aware on SQL.
+function stuckAuthorSteer(n: number, sqlOn: boolean): string {
+  return (
+    `You've hit ${n} Malloy compile errors in a row — re-running the same shape will NOT clear them. Diagnose by cause, then fix:\n` +
+    "- \"'X' is not defined\": you are guessing a column name. Do NOT guess — call list_columns (or get_file on the source) and use the EXACT field names verbatim.\n" +
+    '- select / avg / aggregate / date-type errors: these are SQL habits Malloy rejects. Read the diagnostic literally — a reduction uses group_by: + aggregate:, never select:.\n' +
+    '- If the COMPILED SQL errors (a binder/scope error), the layer view itself is broken — switch to a DIFFERENT view or source.\n' +
+    (sqlOn
+      ? 'If Malloy keeps fighting you, compute the answer with the `query` (SQL) tool and call `submit_sql` — it runs on MotherDuck and is scored identically. Do NOT wrap SQL inside Malloy.'
+      : 'Pivot to a DIFFERENT layer view/source that does not depend on the broken one, and submit_answer with that Malloy.')
   );
 }
 
@@ -244,6 +268,8 @@ export async function runTask(opts: RunTaskOpts): Promise<TaskResult> {
   let authorRecoveryUsed = false; // the author's one forced submit-now turn
   let retryCount = 0;
   let prevMalloyErrSig: string | null = null; // last turn's run_malloy/submit error signature
+  let steersUsed = 0; // stuck-author steers issued (--steer-instead-of-escalate)
+  const STEER_BUDGET = 2; // after this many in-place steers, fall back to escalate()
   const usage: TaskUsage = { promptTokens: 0, completionTokens: 0, cost: 0, cachedTokens: 0, cacheWriteTokens: 0 };
   // Hard ceiling only; each role is bounded separately below so the expensive
   // fixer can never run past --max-fixer-turns regardless of when it escalated.
@@ -357,24 +383,30 @@ export async function runTask(opts: RunTaskOpts): Promise<TaskResult> {
     }
     messages.push({ role: 'user', content: toolResults });
 
-    // Repeated-IDENTICAL Malloy error → the agent is looping (often on a layer
-    // binder/scope bug it can't fix by rewriting). Steer it ONCE to the SQL
-    // fallback instead of letting it burn turns re-running the same thing.
+    if (deps.state.submitted) break;
+
     const errSig = malloyErr ? normErrSig(malloyErr) : null;
-    if (errSig && errSig === prevMalloyErrSig) {
+    consecutiveErrors = anyError ? consecutiveErrors + 1 : 0;
+    // Author max-turns escalation is handled at the top of the loop; here we act
+    // on repeated tool errors. Exactly one of these fires per turn:
+    //  1. steer-in-place (flagged): keep the author model, inject a steer, continue;
+    //  2. escalate to the fixer (default, or after the steer budget is spent);
+    //  3. one-shot same-error nudge when neither (1) nor (2) tripped this turn.
+    const stuck = role === 'author' && consecutiveErrors >= opts.escalateAfter;
+    if (stuck && opts.steerInsteadOfEscalate && steersUsed < STEER_BUDGET) {
+      messages.push({ role: 'user', content: stuckAuthorSteer(consecutiveErrors, sqlOn) });
+      opts.onEvent?.({ kind: 'stuck_author_steer', detail: errSig?.slice(0, 80) ?? null });
+      steersUsed++;
+      consecutiveErrors = 0; // give the author a fresh streak after the steer
+    } else if (stuck) {
+      escalate(`${consecutiveErrors} consecutive tool errors`);
+    } else if (errSig && errSig === prevMalloyErrSig) {
+      // Looping on the SAME error (often a layer binder/scope bug it can't fix by
+      // rewriting). One-shot nudge off the dead view.
       messages.push({ role: 'user', content: sameErrorSteer(sqlOn) });
       opts.onEvent?.({ kind: 'repeat_error_steer', detail: errSig.slice(0, 80) });
     }
     prevMalloyErrSig = errSig;
-
-    if (deps.state.submitted) break;
-
-    consecutiveErrors = anyError ? consecutiveErrors + 1 : 0;
-    // Author max-turns escalation is handled at the top of the loop; here we
-    // only escalate early on repeated tool errors.
-    if (role === 'author' && consecutiveErrors >= opts.escalateAfter) {
-      escalate(`${consecutiveErrors} consecutive tool errors`);
-    }
   }
 
   const hitLimit = !deps.state.submitted;
@@ -391,6 +423,7 @@ export async function runTask(opts: RunTaskOpts): Promise<TaskResult> {
     hitLimit,
     streamFailureReason,
     authorRecoveryUsed,
+    steersUsed,
     retryCount,
     trace,
   };

--- a/projects/agentic-malloy/src/cli.ts
+++ b/projects/agentic-malloy/src/cli.ts
@@ -679,7 +679,7 @@ async function cmdLayerImprove(flags: Record<string, string | boolean>) {
     // commit-then-official flow for a recordable number.
     const reEvalRunClass = (flags['run-class'] === 'official') ? 'smoke' : ((flags['run-class'] as string) || 'smoke');
     if (flags['run-class'] === 'official') {
-      console.log(`\nℹ️  re-eval runs as SMOKE: the just-edited layer/provenance${res.skillFixesApplied.length ? '/skill' : ''} is uncommitted, and an official run requires a clean tree. To record an official number: commit the edits, then run \`asm-malloy evaluate --split ${(flags.split as string) || 'templates'} --run-class official\`.`);
+      console.log(`\nℹ️  re-eval runs as SMOKE: the just-edited layer/provenance${res.skillFixesApplied.length ? '/skill' : ''} is uncommitted, and an official run requires a clean tree. To record an official number: commit the edits, then run \`asm-malloy evaluate --split ${(flags.split as string) || 'templates'} --run-class official --no-steer\`.`);
     }
     console.log(`\n▶ re-evaluating ${ids.length} task-id(s) from ${path.basename(fromPath)} to measure the improvement (run_class=${reEvalRunClass}) …`);
     await cmdEvaluate({ ...flags, 'run-class': reEvalRunClass, 'task-id': ids.join(','), from: undefined as unknown as string });
@@ -783,7 +783,7 @@ async function main() {
       console.log('           (triages a run\'s misses by MANNER of failure + runs a tool-error meta-analysis;');
       console.log('            edits the layer ONLY for structural defects from TRAIN-only runs, never tunes to a gold answer;');
       console.log('            tool-error rules are recommend-only unless --apply-skill-fixes;');
-      console.log('            --re-eval measures edits as SMOKE — commit, then `evaluate --run-class official` to record a number)');
+      console.log('            --re-eval measures edits as SMOKE — commit, then `evaluate --run-class official --no-steer` to record a number)');
       console.log('  evaluate --split templates|test|all --task-id ID --author sonnet --fixer opus \\');
       console.log('           --run-class smoke|official --escalate-after 2 --concurrency 4 --limit N [--provider anthropic] [--no-sql-fallback] [--no-steer]');
       console.log('           (--provider pins the OpenRouter upstream; defaults to $OPENROUTER_PROVIDER)');

--- a/projects/agentic-malloy/src/cli.ts
+++ b/projects/agentic-malloy/src/cli.ts
@@ -20,6 +20,8 @@ import { runTask } from './agentic-loop.js';
 import { resolveModel } from './llm-client.js';
 import { hashLayerOnDisk, PROVENANCE_PATH, META_DIR } from './layer-build.js';
 import { loadGlossaryArtifact, renderGlossaryForAnswering } from './glossary.js';
+import { loadLayerIndex } from './miss-analysis.js';
+import { computeUsageReport, formatUsageReport } from './usage-report.js';
 import { buildDabstepLayer } from './dabstep-build.js';
 import { improveLayer } from './layer-improve.js';
 import { uploadControllog } from './upload.js';
@@ -715,6 +717,33 @@ async function cmdSummary(file: string) {
   console.log('answer_kind:', kindStr);
 }
 
+/**
+ * usage-report: substrate-value metrics over a completed run's results JSONL —
+ * answer-path economics, share-of-logic, central-vs-per-query, view utilization, and
+ * the answer-time context-token breakdown. Read-only + local (loads the on-disk layer
+ * + skill/primer/glossary; no MCP/network). `--json <path>` writes the report object.
+ */
+async function cmdUsageReport(flags: Record<string, string | boolean>, file: string) {
+  if (!file) throw new Error('usage: asm-malloy usage-report <results.jsonl> [--json out.json]');
+  const rows = (await readFile(file, 'utf8')).split('\n').filter((l) => l.trim()).map((l) => JSON.parse(l));
+  const store = new MalloyStore();
+  await store.load();
+  const layerIndex = await loadLayerIndex();
+  const skill = await readFile(SKILL_PATH, 'utf8');
+  const primer = await readFile(path.join(REPO_ROOT, 'docs', 'malloy', 'malloy-primer.md'), 'utf8');
+  const glossaryBlock = renderGlossaryForAnswering(await loadGlossaryArtifact(META_DIR));
+  const report = computeUsageReport(rows, {
+    centralLayerChars: store.centralLayerChars(),
+    layerIndex,
+    contextChars: { skill: skill.length, primer: primer.length, glossary: glossaryBlock.length },
+  });
+  console.log(formatUsageReport(report, file));
+  if (typeof flags.json === 'string') {
+    await writeFile(flags.json, JSON.stringify(report, null, 2));
+    console.log(`\nwrote ${flags.json}`);
+  }
+}
+
 function loadDotEnv(): void {
   try {
     process.loadEnvFile(path.join(REPO_ROOT, '.env'));
@@ -742,8 +771,10 @@ async function main() {
       return cmdUpload(flags);
     case 'summary':
       return cmdSummary(rest[0]);
+    case 'usage-report':
+      return cmdUsageReport(flags, rest[0]);
     default:
-      console.log('usage: asm-malloy <load|malloy-preflight|layer-build|layer-improve|evaluate|upload|summary> [flags]');
+      console.log('usage: asm-malloy <load|malloy-preflight|layer-build|layer-improve|evaluate|upload|summary|usage-report> [flags]');
       console.log('  load [--motherduck --database agentic_malloy]');
       console.log('  layer-build --model opus --reasoning medium [--no-manual] [--max-rounds 3] [--provider anthropic]');
       console.log('  layer-improve --from results/RUN.jsonl [--model opus --reasoning medium --max-rounds 4] \\');
@@ -758,6 +789,7 @@ async function main() {
       console.log('           (--provider pins the OpenRouter upstream; defaults to $OPENROUTER_PROVIDER)');
       console.log('           (--no-sql-fallback disables submit_sql for a Malloy-only arm; SQL fallback is on by default)');
       console.log('  upload [--database agentic_malloy_logs]   # controllog JSONL -> MotherDuck for the dive');
+      console.log('  usage-report <results.jsonl> [--json out.json]   # substrate-value metrics for a run (read-only, local)');
   }
 }
 

--- a/projects/agentic-malloy/src/cli.ts
+++ b/projects/agentic-malloy/src/cli.ts
@@ -193,6 +193,7 @@ export interface EvalTaskCtx {
   escalateAfter: number;
   maxAuthorTurns: number;
   maxFixerTurns: number;
+  steerInsteadOfEscalate: boolean;
   reasoning: string;
   provider?: string; // pinned OpenRouter upstream provider (or undefined)
   runClass: string;
@@ -260,6 +261,7 @@ export async function runEvalTask(q: Question, ctx: EvalTaskCtx): Promise<EvalTa
         toolSchemas: buildToolSchemas(deps), deps,
         authorModel: ctx.author, fixerModel: ctx.fixer,
         escalateAfter: ctx.escalateAfter, maxAuthorTurns: ctx.maxAuthorTurns, maxFixerTurns: ctx.maxFixerTurns,
+        steerInsteadOfEscalate: ctx.steerInsteadOfEscalate,
         reasoningEffort: ctx.reasoning, provider: ctx.provider, taskId: tid, runId: ctx.runId,
       });
     } catch (e) {
@@ -364,11 +366,12 @@ export async function runEvalTask(q: Question, ctx: EvalTaskCtx): Promise<EvalTa
 
   const row: Record<string, unknown> = {
     task_id: tid, level: q.level, split: ctx.split, author_model: ctx.author, fixer_model: ctx.fixer, run_class: ctx.runClass,
+    steer_instead_of_escalate: ctx.steerInsteadOfEscalate,
     question: q.question, guidelines: q.guidelines, gold_answer: q.answer,
     predicted_answer: scoreResp.predicted_answer, is_correct: scoreResp.is_correct, correctness: scoreResp.correctness,
     match_source: scoreResp.match_source, malloy_source: state.finalMalloy ?? null, compiled_sql: state.finalCompiledSql ?? null,
     translation_match: state.translationMatch ?? null, answer_kind: state.answerKind ?? null,
-    escalated: result?.escalated ?? false, fixer_turns: result?.fixerTurns ?? 0, tool_calls: result?.toolCallCount ?? 0,
+    escalated: result?.escalated ?? false, fixer_turns: result?.fixerTurns ?? 0, steers_used: result?.steersUsed ?? 0, tool_calls: result?.toolCallCount ?? 0,
     files_read: state.filesRead, lint_fixes: state.lintFixesTotal, elapsed_s: +(elapsedMs / 1000).toFixed(2),
     cost_usd: result?.usage.cost ?? 0, prompt_tokens: result?.usage.promptTokens ?? 0, completion_tokens: result?.usage.completionTokens ?? 0,
     cached_tokens: result?.usage.cachedTokens ?? 0, cache_write_tokens: result?.usage.cacheWriteTokens ?? 0, provider: ctx.provider ?? null,
@@ -391,7 +394,17 @@ export async function runEvalTask(q: Question, ctx: EvalTaskCtx): Promise<EvalTa
 async function cmdEvaluate(flags: Record<string, string | boolean>) {
   const split = (flags.split as string) || 'templates';
   const author = resolveModel((flags.author as string) || 'sonnet');
-  const fixer = resolveModel((flags.fixer as string) || 'opus');
+  // Steer-instead-of-escalate is the DEFAULT (opus-free): on repeated compile errors
+  // the AUTHOR is steered in place (see agentic-loop.ts) rather than failing over to a
+  // fixer model. The 27-task × 3-pass A/B showed it non-inferior to the opus failover
+  // (79/81 vs 77/81, within per-pass noise) at ~15% lower cost on that escalation-prone
+  // subset. Opt back into the opus failover with --no-steer (required for an official run).
+  const steerInsteadOfEscalate = !flags['no-steer'];
+  let fixer = resolveModel((flags.fixer as string) || (steerInsteadOfEscalate ? 'sonnet' : 'opus'));
+  if (steerInsteadOfEscalate) {
+    if (flags.fixer) console.warn(`⚠️  --fixer ${String(flags.fixer)} ignored: the in-place steer (default) is opus-free; pass --no-steer to use a fixer failover.`);
+    fixer = author; // no failover model in steer mode; any residual escalate() stays on the author
+  }
 
   // run_class is EXPLICIT (default smoke). It is NOT inferred from model flags —
   // that would mislabel runs (e.g. cheap gemini/gemini as "official"). Only an
@@ -409,7 +422,10 @@ async function cmdEvaluate(flags: Record<string, string | boolean>) {
     if (prov.malloy_provenance !== 'model_authored') reasons.push(`layer is ${prov.malloy_provenance} (${prov.reason}) — run a full \`layer-build\``);
     if (prov.manual_included !== true) reasons.push(`layer built without the manual (manual_included=${prov.manual_included})`);
     if (author !== resolveModel('sonnet')) reasons.push(`author must be sonnet (got ${author})`);
-    if (fixer !== resolveModel('opus')) reasons.push(`fixer must be opus (got ${fixer})`);
+    // The official baseline is the canonical sonnet-author / opus-FAILOVER tiering.
+    // The in-place steer is the everyday default, so an official run must opt out of it.
+    if (steerInsteadOfEscalate) reasons.push('the opus failover is required for an official run — pass --no-steer (the in-place steer is the default for smoke/experiment runs)');
+    else if (fixer !== resolveModel('opus')) reasons.push(`fixer must be opus (got ${fixer})`);
     // An official number must be REPRODUCIBLE from the recorded commit_sha. A dirty
     // tracked tree (e.g. layer-improve having modified src/skill.md, or any layer
     // edit) means the scored prompt/layer state isn't committed — refuse, don't
@@ -498,7 +514,7 @@ async function cmdEvaluate(flags: Record<string, string | boolean>) {
     console.warn('');
   }
 
-  console.log(`split=${split} · ${questions.length} q · author=${author} fixer=${fixer} · run_class=${runClass} · provenance=${prov.malloy_provenance} · db=${database} · conc=${concurrency} · sql_fallback=${allowSqlFallback ? 'on' : 'off'}${provider ? ` · provider=${provider}` : ''}`);
+  console.log(`split=${split} · ${questions.length} q · author=${author} fixer=${fixer} · run_class=${runClass} · provenance=${prov.malloy_provenance} · db=${database} · conc=${concurrency} · sql_fallback=${allowSqlFallback ? 'on' : 'off'}${steerInsteadOfEscalate ? ' · steer-instead-of-escalate (opus-free)' : ''}${provider ? ` · provider=${provider}` : ''}`);
 
   let correct = 0;
   let completed = 0;
@@ -515,7 +531,7 @@ async function cmdEvaluate(flags: Record<string, string | boolean>) {
 
   const ctx: EvalTaskCtx = {
     systemPrompt, runtime, localRuntime, store, symbols, kinds, viewNames, allowSqlFallback, scorer, database,
-    author, fixer, escalateAfter, maxAuthorTurns, maxFixerTurns, reasoning, provider,
+    author, fixer, escalateAfter, maxAuthorTurns, maxFixerTurns, steerInsteadOfEscalate, reasoning, provider,
     runClass, prov, runId, split,
   };
 
@@ -534,6 +550,7 @@ async function cmdEvaluate(flags: Record<string, string | boolean>) {
           max_author_turns: maxAuthorTurns,
           max_fixer_turns: maxFixerTurns,
           allow_sql_fallback: allowSqlFallback,
+          steer_instead_of_escalate: steerInsteadOfEscalate,
           reasoning,
           provider: provider ?? null,
           substrate: 'motherduck',

--- a/projects/agentic-malloy/src/cli.ts
+++ b/projects/agentic-malloy/src/cli.ts
@@ -785,9 +785,10 @@ async function main() {
       console.log('            tool-error rules are recommend-only unless --apply-skill-fixes;');
       console.log('            --re-eval measures edits as SMOKE — commit, then `evaluate --run-class official` to record a number)');
       console.log('  evaluate --split templates|test|all --task-id ID --author sonnet --fixer opus \\');
-      console.log('           --run-class smoke|official --escalate-after 2 --concurrency 4 --limit N [--provider anthropic] [--no-sql-fallback]');
+      console.log('           --run-class smoke|official --escalate-after 2 --concurrency 4 --limit N [--provider anthropic] [--no-sql-fallback] [--no-steer]');
       console.log('           (--provider pins the OpenRouter upstream; defaults to $OPENROUTER_PROVIDER)');
       console.log('           (--no-sql-fallback disables submit_sql for a Malloy-only arm; SQL fallback is on by default)');
+      console.log('           (in-place steer is the default/opus-free; --no-steer restores the opus failover and is REQUIRED for --run-class official)');
       console.log('  upload [--database agentic_malloy_logs]   # controllog JSONL -> MotherDuck for the dive');
       console.log('  usage-report <results.jsonl> [--json out.json]   # substrate-value metrics for a run (read-only, local)');
   }

--- a/projects/agentic-malloy/src/eval-task.test.ts
+++ b/projects/agentic-malloy/src/eval-task.test.ts
@@ -22,7 +22,7 @@ function fakeTaskResult(over: Partial<TaskResult> = {}): TaskResult {
     submitted: true, escalated: false, escalationReason: null, authorTurns: 1, fixerTurns: 0,
     toolCallCount: 1, usage: { promptTokens: 1, completionTokens: 1, cost: 0, cachedTokens: 0, cacheWriteTokens: 0 },
     authorModel: 'a', fixerModel: 'f', hitLimit: false, streamFailureReason: null,
-    authorRecoveryUsed: false, retryCount: 0, trace: [], ...over,
+    authorRecoveryUsed: false, steersUsed: 0, retryCount: 0, trace: [], ...over,
   };
 }
 
@@ -37,7 +37,7 @@ function baseCtx(over: Partial<EvalTaskCtx>): EvalTaskCtx {
     allowSqlFallback: true,
     scorer: { score: async () => okScore },
     database: 'db', author: 'a', fixer: 'f',
-    escalateAfter: 2, maxAuthorTurns: 20, maxFixerTurns: 6, reasoning: 'off',
+    escalateAfter: 2, maxAuthorTurns: 20, maxFixerTurns: 6, steerInsteadOfEscalate: false, reasoning: 'off',
     runClass: 'smoke',
     prov: { malloy_provenance: 'model_authored', malloy_model_hash: 'h', manual_included: true, authoring_model: 'a', reason: 'r' },
     runId: 'r1', split: 'test',

--- a/projects/agentic-malloy/src/mcp-client.ts
+++ b/projects/agentic-malloy/src/mcp-client.ts
@@ -60,13 +60,15 @@ async function withTransportRetry<T>(client: Client | null, label: string, fn: (
   throw lastErr instanceof Error ? lastErr : new Error(`MCP ${label} failed`);
 }
 
+// Read-only exploration tools exposed to the agent. Each tool's schema is in the
+// prompt every turn, so unused tools are pure prefix overhead: list_databases is
+// useless (the DB is pinned in the preamble) and ask_docs_question saw 0 calls
+// across the held-out runs — both dropped.
 export const ALLOWED_TOOLS = new Set([
   'query',
   'list_tables',
   'list_columns',
-  'list_databases',
   'search_catalog',
-  'ask_docs_question',
 ]);
 
 export interface MCPTool {

--- a/projects/agentic-malloy/src/tools.ts
+++ b/projects/agentic-malloy/src/tools.ts
@@ -1,7 +1,7 @@
 /**
  * Tool surface for the Malloy agent:
- *   - MCP exploration tools (query/list_tables/list_columns/search_catalog/
- *     ask_docs_question) — SQL exploration on MotherDuck, never the final answer.
+ *   - MCP exploration tools (query/list_tables/list_columns/search_catalog) —
+ *     SQL exploration on MotherDuck, never the final answer.
  *   - Malloy layer tools (list_malloy_files, get_file, malloy_lint, run_malloy).
  *   - submit_answer — the scored path: lint -> Malloy run on MotherDuck.
  *

--- a/projects/agentic-malloy/src/usage-report.test.ts
+++ b/projects/agentic-malloy/src/usage-report.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { computeUsageReport, type UsageRow } from './usage-report.js';
+import { buildLayerIndex } from './miss-analysis.js';
+
+// Tiny layer: source `s` with one view `v`, so referencedViews can resolve `s -> v`.
+const INDEX = buildLayerIndex({
+  't.malloy': 'source: s is duckdb.sql("""SELECT 1 as x""") extend {\n  view: v is { group_by: x }\n}',
+});
+
+const AUTH_SRC = 'x'.repeat(40); // authored-malloy per-query source
+const VIEW_SRC = 'run: s -> v + { limit: 1 }'; // references view v on source s
+const SQL_SRC = 'z'.repeat(51); // raw authored SQL (in compiled_sql for sql answers)
+
+function sampleRows(): UsageRow[] {
+  return [
+    { answer_kind: 'authored-malloy', malloy_source: AUTH_SRC, compiled_sql: 'y'.repeat(200), is_correct: true, tool_calls: 5, prompt_tokens: 100, completion_tokens: 10, cached_tokens: 80, cache_write_tokens: 20, cost_usd: 0.01 },
+    { answer_kind: 'view-selection', malloy_source: VIEW_SRC, compiled_sql: 'q'.repeat(60), is_correct: true, tool_calls: 6, prompt_tokens: 200, completion_tokens: 20, cached_tokens: 100, cache_write_tokens: 0, cost_usd: 0.02 },
+    { answer_kind: 'sql', malloy_source: null, compiled_sql: SQL_SRC, is_correct: false, tool_calls: 3, prompt_tokens: 50, completion_tokens: 5, cached_tokens: 50, cache_write_tokens: 0, cost_usd: 0.005 },
+    { answer_kind: null, malloy_source: null, compiled_sql: null, is_correct: false, tool_calls: 1, prompt_tokens: 30, completion_tokens: 0, cached_tokens: 0, cache_write_tokens: 0, cost_usd: 0.001 },
+  ];
+}
+
+describe('computeUsageReport', () => {
+  const r = computeUsageReport(sampleRows(), { centralLayerChars: 5000, layerIndex: INDEX, contextChars: { skill: 4000, primer: 2000, glossary: 2000 } });
+
+  it('counts tasks, accuracy, and per-kind split', () => {
+    expect(r.n).toBe(4);
+    expect(r.accuracy).toBe(50); // 2/4
+    const byKind = Object.fromEntries(r.byKind.map((k) => [k.kind, k]));
+    expect(byKind['authored-malloy'].n).toBe(1);
+    expect(byKind['view-selection'].n).toBe(1);
+    expect(byKind['sql'].n).toBe(1);
+    expect(byKind['none'].n).toBe(1);
+    expect(byKind['sql'].accuracy).toBe(0);
+    expect(byKind['authored-malloy'].accuracy).toBe(100);
+  });
+
+  it('computes share-of-logic from authored Malloy vs authored SQL chars', () => {
+    expect(r.shareOfLogic.malloyChars).toBe(AUTH_SRC.length + VIEW_SRC.length); // Malloy answers' malloy_source
+    expect(r.shareOfLogic.sqlChars).toBe(SQL_SRC.length); // sql answer's compiled_sql only
+    const expected = (AUTH_SRC.length + VIEW_SRC.length) / (AUTH_SRC.length + VIEW_SRC.length + SQL_SRC.length);
+    expect(r.shareOfLogic.ratio).toBeCloseTo(expected, 5);
+  });
+
+  it('null share-of-logic ratio when no authored logic', () => {
+    const none = computeUsageReport([{ answer_kind: null, malloy_source: null, compiled_sql: null }], { centralLayerChars: 1 });
+    expect(none.shareOfLogic.ratio).toBeNull();
+  });
+
+  it('central-vs-per-query: per-query Malloy size + Malloy→SQL expansion', () => {
+    expect(r.centralVsPerQuery.centralLayerChars).toBe(5000);
+    expect(r.centralVsPerQuery.perQueryMalloyMeanChars).toBe(Math.round((AUTH_SRC.length + VIEW_SRC.length) / 2));
+    // expansion = mean(200/40, 60/len(VIEW_SRC))
+    expect(r.centralVsPerQuery.malloyToSqlExpansion).toBeCloseTo((200 / AUTH_SRC.length + 60 / VIEW_SRC.length) / 2, 5);
+  });
+
+  it('view utilization resolves referenced views against the index', () => {
+    expect(r.viewUtilization).toBeDefined();
+    expect(r.viewUtilization!.totalViews).toBe(1);
+    expect(r.viewUtilization!.usedViews).toBe(1);
+    expect(r.viewUtilization!.utilizationPct).toBe(100);
+    expect(r.viewUtilization!.topViews[0]).toMatchObject({ view: 'v', count: 1 });
+  });
+
+  it('token + cost aggregates with cache hit rate', () => {
+    expect(r.tokens.totalPrompt).toBe(380);
+    expect(r.tokens.totalCached).toBe(230);
+    expect(r.tokens.cacheHitRate).toBeCloseTo((230 / 380) * 100, 5);
+    expect(r.tokens.totalCost).toBeCloseTo(0.036, 5);
+    expect(r.tokens.meanCostPerTask).toBeCloseTo(0.009, 5);
+  });
+
+  it('context breakdown present only when contextChars given; omitted otherwise', () => {
+    expect(r.context!.skillTok).toBe(1000); // 4000 chars / 4
+    expect(r.context!.totalTok).toBe(2000); // (4000+2000+2000)/4
+    const noCtx = computeUsageReport(sampleRows(), { centralLayerChars: 1 });
+    expect(noCtx.context).toBeUndefined();
+    expect(noCtx.viewUtilization).toBeUndefined();
+  });
+});

--- a/projects/agentic-malloy/src/usage-report.ts
+++ b/projects/agentic-malloy/src/usage-report.ts
@@ -1,0 +1,202 @@
+/**
+ * usage-report: substrate-value metrics over a completed eval run (the per-question
+ * results JSONL). Answers "is the Malloy layer earning its keep" — how much answer
+ * logic the agent authored as Malloy vs raw SQL, how thin the per-query Malloy is
+ * against the reusable central layer, which layer views actually get reused, and the
+ * answer-time context-token breakdown. Pure (no I/O) so it is unit-testable; the CLI
+ * (`cmdUsageReport`) does the file/store loading and calls these.
+ */
+import { referencedViews, type LayerIndex } from './miss-analysis.js';
+
+/** A results-JSONL row (loosely typed — only the fields the report reads). */
+export interface UsageRow {
+  answer_kind?: string | null;
+  malloy_source?: string | null;
+  compiled_sql?: string | null;
+  is_correct?: boolean;
+  tool_calls?: number;
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  cached_tokens?: number;
+  cache_write_tokens?: number;
+  cost_usd?: number;
+}
+
+export interface UsageReportCtx {
+  centralLayerChars: number;
+  /** Enables the view-utilization section (omit to skip it). */
+  layerIndex?: LayerIndex;
+  /** Answer-time prefix composition, in chars (skill + primer + glossary). */
+  contextChars?: { skill: number; primer: number; glossary: number };
+}
+
+export interface KindStat {
+  kind: string;
+  n: number;
+  pct: number;
+  accuracy: number; // 0–100
+  meanTools: number;
+  meanPromptTokens: number;
+  meanCost: number;
+}
+export interface UsageReport {
+  n: number;
+  accuracy: number; // 0–100
+  byKind: KindStat[];
+  shareOfLogic: { malloyChars: number; sqlChars: number; ratio: number | null }; // ratio 0–1, null if no authored logic
+  centralVsPerQuery: {
+    centralLayerChars: number;
+    perQueryMalloyMeanChars: number;
+    perQueryMalloyMedianChars: number;
+    malloyToSqlExpansion: number | null; // mean compiled_sql.len / malloy_source.len over Malloy answers
+  };
+  viewUtilization?: {
+    totalViews: number;
+    usedViews: number;
+    utilizationPct: number;
+    topViews: Array<{ view: string; source: string; count: number }>;
+  };
+  context?: { skillTok: number; primerTok: number; glossaryTok: number; centralLayerTok: number; totalTok: number };
+  tokens: {
+    totalPrompt: number;
+    totalCompletion: number;
+    totalCached: number;
+    totalCacheWrite: number;
+    cacheHitRate: number; // 0–100
+    totalCost: number;
+    meanCostPerTask: number;
+  };
+}
+
+const MALLOY_KINDS = new Set(['view-selection', 'authored-malloy']);
+const KIND_ORDER = ['view-selection', 'authored-malloy', 'sql', 'none'];
+const TOK = (chars: number) => Math.round(chars / 4); // ~4 chars/token (approx)
+
+const mean = (xs: number[]) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+const median = (xs: number[]) => {
+  if (!xs.length) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.floor(s.length / 2)];
+};
+const kindOf = (r: UsageRow) => r.answer_kind || 'none';
+
+export function computeUsageReport(rows: UsageRow[], ctx: UsageReportCtx): UsageReport {
+  const n = rows.length;
+  const num = (x: number | undefined) => x || 0;
+  const accuracy = n ? (rows.filter((r) => r.is_correct).length / n) * 100 : 0;
+
+  // Per-kind economics.
+  const groups = new Map<string, UsageRow[]>();
+  for (const r of rows) (groups.get(kindOf(r)) ?? groups.set(kindOf(r), []).get(kindOf(r))!).push(r);
+  const byKind: KindStat[] = [...groups.entries()]
+    .map(([kind, rs]) => ({
+      kind,
+      n: rs.length,
+      pct: n ? (rs.length / n) * 100 : 0,
+      accuracy: rs.length ? (rs.filter((r) => r.is_correct).length / rs.length) * 100 : 0,
+      meanTools: mean(rs.map((r) => num(r.tool_calls))),
+      meanPromptTokens: mean(rs.map((r) => num(r.prompt_tokens))),
+      meanCost: mean(rs.map((r) => num(r.cost_usd))),
+    }))
+    .sort((a, b) => (KIND_ORDER.indexOf(a.kind) - KIND_ORDER.indexOf(b.kind)) || b.n - a.n);
+
+  // Share-of-logic: authored Malloy chars vs authored SQL chars (compiled SQL of
+  // Malloy answers is machine-generated, NOT authored logic — excluded here).
+  const malloyRows = rows.filter((r) => MALLOY_KINDS.has(kindOf(r)) && r.malloy_source);
+  const sqlRows = rows.filter((r) => kindOf(r) === 'sql' && r.compiled_sql);
+  const malloyChars = malloyRows.reduce((a, r) => a + (r.malloy_source?.length ?? 0), 0);
+  const sqlChars = sqlRows.reduce((a, r) => a + (r.compiled_sql?.length ?? 0), 0);
+  const denom = malloyChars + sqlChars;
+
+  // Central layer vs per-query authored Malloy; Malloy→SQL expansion.
+  const perQ = malloyRows.map((r) => r.malloy_source!.length);
+  const expansions = malloyRows
+    .filter((r) => r.compiled_sql && r.malloy_source!.length > 0)
+    .map((r) => r.compiled_sql!.length / r.malloy_source!.length);
+
+  const report: UsageReport = {
+    n,
+    accuracy,
+    byKind,
+    shareOfLogic: { malloyChars, sqlChars, ratio: denom ? malloyChars / denom : null },
+    centralVsPerQuery: {
+      centralLayerChars: ctx.centralLayerChars,
+      perQueryMalloyMeanChars: Math.round(mean(perQ)),
+      perQueryMalloyMedianChars: median(perQ),
+      malloyToSqlExpansion: expansions.length ? mean(expansions) : null,
+    },
+    tokens: {
+      totalPrompt: rows.reduce((a, r) => a + num(r.prompt_tokens), 0),
+      totalCompletion: rows.reduce((a, r) => a + num(r.completion_tokens), 0),
+      totalCached: rows.reduce((a, r) => a + num(r.cached_tokens), 0),
+      totalCacheWrite: rows.reduce((a, r) => a + num(r.cache_write_tokens), 0),
+      cacheHitRate: 0,
+      totalCost: rows.reduce((a, r) => a + num(r.cost_usd), 0),
+      meanCostPerTask: 0,
+    },
+  };
+  report.tokens.cacheHitRate = report.tokens.totalPrompt ? (report.tokens.totalCached / report.tokens.totalPrompt) * 100 : 0;
+  report.tokens.meanCostPerTask = n ? report.tokens.totalCost / n : 0;
+
+  // View utilization (which layer views actually get reused).
+  if (ctx.layerIndex) {
+    const totalViews = [...ctx.layerIndex.viewsBySource.values()].reduce((a, s) => a + s.size, 0);
+    const counts = new Map<string, { view: string; source: string; count: number }>();
+    for (const r of malloyRows) {
+      for (const { source, view } of referencedViews(r.malloy_source!, ctx.layerIndex)) {
+        const key = `${source}.${view}`;
+        (counts.get(key) ?? counts.set(key, { view, source, count: 0 }).get(key)!).count++;
+      }
+    }
+    const topViews = [...counts.values()].sort((a, b) => b.count - a.count).slice(0, 10);
+    report.viewUtilization = {
+      totalViews,
+      usedViews: counts.size,
+      utilizationPct: totalViews ? (counts.size / totalViews) * 100 : 0,
+      topViews,
+    };
+  }
+
+  // Answer-time context-token breakdown (the static prefix the prompt re-sends).
+  if (ctx.contextChars) {
+    const c = ctx.contextChars;
+    const skillTok = TOK(c.skill), primerTok = TOK(c.primer), glossaryTok = TOK(c.glossary), centralLayerTok = TOK(ctx.centralLayerChars);
+    report.context = { skillTok, primerTok, glossaryTok, centralLayerTok, totalTok: skillTok + primerTok + glossaryTok };
+  }
+
+  return report;
+}
+
+export function formatUsageReport(r: UsageReport, label?: string): string {
+  const L: string[] = [];
+  const pct = (x: number) => `${x.toFixed(0)}%`;
+  if (label) L.push(label);
+  L.push(`tasks: ${r.n}   accuracy: ${r.accuracy.toFixed(1)}%`);
+  L.push('');
+  L.push('answer-path economics:');
+  L.push(`  ${'kind'.padEnd(16)}${'n'.padStart(5)}${'%'.padStart(6)}${'acc'.padStart(6)}${'meanTools'.padStart(11)}${'meanPromptTok'.padStart(15)}${'meanCost'.padStart(10)}`);
+  for (const k of r.byKind)
+    L.push(`  ${k.kind.padEnd(16)}${String(k.n).padStart(5)}${pct(k.pct).padStart(6)}${pct(k.accuracy).padStart(6)}${k.meanTools.toFixed(1).padStart(11)}${Math.round(k.meanPromptTokens).toLocaleString().padStart(15)}${('$' + k.meanCost.toFixed(4)).padStart(10)}`);
+  L.push('');
+  const sl = r.shareOfLogic;
+  L.push(`share-of-logic (authored Malloy / authored Malloy+SQL): ${sl.ratio == null ? 'n/a' : pct(sl.ratio * 100)}`);
+  L.push(`  authored Malloy: ${sl.malloyChars.toLocaleString()} chars   authored SQL: ${sl.sqlChars.toLocaleString()} chars`);
+  const cv = r.centralVsPerQuery;
+  L.push(`central layer: ${cv.centralLayerChars.toLocaleString()} chars   per-query Malloy: mean ${cv.perQueryMalloyMeanChars.toLocaleString()} / median ${cv.perQueryMalloyMedianChars.toLocaleString()} chars`
+    + (cv.malloyToSqlExpansion != null ? `   Malloy→SQL ×${cv.malloyToSqlExpansion.toFixed(1)}` : ''));
+  if (r.viewUtilization) {
+    const v = r.viewUtilization;
+    L.push('');
+    L.push(`view utilization: ${v.usedViews}/${v.totalViews} views used (${pct(v.utilizationPct)})`);
+    if (v.topViews.length) L.push('  top: ' + v.topViews.map((t) => `${t.view}×${t.count}`).join(', '));
+  }
+  if (r.context) {
+    const c = r.context;
+    L.push('');
+    L.push(`answer-time context (~tokens): skill ${c.skillTok.toLocaleString()} · primer ${c.primerTok.toLocaleString()} · glossary ${c.glossaryTok.toLocaleString()} = ${c.totalTok.toLocaleString()} prose prefix  (central layer ${c.centralLayerTok.toLocaleString()}, read on demand)`);
+  }
+  const t = r.tokens;
+  L.push('');
+  L.push(`tokens: prompt ${t.totalPrompt.toLocaleString()} (cache hit ${pct(t.cacheHitRate)}) · completion ${t.totalCompletion.toLocaleString()}   cost: $${t.totalCost.toFixed(2)} ($${t.meanCostPerTask.toFixed(4)}/task)`);
+  return L.join('\n');
+}


### PR DESCRIPTION
Consolidated Phase-2/3 optimization pass for review. Three shipped changes + the analysis docs. **Layer artifact is intentionally NOT touched** — `main` keeps the good layer `d7a2545e`; the net-negative rebuild is documented but parked (see below).

## Code changes

**1. `steer-instead-of-escalate` (default opus-free failover)** — `agentic-loop.ts`, `cli.ts`
On repeated Malloy compile errors the author is steered *in place* (`stuckAuthorSteer`: read exact fields / fix the SQL-habit form / switch view / fall back to `submit_sql`) instead of failing over to opus. A 3-arm × 3-pass A/B over the 27 escalation-prone tasks: steer **79/81** vs opus **77/81** (within per-pass noise) at ~15% lower cost, opus-free. `--no-steer` restores the opus failover; the official-run gate requires it. Records `steer_instead_of_escalate` + `steers_used`. See `docs/steer-vs-escalate-ab.md`.

**2. `usage-report` (substrate-value metrics)** — `usage-report.ts` (+ test), `cli.ts`
`asm-malloy usage-report <results.jsonl>` aggregates a run: answer-path economics, **share-of-logic**, central-vs-per-query Malloy size, **view utilization**, context-token breakdown. Pure functions, unit-tested; read-only + local. Validated end-to-end (reproduces hand-computed figures for 2334Z).

**3. Drop unused MCP tools** — `mcp-client.ts`, `tools.ts`
`list_databases` (DB pinned) + `ask_docs_question` (0 calls) removed from the prompt. ~1.5% prefix trim; honest small win.

## Docs / findings
- `docs/optimization-capstone.md` — the verdict + **every backlog idea dispositioned** + a §6 error-recipe→coverage map.
- `docs/steer-vs-escalate-ab.md` — the escalation A/B.
- `docs/layer-rebuild-outcome.md` — the layer rebuild **finding** (the rebuild itself is excluded; see below).

## What this PR deliberately EXCLUDES
The full `layer-build` rebuild (`a2a8a381`) fixed the c3 AVG defect (gate 18→1) but is **net-negative**: it dropped the counterfactual/steering surfaces and regressed train 24→22, and gained no score because the SQL bypass already masked the defect. Its **layer files are not in this PR** (0 layer files changed) — only the findings doc. The layer diff is parked on `agentic-malloy-layer-rebuild`.

## Headline finding (for context)
The substrate is barely used — share-of-logic is config-dependent (15–87%), only ~12–17 of 84 views are ever referenced, and fixing the layer's defect doesn't move the score because the agent routes around it via SQL. Efficiency is tapped without trading accuracy (every lever routes through fewer-turns or smaller-prefix; both cached-cheap or accuracy-costly).

## Verification
`npm run typecheck` clean · `npx vitest run` **222 passing**.

## Supersedes
Consolidates **#74** (steer) and **#75** (usage-report) — those can be closed in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)