### PR TITLE
data-chat-mini: surface reference-attested guides in the database view

### DIFF
--- a/projects/data-chat-mini/app/api/schema/route.ts
+++ b/projects/data-chat-mini/app/api/schema/route.ts
@@ -2,7 +2,8 @@
  * Schema browser endpoint. Lazy-loads catalog metadata for the schema
  * explorer sidebar — one request per database/table the user expands.
  *
- *  - `?database=foo` (optional `&schema=bar`) → list_tables
+ *  - `?database=foo` (optional `&schema=bar`) → list_tables, plus any
+ *    `relatedGuides` the server attests are about this database
  *  - `?database=foo&table=baz` (optional `&schema=bar`) → list_columns
  *
  * Read scaling: the per-session id arrives in the `x-session-id` header and is
@@ -10,7 +11,7 @@
  */
 import { createMCPClient, executeTool } from '@/lib/mcp-client';
 import { isAuthError, authExpiredResponse, getSessionHint } from '@/lib/api-helpers';
-import { parseTables, parseColumns } from '@/lib/mcp-parsers';
+import { parseTables, parseColumns, parseRelatedGuides } from '@/lib/mcp-parsers';
 import { NextRequest } from 'next/server';
 
 export async function GET(request: NextRequest) {
@@ -35,7 +36,7 @@ export async function GET(request: NextRequest) {
       const args: Record<string, unknown> = { database };
       if (schema) args.schema = schema;
       const raw = await executeTool(client, 'list_tables', args, true);
-      return Response.json({ tables: parseTables(raw) });
+      return Response.json({ tables: parseTables(raw), relatedGuides: parseRelatedGuides(raw) });
     } finally {
       try { await client.close(); } catch { /* ignore */ }
     }

--- a/projects/data-chat-mini/app/chat/SchemaExplorerSidebar.tsx
+++ b/projects/data-chat-mini/app/chat/SchemaExplorerSidebar.tsx
@@ -81,6 +81,10 @@ export function SchemaExplorerSidebar({
   const [popover, setPopover] = useState<{ kind: 'guide'; guide: GuideSummary } | { kind: 'create' } | null>(null);
   const [selectedTable, setSelectedTable] = useState<SelectedTable | null>(null);
   const [scope, setScope] = useState<'database' | 'all'>('database');
+  // Bumped by refreshGuides so sidebar-driven guide mutations (create/edit/
+  // delete in the popover) also re-pull relatedGuides — otherwise a deleted
+  // guide's related card would linger until a database switch.
+  const [schemaReloadKey, setSchemaReloadKey] = useState(0);
 
   useEffect(() => {
     if (demoReplay) return;
@@ -101,7 +105,7 @@ export function SchemaExplorerSidebar({
       }
     })();
     return () => { cancelled = true; };
-  }, [database, demoReplay, contextReloadKey]);
+  }, [database, demoReplay, contextReloadKey, schemaReloadKey]);
 
   const refreshGuides = useCallback(() => {
     if (demoReplay) return;
@@ -111,6 +115,7 @@ export function SchemaExplorerSidebar({
     // with counts); per-topic guides load lazily on expansion. A refresh
     // collapses open topics so nothing shows stale content.
     setOpenTopics({});
+    setSchemaReloadKey((k) => k + 1);
     fetch('/api/guides', { headers: { 'x-session-id': getSessionId() } })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -197,6 +202,16 @@ export function SchemaExplorerSidebar({
     }
     return merged;
   }, [scope, relatedGuides, visibleGuides]);
+
+  // Header total. Related guides carry real topics, so a guide can appear as
+  // a root card AND inside a visible topic's guide_count — subtract that
+  // overlap (exact topic match) so it isn't counted twice.
+  const guideCount = useMemo(() => {
+    const topicSet = new Set(visibleTopics.map((t) => t.topic));
+    const overlap = displayGuides.filter((g) => g.topic && topicSet.has(g.topic)).length;
+    const topicTotal = visibleTopics.reduce((n, t) => n + t.guide_count, 0);
+    return displayGuides.length + Math.max(0, topicTotal - overlap);
+  }, [displayGuides, visibleTopics]);
 
   const toggleTable = async (t: SchemaTable) => {
     const key = `${t.schema}.${t.name}`;
@@ -318,7 +333,7 @@ export function SchemaExplorerSidebar({
           <div className="flex items-center justify-between mb-2">
             <div className="sidebar-heading compact">
               <span>Guides</span>
-              <code>{displayGuides.length + visibleTopics.reduce((n, t) => n + t.guide_count, 0)}</code>
+              <code>{guideCount}</code>
             </div>
             <div className="flex items-center gap-1">
               <button
@@ -366,7 +381,8 @@ export function SchemaExplorerSidebar({
           {!demoReplay && !guidesError && guidesLoading && guides.length === 0 && (
             <div className="text-xs text-[var(--muted)]">Loading guides…</div>
           )}
-          {!demoReplay && !guidesError && !guidesLoading && guides.length === 0 && topics.length === 0 && (
+          {!demoReplay && !guidesError && !guidesLoading && guides.length === 0 && topics.length === 0
+            && displayGuides.length === 0 && (
             <div className="text-xs text-[var(--muted)]">
               No guides yet. Create one, or the assistant saves durable rules it learns as private guides.
             </div>

--- a/projects/data-chat-mini/app/chat/SchemaExplorerSidebar.tsx
+++ b/projects/data-chat-mini/app/chat/SchemaExplorerSidebar.tsx
@@ -1,30 +1,16 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { getSessionId } from '@/lib/session-id';
 import { DEMO_SCHEMA_COLUMNS, DEMO_SCHEMA_TABLES } from '@/lib/demo-mode';
 import type { SchemaTable, SchemaColumn } from '@/lib/mcp-parsers';
+import { mergeRelatedGuides, countSidebarGuides, type GuideSummary, type TopicSummary } from '@/lib/guide-view';
 
 /** A schema-qualified table selection — disambiguates same-named tables. */
 interface SelectedTable { schema: string; name: string }
-
-/** One guide as summarized by list_guides. */
-interface GuideSummary {
-  uuid: string;
-  topic: string;
-  title: string;
-  description: string;
-  access: string;
-}
-
-/** One topic (folder) row as summarized by list_guides. */
-interface TopicSummary {
-  topic: string;
-  guide_count: number;
-}
 
 /** A catalog reference row in the (advanced) references editor. */
 interface RefRow { database: string; schema: string; table: string; description: string }
@@ -83,8 +69,18 @@ export function SchemaExplorerSidebar({
   const [scope, setScope] = useState<'database' | 'all'>('database');
   // Bumped by refreshGuides so sidebar-driven guide mutations (create/edit/
   // delete in the popover) also re-pull relatedGuides — otherwise a deleted
-  // guide's related card would linger until a database switch.
+  // guide's related card would linger until a database switch. This is the
+  // schema effect's ONLY refresh token besides the database itself: mount and
+  // contextReloadKey changes both funnel through refreshGuides, so each cause
+  // produces exactly one schema fetch (no double-fetch).
   const [schemaReloadKey, setSchemaReloadKey] = useState(0);
+  // Skip the bump on refreshGuides' initial mount call — the schema effect's
+  // own first run already fetches.
+  const firstGuidesRefresh = useRef(true);
+  // Generation guard: refreshGuides responses arriving out of order must not
+  // let a stale response overwrite newer state (e.g. resurrect a just-deleted
+  // guide). Only the latest generation applies.
+  const guidesFetchGen = useRef(0);
 
   useEffect(() => {
     if (demoReplay) return;
@@ -101,11 +97,13 @@ export function SchemaExplorerSidebar({
           setRelatedGuides(Array.isArray(data.relatedGuides) ? data.relatedGuides : []);
         }
       } catch (err) {
+        // Deliberate last-good behavior: tables/relatedGuides keep their prior
+        // values on a failed re-fetch (consistent with the tables list).
         if (!cancelled) setTablesError(err instanceof Error ? err.message : 'Failed to load tables');
       }
     })();
     return () => { cancelled = true; };
-  }, [database, demoReplay, contextReloadKey, schemaReloadKey]);
+  }, [database, demoReplay, schemaReloadKey]);
 
   const refreshGuides = useCallback(() => {
     if (demoReplay) return;
@@ -115,18 +113,29 @@ export function SchemaExplorerSidebar({
     // with counts); per-topic guides load lazily on expansion. A refresh
     // collapses open topics so nothing shows stale content.
     setOpenTopics({});
-    setSchemaReloadKey((k) => k + 1);
+    if (firstGuidesRefresh.current) {
+      firstGuidesRefresh.current = false;
+    } else {
+      setSchemaReloadKey((k) => k + 1);
+    }
+    const gen = ++guidesFetchGen.current;
     fetch('/api/guides', { headers: { 'x-session-id': getSessionId() } })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
       })
       .then((data) => {
+        if (gen !== guidesFetchGen.current) return;
         setGuides(Array.isArray(data.guides) ? data.guides : []);
         setTopics(Array.isArray(data.topics) ? data.topics : []);
       })
-      .catch((err) => setGuidesError(err instanceof Error ? err.message : 'Failed to load guides'))
-      .finally(() => setGuidesLoading(false));
+      .catch((err) => {
+        if (gen !== guidesFetchGen.current) return;
+        setGuidesError(err instanceof Error ? err.message : 'Failed to load guides');
+      })
+      .finally(() => {
+        if (gen === guidesFetchGen.current) setGuidesLoading(false);
+      });
   }, [demoReplay]);
 
   const toggleTopic = useCallback((topic: string) => {
@@ -190,28 +199,16 @@ export function SchemaExplorerSidebar({
   // Guide cards to render in the root list. In 'all' scope this is just the
   // text-matched (full) list. In 'database' scope it's the union of the
   // server-attested relatedGuides (first) and the text match, deduped by uuid
-  // with relatedGuides winning.
-  const displayGuides = useMemo(() => {
-    if (scope === 'all') return visibleGuides;
-    const seen = new Set<string>();
-    const merged: GuideSummary[] = [];
-    for (const g of [...relatedGuides, ...visibleGuides]) {
-      if (seen.has(g.uuid)) continue;
-      seen.add(g.uuid);
-      merged.push(g);
-    }
-    return merged;
-  }, [scope, relatedGuides, visibleGuides]);
+  // with relatedGuides winning. Union + count logic lives in lib/guide-view.
+  const displayGuides = useMemo(
+    () => (scope === 'all' ? visibleGuides : mergeRelatedGuides(relatedGuides, visibleGuides)),
+    [scope, relatedGuides, visibleGuides],
+  );
 
-  // Header total. Related guides carry real topics, so a guide can appear as
-  // a root card AND inside a visible topic's guide_count — subtract that
-  // overlap (exact topic match) so it isn't counted twice.
-  const guideCount = useMemo(() => {
-    const topicSet = new Set(visibleTopics.map((t) => t.topic));
-    const overlap = displayGuides.filter((g) => g.topic && topicSet.has(g.topic)).length;
-    const topicTotal = visibleTopics.reduce((n, t) => n + t.guide_count, 0);
-    return displayGuides.length + Math.max(0, topicTotal - overlap);
-  }, [displayGuides, visibleTopics]);
+  const guideCount = useMemo(
+    () => countSidebarGuides(displayGuides, visibleTopics),
+    [displayGuides, visibleTopics],
+  );
 
   const toggleTable = async (t: SchemaTable) => {
     const key = `${t.schema}.${t.name}`;

--- a/projects/data-chat-mini/app/chat/SchemaExplorerSidebar.tsx
+++ b/projects/data-chat-mini/app/chat/SchemaExplorerSidebar.tsx
@@ -77,6 +77,12 @@ export function SchemaExplorerSidebar({
   // Skip the bump on refreshGuides' initial mount call — the schema effect's
   // own first run already fetches.
   const firstGuidesRefresh = useRef(true);
+  // Re-arm on entering replay: leaving replay re-runs the schema effect via
+  // its demoReplay dep, so the first post-replay refreshGuides must skip the
+  // bump too or replay-exit would double-fetch /api/schema.
+  useEffect(() => {
+    if (demoReplay) firstGuidesRefresh.current = true;
+  }, [demoReplay]);
   // Generation guard: refreshGuides responses arriving out of order must not
   // let a stale response overwrite newer state (e.g. resurrect a just-deleted
   // guide). Only the latest generation applies.

--- a/projects/data-chat-mini/app/chat/SchemaExplorerSidebar.tsx
+++ b/projects/data-chat-mini/app/chat/SchemaExplorerSidebar.tsx
@@ -65,6 +65,10 @@ export function SchemaExplorerSidebar({
 }) {
   const [tables, setTables] = useState<SchemaTable[] | null>(null);
   const [tablesError, setTablesError] = useState<string | null>(null);
+  // Guides the server attests are about this database via structured catalog
+  // references (reference-driven, includes private guides) — authoritative,
+  // unioned into the database-scope list ahead of the text match.
+  const [relatedGuides, setRelatedGuides] = useState<GuideSummary[]>([]);
   const [expanded, setExpanded] = useState<Record<string, SchemaColumn[] | 'loading'>>({});
   const [openColumns, setOpenColumns] = useState<Record<string, boolean>>({});
   const [guides, setGuides] = useState<GuideSummary[]>([]);
@@ -88,13 +92,16 @@ export function SchemaExplorerSidebar({
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
-        if (!cancelled) setTables(data.tables || []);
+        if (!cancelled) {
+          setTables(data.tables || []);
+          setRelatedGuides(Array.isArray(data.relatedGuides) ? data.relatedGuides : []);
+        }
       } catch (err) {
         if (!cancelled) setTablesError(err instanceof Error ? err.message : 'Failed to load tables');
       }
     })();
     return () => { cancelled = true; };
-  }, [database, demoReplay]);
+  }, [database, demoReplay, contextReloadKey]);
 
   const refreshGuides = useCallback(() => {
     if (demoReplay) return;
@@ -174,6 +181,22 @@ export function SchemaExplorerSidebar({
     const dbNorm = norm(database);
     return topics.filter((t) => norm(t.topic).includes(dbNorm));
   }, [topics, scope, database]);
+
+  // Guide cards to render in the root list. In 'all' scope this is just the
+  // text-matched (full) list. In 'database' scope it's the union of the
+  // server-attested relatedGuides (first) and the text match, deduped by uuid
+  // with relatedGuides winning.
+  const displayGuides = useMemo(() => {
+    if (scope === 'all') return visibleGuides;
+    const seen = new Set<string>();
+    const merged: GuideSummary[] = [];
+    for (const g of [...relatedGuides, ...visibleGuides]) {
+      if (seen.has(g.uuid)) continue;
+      seen.add(g.uuid);
+      merged.push(g);
+    }
+    return merged;
+  }, [scope, relatedGuides, visibleGuides]);
 
   const toggleTable = async (t: SchemaTable) => {
     const key = `${t.schema}.${t.name}`;
@@ -295,7 +318,7 @@ export function SchemaExplorerSidebar({
           <div className="flex items-center justify-between mb-2">
             <div className="sidebar-heading compact">
               <span>Guides</span>
-              <code>{visibleGuides.length + visibleTopics.reduce((n, t) => n + t.guide_count, 0)}</code>
+              <code>{displayGuides.length + visibleTopics.reduce((n, t) => n + t.guide_count, 0)}</code>
             </div>
             <div className="flex items-center gap-1">
               <button
@@ -349,9 +372,10 @@ export function SchemaExplorerSidebar({
             </div>
           )}
           {!demoReplay && !guidesError && (guides.length > 0 || topics.length > 0)
-            && visibleGuides.length === 0 && visibleTopics.length === 0 && (
+            && displayGuides.length === 0 && visibleTopics.length === 0 && (
             <div className="text-xs text-[var(--muted)]">
-              No guides mention <code>{database}</code>.{' '}
+              No guides reference <code>{database}</code> yet. Guides appear here when they attach a
+              catalog reference to this database or mention it in their topic, title, or description.{' '}
               <button onClick={() => setScope('all')} className="text-[var(--accent)] hover:underline">
                 Show all
               </button>
@@ -359,7 +383,7 @@ export function SchemaExplorerSidebar({
           )}
 
           <ul className="text-sm flex flex-col gap-2">
-            {visibleGuides.map((g) => (
+            {displayGuides.map((g) => (
               <li key={g.uuid}>
                 <GuideCard guide={g} onOpen={() => setPopover({ kind: 'guide', guide: g })} />
               </li>

--- a/projects/data-chat-mini/lib/guide-view.test.ts
+++ b/projects/data-chat-mini/lib/guide-view.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { mergeRelatedGuides, countSidebarGuides, type GuideSummary } from './guide-view';
+
+const g = (uuid: string, topic = ''): GuideSummary => ({
+  uuid,
+  topic,
+  title: `Guide ${uuid}`,
+  description: '',
+  access: 'user',
+});
+
+describe('mergeRelatedGuides', () => {
+  it('puts related guides first and appends unmatched text matches', () => {
+    const merged = mergeRelatedGuides([g('r1', 'foo')], [g('t1'), g('t2')]);
+    expect(merged.map((x) => x.uuid)).toEqual(['r1', 't1', 't2']);
+  });
+
+  it('dedupes by uuid with the related entry winning', () => {
+    const related = { ...g('dup', 'foo'), title: 'related version' };
+    const text = { ...g('dup'), title: 'text version' };
+    const merged = mergeRelatedGuides([related], [text, g('t1')]);
+    expect(merged).toHaveLength(2);
+    expect(merged[0].title).toBe('related version');
+  });
+
+  it('handles empty inputs', () => {
+    expect(mergeRelatedGuides([], [])).toEqual([]);
+    expect(mergeRelatedGuides([], [g('a')])).toHaveLength(1);
+    expect(mergeRelatedGuides([g('a')], [])).toHaveLength(1);
+  });
+});
+
+describe('countSidebarGuides', () => {
+  it('adds card count and topic counts when there is no overlap', () => {
+    expect(countSidebarGuides([g('a')], [{ topic: 'foo', guide_count: 2 }])).toBe(3);
+  });
+
+  it('subtracts a displayed guide whose topic is a visible topic row', () => {
+    expect(countSidebarGuides([g('a', 'foo')], [{ topic: 'foo', guide_count: 2 }])).toBe(2);
+  });
+
+  it('never subtracts for empty-topic (root) guides', () => {
+    expect(countSidebarGuides([g('a', '')], [{ topic: 'foo', guide_count: 1 }])).toBe(2);
+  });
+
+  it('clamps when the overlap heuristic exceeds a topic count (documented imprecision)', () => {
+    // Two displayed guides share one topic whose aggregate count is 1 — the
+    // subtraction over-shoots and the clamp floors the topic contribution at
+    // 0, so the total is the card count alone. Best-effort by design: topic
+    // rows expose only aggregate guide_count, not uuid membership.
+    expect(countSidebarGuides([g('a', 'foo'), g('b', 'foo')], [{ topic: 'foo', guide_count: 1 }])).toBe(2);
+  });
+});

--- a/projects/data-chat-mini/lib/guide-view.ts
+++ b/projects/data-chat-mini/lib/guide-view.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure view logic for the sidebar's Guides section — extracted from
+ * SchemaExplorerSidebar so the union/dedupe and count math are unit-testable.
+ */
+
+/** One guide as summarized by list_guides / list_tables.relatedGuides. */
+export interface GuideSummary {
+  uuid: string;
+  topic: string;
+  title: string;
+  description: string;
+  access: string;
+}
+
+/** One topic (folder) row as summarized by list_guides. */
+export interface TopicSummary {
+  topic: string;
+  guide_count: number;
+}
+
+/**
+ * Union for the database-scoped guide list: server-attested related guides
+ * first (they're authoritative — reference-driven), then the text-matched
+ * guides, deduplicated by uuid with the related entry winning.
+ */
+export function mergeRelatedGuides(
+  related: GuideSummary[],
+  textMatched: GuideSummary[],
+): GuideSummary[] {
+  const seen = new Set<string>();
+  const merged: GuideSummary[] = [];
+  for (const g of [...related, ...textMatched]) {
+    if (seen.has(g.uuid)) continue;
+    seen.add(g.uuid);
+    merged.push(g);
+  }
+  return merged;
+}
+
+/**
+ * Header total for the Guides section. Related guides carry real topics, so a
+ * guide can appear both as a root card and inside a visible topic's
+ * guide_count — subtract that overlap (exact topic match) so it isn't counted
+ * twice.
+ *
+ * Known-imprecise by design: topic rows only expose an aggregate guide_count,
+ * not uuid membership, so when several displayed guides share one topic the
+ * subtraction can exceed that topic's count and the clamp makes the total
+ * slightly low. Exact accounting would need per-topic uuid lists from the
+ * MCP; this is a cosmetic count, so best-effort is fine.
+ */
+export function countSidebarGuides(
+  display: GuideSummary[],
+  topics: TopicSummary[],
+): number {
+  const topicSet = new Set(topics.map((t) => t.topic));
+  const overlap = display.filter((g) => g.topic && topicSet.has(g.topic)).length;
+  const topicTotal = topics.reduce((n, t) => n + t.guide_count, 0);
+  return display.length + Math.max(0, topicTotal - overlap);
+}

--- a/projects/data-chat-mini/lib/mcp-parsers.test.ts
+++ b/projects/data-chat-mini/lib/mcp-parsers.test.ts
@@ -59,6 +59,22 @@ describe('parseRelatedGuides', () => {
       { uuid: 'abc-123', topic: '', title: '', description: '', access: '' },
     ]);
   });
+
+  it('preserves a root-level private guide (empty topic, access user)', () => {
+    const raw = JSON.stringify({
+      relatedGuides: [
+        { uuid: 'def-456', topic: '', title: 'My private notes', description: '', access: 'user' },
+      ],
+    });
+    expect(parseRelatedGuides(raw)).toEqual([
+      { uuid: 'def-456', topic: '', title: 'My private notes', description: '', access: 'user' },
+    ]);
+  });
+
+  it('returns [] when relatedGuides is present but not an array', () => {
+    expect(parseRelatedGuides(JSON.stringify({ relatedGuides: 'oops' }))).toEqual([]);
+    expect(parseRelatedGuides(JSON.stringify({ relatedGuides: { uuid: 'x' } }))).toEqual([]);
+  });
 });
 
 describe('parseTables (shared fixture)', () => {

--- a/projects/data-chat-mini/lib/mcp-parsers.test.ts
+++ b/projects/data-chat-mini/lib/mcp-parsers.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { parseTables, parseRelatedGuides } from './mcp-parsers';
+
+// Real `list_tables` MCP response shape (nba_box_scores_v2), trimmed. Note
+// `relatedGuides` sits alongside `tables` at the top level, not nested.
+const LIST_TABLES_FIXTURE = JSON.stringify({
+  success: true,
+  database: 'nba_box_scores_v2',
+  schema: 'all',
+  tableCount: 12,
+  viewCount: 4,
+  tables: [{ schema: 'main', name: 'box_scores', type: 'table', comment: '3,820,649 rows' }],
+  count: 1,
+  totalCount: 16,
+  truncated: true,
+  message: 'Showing 1 of 16 results.',
+  relatedGuides: [
+    {
+      uuid: '4089a7ab-7d24-4c23-ad38-9d6628b050fb',
+      topic: 'nba',
+      title: 'NBA box scores — querying nba_box_scores_v2',
+      access: 'organization',
+      description: 'Correctness rules (grain, joins, stat eras) and object reference for the nba_box_scores_v2 database',
+    },
+  ],
+});
+
+describe('parseRelatedGuides', () => {
+  it('parses the realistic list_tables fixture into one guide with all fields', () => {
+    const guides = parseRelatedGuides(LIST_TABLES_FIXTURE);
+    expect(guides).toEqual([
+      {
+        uuid: '4089a7ab-7d24-4c23-ad38-9d6628b050fb',
+        topic: 'nba',
+        title: 'NBA box scores — querying nba_box_scores_v2',
+        description: 'Correctness rules (grain, joins, stat eras) and object reference for the nba_box_scores_v2 database',
+        access: 'organization',
+      },
+    ]);
+  });
+
+  it('returns [] when relatedGuides is missing', () => {
+    const raw = JSON.stringify({ success: true, tables: [] });
+    expect(parseRelatedGuides(raw)).toEqual([]);
+  });
+
+  it('returns [] on non-JSON input', () => {
+    expect(parseRelatedGuides('not json at all')).toEqual([]);
+  });
+
+  it('drops rows without a uuid and coerces missing optional fields to empty strings', () => {
+    const raw = JSON.stringify({
+      relatedGuides: [
+        { topic: 'nba', title: 'no uuid, should be dropped' },
+        { uuid: 'abc-123' },
+      ],
+    });
+    expect(parseRelatedGuides(raw)).toEqual([
+      { uuid: 'abc-123', topic: '', title: '', description: '', access: '' },
+    ]);
+  });
+});
+
+describe('parseTables (shared fixture)', () => {
+  it('still parses the box_scores row out of the same list_tables payload', () => {
+    expect(parseTables(LIST_TABLES_FIXTURE)).toEqual([
+      { schema: 'main', name: 'box_scores', type: 'table', comment: '3,820,649 rows', fragmentCount: undefined },
+    ]);
+  });
+});

--- a/projects/data-chat-mini/lib/mcp-parsers.ts
+++ b/projects/data-chat-mini/lib/mcp-parsers.ts
@@ -192,6 +192,42 @@ export function parseDives(raw: string): DiveSummary[] {
   }
 }
 
+export interface RelatedGuide {
+  uuid: string;
+  topic: string;
+  title: string;
+  description: string;
+  access: string;
+}
+
+/**
+ * Parse the `relatedGuides` field on a `list_tables` MCP response — guides
+ * the server attests are about this database (via structured catalog
+ * references), including the caller's private (`access: "user"`) guides.
+ * Tolerates a missing/absent key. `topic` may legitimately be `''` (a
+ * root-level guide); rows without a string `uuid` are dropped since there's
+ * nothing to link to. Returns an empty list on unparseable input.
+ */
+export function parseRelatedGuides(raw: string): RelatedGuide[] {
+  try {
+    const parsed = JSON.parse(raw);
+    const list: unknown = Array.isArray(parsed?.relatedGuides) ? parsed.relatedGuides : null;
+    if (!list) return [];
+    return (list as Array<Record<string, unknown>>)
+      .filter((row): row is Record<string, unknown> => !!row && typeof row === 'object')
+      .map(row => ({
+        uuid: typeof row.uuid === 'string' ? row.uuid : '',
+        topic: typeof row.topic === 'string' ? row.topic : '',
+        title: typeof row.title === 'string' ? row.title : '',
+        description: typeof row.description === 'string' ? row.description : '',
+        access: typeof row.access === 'string' ? row.access : '',
+      }))
+      .filter(g => g.uuid);
+  } catch {
+    return [];
+  }
+}
+
 /**
  * The MCP `context` field is a freeform string like `"3 context fragments"`
  * or `"0 context fragments"`. Pull the leading integer out so we can use it

--- a/projects/data-chat-mini/reports/demo-validation/latest.json
+++ b/projects/data-chat-mini/reports/demo-validation/latest.json
@@ -1,9 +1,9 @@
 {
-  "runId": "2026-07-24T06-11-12-391Z-mock",
+  "runId": "2026-07-24T06-23-37-533Z-mock",
   "mode": "mock",
   "dataset": "nba_box_scores_v2",
-  "startedAt": "2026-07-24T06:11:12.391Z",
-  "completedAt": "2026-07-24T06:11:12.545Z",
+  "startedAt": "2026-07-24T06:23:37.533Z",
+  "completedAt": "2026-07-24T06:23:37.696Z",
   "assertions": [
     {
       "name": "database selection lists canonical dataset",
@@ -135,7 +135,7 @@
       "name": "context query/update/delete lifecycle succeeds",
       "pass": true,
       "severity": "P2",
-      "detail": "context services: query_context_layer:1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92bf-d18b-726a-99d2-e4b39baac1ba\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment \"box_scores to schedule join key\". | update_context_layer:Deleted fragment 019f92bf-d18b-726a-99d2-e4b39baac1ba."
+      "detail": "context services: query_context_layer:1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92cb-3042-7605-9867-f216dc7a7fa1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment \"box_scores to schedule join key\". | update_context_layer:Deleted fragment 019f92cb-3042-7605-9867-f216dc7a7fa1."
     },
     {
       "name": "presenter reset clears local conversations and context",
@@ -816,7 +816,7 @@
     },
     {
       "type": "mviz_pending",
-      "id": "3971d69d-670a-4270-a91c-56f78f92ce79"
+      "id": "777d848c-a891-41de-aa9f-77bb72ca758d"
     },
     {
       "type": "text",
@@ -826,7 +826,7 @@
       "type": "mviz_html",
       "content": "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Dashboard</title>\n  <style>*{box-sizing:border-box;margin:0;padding:0}:root{--bg:#FFFFFF;--fg:#1C1E26;--text:#1C1E26;--text-muted:#6B7280;--grid:#ECEDEF;--red:#2563EB;--link:#0777b3;--font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;--font-mono:'JetBrains Mono','Roboto Mono',ui-monospace,monospace}body.theme-dark{--bg:#231f20;--fg:#ffffff;--text:#ffffff;--text-muted:#888888;--grid:#3a3a3a;--red:#bc1200;--link:#0777b3}html,body{width:100%;min-height:100%;font-family:var(--font-family);color:var(--text);font-size:12px;transition:background-color 0.3s,color 0.3s}.dashboard{max-width:720px;margin:0 auto;padding:16px;position:relative;overflow-x:hidden}body.theme-dark .theme-toggle .icon-moon{display:none}body.theme-dark .theme-toggle .icon-sun{display:block}.dashboard-section{margin-bottom:16px}.chart-title{font-family:var(--font-family);font-weight:700;font-size:10px;font-weight:bold;color:var(--text);margin-bottom:4px}.row{display:grid;grid-template-columns:repeat(16,1fr);gap:8px;margin-bottom:8px}@media (max-width:720px){.row{grid-template-columns:repeat(8,1fr)}.row>*{grid-column:span min(var(--col-span,8),8)}}@media (max-width:480px){.row{grid-template-columns:1fr}.row>*{grid-column:span 1}.grid-item{overflow-x:auto;-webkit-overflow-scrolling:touch}}.grid-item{padding:4px;transition:background-color 0.3s}.data-table{width:100%;border-collapse:collapse;font-size:11px}.data-table th{font-family:var(--font-family);font-size:9px;font-weight:bold;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.03em;padding:6px 8px;border-bottom:1px solid var(--text);text-align:left}.data-table td{padding:5px 8px;color:var(--text);border-bottom:1px solid var(--grid)}.data-table.table-compact th,.data-table.table-compact td{padding:4px 6px}.dashboard.dashboard-embed{max-width:100%;padding:8px}@media (max-width:720px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}}@media (max-width:480px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}.dashboard.dashboard-embed .grid-item{overflow-x:visible}}th.sortable{cursor:pointer}th.sortable[data-sort-dir]{color:inherit}.mviz-sort-ind{display:inline-block;min-width:0.9em;margin-left:2px;font-size:9px;opacity:0.7;text-align:left;white-space:nowrap}</style>\n\n<style>\n  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');\n  /* Kill the browser default body margin so the frame hugs its host card. */\n  html, body {\n    margin: 0 !important;\n  }\n  .dashboard {\n    max-width: 100% !important;\n    padding: 20px !important;\n  }\n  .dashboard-section:last-child {\n    margin-bottom: 0 !important;\n    padding-bottom: 0 !important;\n  }\n  .row:last-child {\n    margin-bottom: 0 !important;\n  }\n  html, body { font-size: 14px !important; }\n  .section-title { font-size: 16px !important; font-weight: 600 !important; }\n  .chart-title { font-size: 16px !important; }\n  .big-value { font-size: 30px !important; font-weight: 700 !important; }\n  .label { font-size: 13px !important; }\n  .delta { font-size: 24px !important; }\n  .delta .value { font-size: 24px !important; }\n  .delta .arrow { font-size: 24px !important; }\n  .delta .label { font-size: 13px !important; }\n  .row { gap: 12px !important; margin-bottom: 12px !important; }\n  .alert .message { font-size: 13px !important; }\n  .data-table {\n    border-radius: 10px !important;\n    overflow: hidden !important;\n  }\n  .data-table th {\n    border-bottom-color: var(--grid) !important;\n    font-size: 12px !important;\n    font-weight: 600 !important;\n    padding: 8px 12px !important;\n  }\n  .data-table td {\n    font-size: 12px !important;\n    padding: 8px 12px !important;\n  }\n  .note-content, .text-content { font-size: 13px !important; line-height: 1.5 !important; }\n  .markdown-content { font-size: 14px !important; line-height: 1.6 !important; }\n  .markdown-content h1 { font-size: 28px !important; }\n  .markdown-content h2 { font-size: 22px !important; }\n  .markdown-content h3 { font-size: 18px !important; }\n  .markdown-content p, .markdown-content li { font-size: 14px !important; }\n  .markdown-content code { font-size: 13px !important; }\n  .card, .chart-card, .note, .alert, .text-card {\n    border-radius: 10px !important;\n    box-shadow: none !important;\n  }\n</style>\n</head><body class=\"theme-light\"><div class=\"dashboard dashboard-embed\"><section class=\"dashboard-section\"><div class=\"row\"><div class=\"grid-item\" style=\"--col-span: 16; grid-column: span 16;\"><h3 class=\"chart-title\">Recent NBA Seasons</h3><table id=\"mviz-dash-table-1\" class=\"data-table table-compact\" style=\"width: 100%; border-collapse: collapse; font-size: 10px;\"><thead><tr><th class=\"sortable\" data-col=\"0\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;\">Season<span class=\"mviz-sort-ind\"></span></th><th class=\"sortable\" data-col=\"1\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;\">Games<span class=\"mviz-sort-ind\"></span></th></tr></thead><tbody><tr><td data-sort=\"2024\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>2,024</strong></td><td data-sort=\"1319\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">1,319</td></tr><tr><td data-sort=\"2023\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>2,023</strong></td><td data-sort=\"1318\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">1,318</td></tr><tr><td data-sort=\"2022\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>2,022</strong></td><td data-sort=\"1317\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">1,317</td></tr></tbody></table></div></div></section></div>\n  <script>(function(){if(window.mvizTableInit) return;function compareCells(a,b){var an=parseFloat(a),bn=parseFloat(b);if(!isNaN(an)&&!isNaN(bn)) return an-bn;return String(a).localeCompare(String(b));}function getSortKey(cell){var v=cell.getAttribute('data-sort');return v!=null?v:cell.textContent.trim();}window.mvizTableInit=function(tableId){var table=document.getElementById(tableId);if(!table) return;var thead=table.tHead;var tbody=table.tBodies[0];if(!thead||!tbody) return;var origRows=Array.prototype.slice.call(tbody.rows);var visibility={};origRows.forEach(function(r,i){visibility[i]=true;});function applyVisibility(){origRows.forEach(function(r,i){r.style.display=visibility[i]?'':'none';});}var sortableHeaders=thead.querySelectorAll('th.sortable');var activeTh=null;var activeState=0;sortableHeaders.forEach(function(th){th.style.cursor='pointer';th.style.userSelect='none';th.addEventListener('click',function(){var colIdx=parseInt(th.getAttribute('data-col'),10);if(isNaN(colIdx)) return;if(activeTh===th){activeState=activeState===1?-1:activeState===-1?0:1;}else{if(activeTh){activeTh.removeAttribute('data-sort-dir');var prevInd=activeTh.querySelector('.mviz-sort-ind');if(prevInd) prevInd.textContent='';}activeTh=th;activeState=1;}var ind=th.querySelector('.mviz-sort-ind');if(activeState===0){th.removeAttribute('data-sort-dir');if(ind) ind.textContent='';activeTh=null;origRows.forEach(function(r){tbody.appendChild(r);});applyVisibility();return;}th.setAttribute('data-sort-dir',activeState===1?'asc':'desc');if(ind) ind.textContent=activeState===1?'▲':'▼';var sorted=origRows.slice().sort(function(a,b){var av=getSortKey(a.cells[colIdx]);var bv=getSortKey(b.cells[colIdx]);var cmp=compareCells(av,bv);return activeState===1?cmp:-cmp;});sorted.forEach(function(r){tbody.appendChild(r);});applyVisibility();});});var container=table.parentElement;var globalInput=container&&container.querySelector('.mviz-filter-global[data-table=\"'+tableId+'\"]');if(globalInput){globalInput.addEventListener('input',function(){var q=globalInput.value.toLowerCase();origRows.forEach(function(r,i){visibility[i]=!q||r.textContent.toLowerCase().indexOf(q)!==-1;});applyVisibility();});}};})();if(window.mvizTableInit) window.mvizTableInit(\"mviz-dash-table-1\");</script>\n\n<script>\n(function() {\n  function reportHeight() {\n    var h = document.body ? document.body.scrollHeight : 0;\n    if (h > 0) parent.postMessage({ type: 'mviz-height', height: h }, '*');\n  }\n  if (document.readyState === 'complete') reportHeight();\n  else window.addEventListener('load', reportHeight);\n  new MutationObserver(reportHeight).observe(document.documentElement, { childList: true, subtree: true });\n  setTimeout(reportHeight, 300);\n  setTimeout(reportHeight, 1000);\n})();\n</script>\n</body></html>",
       "source": "```table size=[16,5]\n{\"title\":\"Recent NBA Seasons\",\"columns\":[{\"id\":\"season_year\",\"title\":\"Season\",\"bold\":true},{\"id\":\"games\",\"title\":\"Games\",\"fmt\":\"auto\",\"align\":\"right\"}],\"data\":[{\"season_year\":2024,\"games\":1319},{\"season_year\":2023,\"games\":1318},{\"season_year\":2022,\"games\":1317}],\"compact\":true}\n```",
-      "id": "3971d69d-670a-4270-a91c-56f78f92ce79"
+      "id": "777d848c-a891-41de-aa9f-77bb72ca758d"
     },
     {
       "type": "text",
@@ -1059,7 +1059,7 @@
     },
     {
       "type": "mviz_pending",
-      "id": "6dd46e57-b56a-4722-9630-eca95addb7dd"
+      "id": "ce66c7fe-7ec5-4cc8-b3dc-7e5055e07251"
     },
     {
       "type": "text",
@@ -1069,7 +1069,7 @@
       "type": "mviz_html",
       "content": "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Dashboard</title>\n  <style>*{box-sizing:border-box;margin:0;padding:0}:root{--bg:#FFFFFF;--fg:#1C1E26;--text:#1C1E26;--text-muted:#6B7280;--grid:#ECEDEF;--red:#2563EB;--link:#0777b3;--font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;--font-mono:'JetBrains Mono','Roboto Mono',ui-monospace,monospace}body.theme-dark{--bg:#231f20;--fg:#ffffff;--text:#ffffff;--text-muted:#888888;--grid:#3a3a3a;--red:#bc1200;--link:#0777b3}html,body{width:100%;min-height:100%;font-family:var(--font-family);color:var(--text);font-size:12px;transition:background-color 0.3s,color 0.3s}.dashboard{max-width:720px;margin:0 auto;padding:16px;position:relative;overflow-x:hidden}body.theme-dark .theme-toggle .icon-moon{display:none}body.theme-dark .theme-toggle .icon-sun{display:block}.dashboard-section{margin-bottom:16px}.chart-title{font-family:var(--font-family);font-weight:700;font-size:10px;font-weight:bold;color:var(--text);margin-bottom:4px}.row{display:grid;grid-template-columns:repeat(16,1fr);gap:8px;margin-bottom:8px}@media (max-width:720px){.row{grid-template-columns:repeat(8,1fr)}.row>*{grid-column:span min(var(--col-span,8),8)}}@media (max-width:480px){.row{grid-template-columns:1fr}.row>*{grid-column:span 1}.grid-item{overflow-x:auto;-webkit-overflow-scrolling:touch}}.grid-item{padding:4px;transition:background-color 0.3s}.data-table{width:100%;border-collapse:collapse;font-size:11px}.data-table th{font-family:var(--font-family);font-size:9px;font-weight:bold;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.03em;padding:6px 8px;border-bottom:1px solid var(--text);text-align:left}.data-table td{padding:5px 8px;color:var(--text);border-bottom:1px solid var(--grid)}.data-table.table-compact th,.data-table.table-compact td{padding:4px 6px}.dashboard.dashboard-embed{max-width:100%;padding:8px}@media (max-width:720px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}}@media (max-width:480px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}.dashboard.dashboard-embed .grid-item{overflow-x:visible}}th.sortable{cursor:pointer}th.sortable[data-sort-dir]{color:inherit}.mviz-sort-ind{display:inline-block;min-width:0.9em;margin-left:2px;font-size:9px;opacity:0.7;text-align:left;white-space:nowrap}</style>\n\n<style>\n  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');\n  /* Kill the browser default body margin so the frame hugs its host card. */\n  html, body {\n    margin: 0 !important;\n  }\n  .dashboard {\n    max-width: 100% !important;\n    padding: 20px !important;\n  }\n  .dashboard-section:last-child {\n    margin-bottom: 0 !important;\n    padding-bottom: 0 !important;\n  }\n  .row:last-child {\n    margin-bottom: 0 !important;\n  }\n  html, body { font-size: 14px !important; }\n  .section-title { font-size: 16px !important; font-weight: 600 !important; }\n  .chart-title { font-size: 16px !important; }\n  .big-value { font-size: 30px !important; font-weight: 700 !important; }\n  .label { font-size: 13px !important; }\n  .delta { font-size: 24px !important; }\n  .delta .value { font-size: 24px !important; }\n  .delta .arrow { font-size: 24px !important; }\n  .delta .label { font-size: 13px !important; }\n  .row { gap: 12px !important; margin-bottom: 12px !important; }\n  .alert .message { font-size: 13px !important; }\n  .data-table {\n    border-radius: 10px !important;\n    overflow: hidden !important;\n  }\n  .data-table th {\n    border-bottom-color: var(--grid) !important;\n    font-size: 12px !important;\n    font-weight: 600 !important;\n    padding: 8px 12px !important;\n  }\n  .data-table td {\n    font-size: 12px !important;\n    padding: 8px 12px !important;\n  }\n  .note-content, .text-content { font-size: 13px !important; line-height: 1.5 !important; }\n  .markdown-content { font-size: 14px !important; line-height: 1.6 !important; }\n  .markdown-content h1 { font-size: 28px !important; }\n  .markdown-content h2 { font-size: 22px !important; }\n  .markdown-content h3 { font-size: 18px !important; }\n  .markdown-content p, .markdown-content li { font-size: 14px !important; }\n  .markdown-content code { font-size: 13px !important; }\n  .card, .chart-card, .note, .alert, .text-card {\n    border-radius: 10px !important;\n    box-shadow: none !important;\n  }\n</style>\n</head><body class=\"theme-light\"><div class=\"dashboard dashboard-embed\"><section class=\"dashboard-section\"><div class=\"row\"><div class=\"grid-item\" style=\"--col-span: 16; grid-column: span 16;\"><h3 class=\"chart-title\">2024 Regular Season Team Scoring Leaders</h3><table id=\"mviz-dash-table-2\" class=\"data-table table-compact\" style=\"width: 100%; border-collapse: collapse; font-size: 10px;\"><thead><tr><th class=\"sortable\" data-col=\"0\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;\">Team<span class=\"mviz-sort-ind\"></span></th><th class=\"sortable\" data-col=\"1\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;\">Points<span class=\"mviz-sort-ind\"></span></th></tr></thead><tbody><tr><td data-sort=\"BOS\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>BOS</strong></td><td data-sort=\"10422\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">10.42k</td></tr><tr><td data-sort=\"DEN\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>DEN</strong></td><td data-sort=\"10051\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">10.05k</td></tr><tr><td data-sort=\"OKC\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>OKC</strong></td><td data-sort=\"9964\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">9,964</td></tr><tr><td data-sort=\"MIN\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>MIN</strong></td><td data-sort=\"9818\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">9,818</td></tr><tr><td data-sort=\"NYK\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>NYK</strong></td><td data-sort=\"9721\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">9,721</td></tr></tbody></table></div></div></section></div>\n  <script>(function(){if(window.mvizTableInit) return;function compareCells(a,b){var an=parseFloat(a),bn=parseFloat(b);if(!isNaN(an)&&!isNaN(bn)) return an-bn;return String(a).localeCompare(String(b));}function getSortKey(cell){var v=cell.getAttribute('data-sort');return v!=null?v:cell.textContent.trim();}window.mvizTableInit=function(tableId){var table=document.getElementById(tableId);if(!table) return;var thead=table.tHead;var tbody=table.tBodies[0];if(!thead||!tbody) return;var origRows=Array.prototype.slice.call(tbody.rows);var visibility={};origRows.forEach(function(r,i){visibility[i]=true;});function applyVisibility(){origRows.forEach(function(r,i){r.style.display=visibility[i]?'':'none';});}var sortableHeaders=thead.querySelectorAll('th.sortable');var activeTh=null;var activeState=0;sortableHeaders.forEach(function(th){th.style.cursor='pointer';th.style.userSelect='none';th.addEventListener('click',function(){var colIdx=parseInt(th.getAttribute('data-col'),10);if(isNaN(colIdx)) return;if(activeTh===th){activeState=activeState===1?-1:activeState===-1?0:1;}else{if(activeTh){activeTh.removeAttribute('data-sort-dir');var prevInd=activeTh.querySelector('.mviz-sort-ind');if(prevInd) prevInd.textContent='';}activeTh=th;activeState=1;}var ind=th.querySelector('.mviz-sort-ind');if(activeState===0){th.removeAttribute('data-sort-dir');if(ind) ind.textContent='';activeTh=null;origRows.forEach(function(r){tbody.appendChild(r);});applyVisibility();return;}th.setAttribute('data-sort-dir',activeState===1?'asc':'desc');if(ind) ind.textContent=activeState===1?'▲':'▼';var sorted=origRows.slice().sort(function(a,b){var av=getSortKey(a.cells[colIdx]);var bv=getSortKey(b.cells[colIdx]);var cmp=compareCells(av,bv);return activeState===1?cmp:-cmp;});sorted.forEach(function(r){tbody.appendChild(r);});applyVisibility();});});var container=table.parentElement;var globalInput=container&&container.querySelector('.mviz-filter-global[data-table=\"'+tableId+'\"]');if(globalInput){globalInput.addEventListener('input',function(){var q=globalInput.value.toLowerCase();origRows.forEach(function(r,i){visibility[i]=!q||r.textContent.toLowerCase().indexOf(q)!==-1;});applyVisibility();});}};})();if(window.mvizTableInit) window.mvizTableInit(\"mviz-dash-table-2\");</script>\n\n<script>\n(function() {\n  function reportHeight() {\n    var h = document.body ? document.body.scrollHeight : 0;\n    if (h > 0) parent.postMessage({ type: 'mviz-height', height: h }, '*');\n  }\n  if (document.readyState === 'complete') reportHeight();\n  else window.addEventListener('load', reportHeight);\n  new MutationObserver(reportHeight).observe(document.documentElement, { childList: true, subtree: true });\n  setTimeout(reportHeight, 300);\n  setTimeout(reportHeight, 1000);\n})();\n</script>\n</body></html>",
       "source": "```table size=[16,5]\n{\"title\":\"2024 Regular Season Team Scoring Leaders\",\"columns\":[{\"id\":\"team\",\"title\":\"Team\",\"bold\":true},{\"id\":\"points\",\"title\":\"Points\",\"fmt\":\"auto\",\"align\":\"right\"}],\"data\":[{\"team\":\"BOS\",\"points\":10422},{\"team\":\"DEN\",\"points\":10051},{\"team\":\"OKC\",\"points\":9964},{\"team\":\"MIN\",\"points\":9818},{\"team\":\"NYK\",\"points\":9721}],\"compact\":true}\n```",
-      "id": "6dd46e57-b56a-4722-9630-eca95addb7dd"
+      "id": "ce66c7fe-7ec5-4cc8-b3dc-7e5055e07251"
     },
     {
       "type": "text",
@@ -1192,7 +1192,7 @@
     },
     {
       "type": "mviz_pending",
-      "id": "0d678c36-a5d0-4043-bd31-61a4be89cb68"
+      "id": "d3791f7d-166f-4004-a85b-9fa7e58477d6"
     },
     {
       "type": "text",
@@ -1202,7 +1202,7 @@
       "type": "mviz_html",
       "content": "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Dashboard</title>\n  <script src=\"https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js\"></script>\n  <style>*{box-sizing:border-box;margin:0;padding:0}:root{--bg:#FFFFFF;--fg:#1C1E26;--text:#1C1E26;--text-muted:#6B7280;--grid:#ECEDEF;--red:#2563EB;--link:#0777b3;--font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;--font-mono:'JetBrains Mono','Roboto Mono',ui-monospace,monospace}body.theme-dark{--bg:#231f20;--fg:#ffffff;--text:#ffffff;--text-muted:#888888;--grid:#3a3a3a;--red:#bc1200;--link:#0777b3}html,body{width:100%;min-height:100%;font-family:var(--font-family);color:var(--text);font-size:12px;transition:background-color 0.3s,color 0.3s}.dashboard{max-width:720px;margin:0 auto;padding:16px;position:relative;overflow-x:hidden}body.theme-dark .theme-toggle .icon-moon{display:none}body.theme-dark .theme-toggle .icon-sun{display:block}.dashboard-section{margin-bottom:16px}.chart-title{font-family:var(--font-family);font-weight:700;font-size:10px;font-weight:bold;color:var(--text);margin-bottom:4px}.row{display:grid;grid-template-columns:repeat(16,1fr);gap:8px;margin-bottom:8px}@media (max-width:720px){.row{grid-template-columns:repeat(8,1fr)}.row>*{grid-column:span min(var(--col-span,8),8)}}@media (max-width:480px){.row{grid-template-columns:1fr}.row>*{grid-column:span 1}.grid-item{overflow-x:auto;-webkit-overflow-scrolling:touch}}.grid-item{padding:4px;transition:background-color 0.3s}.dashboard.dashboard-embed{max-width:100%;padding:8px}@media (max-width:720px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}}@media (max-width:480px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}.dashboard.dashboard-embed .grid-item{overflow-x:visible}}</style>\n\n<style>\n  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');\n  /* Kill the browser default body margin so the frame hugs its host card. */\n  html, body {\n    margin: 0 !important;\n  }\n  .dashboard {\n    max-width: 100% !important;\n    padding: 20px !important;\n  }\n  .dashboard-section:last-child {\n    margin-bottom: 0 !important;\n    padding-bottom: 0 !important;\n  }\n  .row:last-child {\n    margin-bottom: 0 !important;\n  }\n  html, body { font-size: 14px !important; }\n  .section-title { font-size: 16px !important; font-weight: 600 !important; }\n  .chart-title { font-size: 16px !important; }\n  .big-value { font-size: 30px !important; font-weight: 700 !important; }\n  .label { font-size: 13px !important; }\n  .delta { font-size: 24px !important; }\n  .delta .value { font-size: 24px !important; }\n  .delta .arrow { font-size: 24px !important; }\n  .delta .label { font-size: 13px !important; }\n  .row { gap: 12px !important; margin-bottom: 12px !important; }\n  .alert .message { font-size: 13px !important; }\n  .data-table {\n    border-radius: 10px !important;\n    overflow: hidden !important;\n  }\n  .data-table th {\n    border-bottom-color: var(--grid) !important;\n    font-size: 12px !important;\n    font-weight: 600 !important;\n    padding: 8px 12px !important;\n  }\n  .data-table td {\n    font-size: 12px !important;\n    padding: 8px 12px !important;\n  }\n  .note-content, .text-content { font-size: 13px !important; line-height: 1.5 !important; }\n  .markdown-content { font-size: 14px !important; line-height: 1.6 !important; }\n  .markdown-content h1 { font-size: 28px !important; }\n  .markdown-content h2 { font-size: 22px !important; }\n  .markdown-content h3 { font-size: 18px !important; }\n  .markdown-content p, .markdown-content li { font-size: 14px !important; }\n  .markdown-content code { font-size: 13px !important; }\n  .card, .chart-card, .note, .alert, .text-card {\n    border-radius: 10px !important;\n    box-shadow: none !important;\n  }\n</style>\n</head><body class=\"theme-light\"><div class=\"dashboard dashboard-embed\"><section class=\"dashboard-section\"><div class=\"row\"><div class=\"grid-item\" style=\"--col-span: 8; grid-column: span 8;\"><h3 class=\"chart-title\">Top Teams by Points</h3><div id=\"chart_1\" style=\"width: 100%; height: 360px;\"></div></div></div></section></div>\n  <script>(function(){var chart=echarts.init(document.getElementById('chart_1'),null,{renderer:'svg'});chart.setOption({\"backgroundColor\":\"transparent\",\"animation\":false,\"tooltip\":{\"trigger\":\"axis\",\"axisPointer\":{\"type\":\"shadow\"},\"backgroundColor\":\"#ffffff\",\"borderColor\":\"#d4d4d4\",\"textStyle\":{\"color\":\"#231f20\"}},\"grid\":{\"left\":\"2%\",\"right\":\"2%\",\"top\":\"14%\",\"bottom\":\"8%\",\"containLabel\":true},\"xAxis\":{\"type\":\"category\",\"data\":[\"BOS\",\"DEN\",\"OKC\",\"MIN\",\"NYK\"],\"axisLine\":{\"show\":false},\"axisTick\":{\"show\":false},\"axisLabel\":{\"color\":\"#6a6a6a\",\"interval\":0,\"rotate\":45,\"overflow\":\"truncate\",\"ellipsis\":\"...\",\"width\":100}},\"yAxis\":{\"type\":\"value\",\"axisLine\":{\"show\":false},\"axisTick\":{\"show\":false},\"axisLabel\":{\"color\":\"#6a6a6a\",\"fontSize\":11,\"margin\":10,\"formatter\":function(value){return value.toLocaleString();}},\"splitLine\":{\"lineStyle\":{\"color\":\"#d4d4d4\",\"type\":[2,3],\"opacity\":0.6}}},\"series\":[{\"name\":\"points\",\"type\":\"bar\",\"data\":[10422,10051,9964,9818,9721],\"barMaxWidth\":32,\"itemStyle\":{\"color\":\"#9F7AEA\"},\"label\":{\"show\":true,\"position\":\"top\",\"color\":\"#6a6a6a\",\"fontSize\":10,\"offset\":[0,-2],\"formatter\":function(params){var value=params.value;if(Array.isArray(value)) value=value[1];return value.toLocaleString();}}}]});window.addEventListener('resize',function(){chart.resize();});})();</script>\n\n<script>\n(function() {\n  function reportHeight() {\n    var h = document.body ? document.body.scrollHeight : 0;\n    if (h > 0) parent.postMessage({ type: 'mviz-height', height: h }, '*');\n  }\n  if (document.readyState === 'complete') reportHeight();\n  else window.addEventListener('load', reportHeight);\n  new MutationObserver(reportHeight).observe(document.documentElement, { childList: true, subtree: true });\n  setTimeout(reportHeight, 300);\n  setTimeout(reportHeight, 1000);\n})();\n</script>\n</body></html>",
       "source": "```bar size=[8,12]\n{\"type\":\"bar\",\"title\":\"Top Teams by Points\",\"x\":\"team\",\"y\":\"points\",\"format\":\"num0\",\"data\":[{\"team\":\"BOS\",\"points\":10422},{\"team\":\"DEN\",\"points\":10051},{\"team\":\"OKC\",\"points\":9964},{\"team\":\"MIN\",\"points\":9818},{\"team\":\"NYK\",\"points\":9721}]}\n```",
-      "id": "0d678c36-a5d0-4043-bd31-61a4be89cb68"
+      "id": "d3791f7d-166f-4004-a85b-9fa7e58477d6"
     },
     {
       "type": "text",
@@ -1426,7 +1426,7 @@
         "name": "update_context_layer",
         "args": {
           "action": "update",
-          "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba",
+          "id": "019f92cb-3042-7605-9867-f216dc7a7fa1",
           "title": "box_scores to schedule join key",
           "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
           "references": [
@@ -1448,7 +1448,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "update",
-                "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba",
+                "id": "019f92cb-3042-7605-9867-f216dc7a7fa1",
                 "title": "box_scores to schedule join key",
                 "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
                 "references": [
@@ -1488,7 +1488,7 @@
         "name": "update_context_layer",
         "args": {
           "action": "delete",
-          "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba"
+          "id": "019f92cb-3042-7605-9867-f216dc7a7fa1"
         }
       }
     },
@@ -1504,7 +1504,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "delete",
-                "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba"
+                "id": "019f92cb-3042-7605-9867-f216dc7a7fa1"
               }
             }
           ]
@@ -1624,7 +1624,7 @@
               "database:nba_box_scores_v2.main.schedule"
             ]
           },
-          "resultText": "Created fragment \"box_scores to schedule join key\" (id 019f92bf-d18b-726a-99d2-e4b39baac1ba).",
+          "resultText": "Created fragment \"box_scores to schedule join key\" (id 019f92cb-3042-7605-9867-f216dc7a7fa1).",
           "isError": false
         }
       ],
@@ -1731,7 +1731,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_save_1",
-              "content": "Created fragment \"box_scores to schedule join key\" (id 019f92bf-d18b-726a-99d2-e4b39baac1ba)."
+              "content": "Created fragment \"box_scores to schedule join key\" (id 019f92cb-3042-7605-9867-f216dc7a7fa1)."
             }
           ]
         },
@@ -1814,7 +1814,7 @@
             "query": "full-game team scoring grain double count",
             "reference": "database:nba_box_scores_v2.main.box_scores"
           },
-          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92bf-d18b-726a-99d2-e4b39baac1ba\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
+          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92cb-3042-7605-9867-f216dc7a7fa1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
           "isError": false
         },
         {
@@ -1828,7 +1828,7 @@
               "database:nba_box_scores_v2.main.box_scores"
             ]
           },
-          "resultText": "Created fragment \"full-game team scoring grain\" (id 019f92bf-d21a-7482-890f-b9cde3f24b51).",
+          "resultText": "Created fragment \"full-game team scoring grain\" (id 019f92cb-30da-7926-be87-d3c52a1f8203).",
           "isError": false
         }
       ],
@@ -1853,7 +1853,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_lookup_grain",
-              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92bf-d18b-726a-99d2-e4b39baac1ba\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
+              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92cb-3042-7605-9867-f216dc7a7fa1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
             }
           ]
         },
@@ -1905,7 +1905,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_save_grain",
-              "content": "Created fragment \"full-game team scoring grain\" (id 019f92bf-d21a-7482-890f-b9cde3f24b51)."
+              "content": "Created fragment \"full-game team scoring grain\" (id 019f92cb-30da-7926-be87-d3c52a1f8203)."
             }
           ]
         },
@@ -1957,7 +1957,7 @@
             "query": "full-game team scoring grain",
             "reference": "database:nba_box_scores_v2.main.box_scores"
           },
-          "resultText": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f92bf-d21a-7482-890f-b9cde3f24b51\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals.",
+          "resultText": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f92cb-30da-7926-be87-d3c52a1f8203\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals.",
           "isError": false
         }
       ],
@@ -1982,7 +1982,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_lookup_2",
-              "content": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f92bf-d21a-7482-890f-b9cde3f24b51\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals."
+              "content": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f92cb-30da-7926-be87-d3c52a1f8203\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals."
             }
           ]
         },
@@ -2118,7 +2118,7 @@
           "args": {
             "query": "FullGame join"
           },
-          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92bf-d18b-726a-99d2-e4b39baac1ba\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
+          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92cb-3042-7605-9867-f216dc7a7fa1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
           "isError": false
         },
         {
@@ -2126,7 +2126,7 @@
           "name": "update_context_layer",
           "args": {
             "action": "update",
-            "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba",
+            "id": "019f92cb-3042-7605-9867-f216dc7a7fa1",
             "title": "box_scores to schedule join key",
             "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
             "references": [
@@ -2142,9 +2142,9 @@
           "name": "update_context_layer",
           "args": {
             "action": "delete",
-            "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba"
+            "id": "019f92cb-3042-7605-9867-f216dc7a7fa1"
           },
-          "resultText": "Deleted fragment 019f92bf-d18b-726a-99d2-e4b39baac1ba.",
+          "resultText": "Deleted fragment 019f92cb-3042-7605-9867-f216dc7a7fa1.",
           "isError": false
         }
       ],
@@ -2168,7 +2168,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_lookup_3",
-              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92bf-d18b-726a-99d2-e4b39baac1ba\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
+              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92cb-3042-7605-9867-f216dc7a7fa1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
             }
           ]
         },
@@ -2181,7 +2181,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "update",
-                "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba",
+                "id": "019f92cb-3042-7605-9867-f216dc7a7fa1",
                 "title": "box_scores to schedule join key",
                 "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
                 "references": [
@@ -2211,7 +2211,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "delete",
-                "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba"
+                "id": "019f92cb-3042-7605-9867-f216dc7a7fa1"
               }
             }
           ]
@@ -2222,7 +2222,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_delete_1",
-              "content": "Deleted fragment 019f92bf-d18b-726a-99d2-e4b39baac1ba."
+              "content": "Deleted fragment 019f92cb-3042-7605-9867-f216dc7a7fa1."
             }
           ]
         },

--- a/projects/data-chat-mini/reports/demo-validation/latest.json
+++ b/projects/data-chat-mini/reports/demo-validation/latest.json
@@ -1,9 +1,9 @@
 {
-  "runId": "2026-07-24T04-42-10-506Z-mock",
+  "runId": "2026-07-24T05-57-52-667Z-mock",
   "mode": "mock",
   "dataset": "nba_box_scores_v2",
-  "startedAt": "2026-07-24T04:42:10.506Z",
-  "completedAt": "2026-07-24T04:42:10.660Z",
+  "startedAt": "2026-07-24T05:57:52.667Z",
+  "completedAt": "2026-07-24T05:57:52.822Z",
   "assertions": [
     {
       "name": "database selection lists canonical dataset",
@@ -135,7 +135,7 @@
       "name": "context query/update/delete lifecycle succeeds",
       "pass": true,
       "severity": "P2",
-      "detail": "context services: query_context_layer:1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f926e-4ecf-78b0-a3af-bc8ded6190ee\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment \"box_scores to schedule join key\". | update_context_layer:Deleted fragment 019f926e-4ecf-78b0-a3af-bc8ded6190ee."
+      "detail": "context services: query_context_layer:1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92b3-9da0-7542-922b-2405716cf7f0\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment \"box_scores to schedule join key\". | update_context_layer:Deleted fragment 019f92b3-9da0-7542-922b-2405716cf7f0."
     },
     {
       "name": "presenter reset clears local conversations and context",
@@ -816,7 +816,7 @@
     },
     {
       "type": "mviz_pending",
-      "id": "5ce524d2-2f2f-42a3-9de9-35a0fa6c47ed"
+      "id": "41a31c03-8c7a-4aa5-9d59-e987a7a79509"
     },
     {
       "type": "text",
@@ -826,7 +826,7 @@
       "type": "mviz_html",
       "content": "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Dashboard</title>\n  <style>*{box-sizing:border-box;margin:0;padding:0}:root{--bg:#FFFFFF;--fg:#1C1E26;--text:#1C1E26;--text-muted:#6B7280;--grid:#ECEDEF;--red:#2563EB;--link:#0777b3;--font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;--font-mono:'JetBrains Mono','Roboto Mono',ui-monospace,monospace}body.theme-dark{--bg:#231f20;--fg:#ffffff;--text:#ffffff;--text-muted:#888888;--grid:#3a3a3a;--red:#bc1200;--link:#0777b3}html,body{width:100%;min-height:100%;font-family:var(--font-family);color:var(--text);font-size:12px;transition:background-color 0.3s,color 0.3s}.dashboard{max-width:720px;margin:0 auto;padding:16px;position:relative;overflow-x:hidden}body.theme-dark .theme-toggle .icon-moon{display:none}body.theme-dark .theme-toggle .icon-sun{display:block}.dashboard-section{margin-bottom:16px}.chart-title{font-family:var(--font-family);font-weight:700;font-size:10px;font-weight:bold;color:var(--text);margin-bottom:4px}.row{display:grid;grid-template-columns:repeat(16,1fr);gap:8px;margin-bottom:8px}@media (max-width:720px){.row{grid-template-columns:repeat(8,1fr)}.row>*{grid-column:span min(var(--col-span,8),8)}}@media (max-width:480px){.row{grid-template-columns:1fr}.row>*{grid-column:span 1}.grid-item{overflow-x:auto;-webkit-overflow-scrolling:touch}}.grid-item{padding:4px;transition:background-color 0.3s}.data-table{width:100%;border-collapse:collapse;font-size:11px}.data-table th{font-family:var(--font-family);font-size:9px;font-weight:bold;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.03em;padding:6px 8px;border-bottom:1px solid var(--text);text-align:left}.data-table td{padding:5px 8px;color:var(--text);border-bottom:1px solid var(--grid)}.data-table.table-compact th,.data-table.table-compact td{padding:4px 6px}.dashboard.dashboard-embed{max-width:100%;padding:8px}@media (max-width:720px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}}@media (max-width:480px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}.dashboard.dashboard-embed .grid-item{overflow-x:visible}}th.sortable{cursor:pointer}th.sortable[data-sort-dir]{color:inherit}.mviz-sort-ind{display:inline-block;min-width:0.9em;margin-left:2px;font-size:9px;opacity:0.7;text-align:left;white-space:nowrap}</style>\n\n<style>\n  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');\n  /* Kill the browser default body margin so the frame hugs its host card. */\n  html, body {\n    margin: 0 !important;\n  }\n  .dashboard {\n    max-width: 100% !important;\n    padding: 20px !important;\n  }\n  .dashboard-section:last-child {\n    margin-bottom: 0 !important;\n    padding-bottom: 0 !important;\n  }\n  .row:last-child {\n    margin-bottom: 0 !important;\n  }\n  html, body { font-size: 14px !important; }\n  .section-title { font-size: 16px !important; font-weight: 600 !important; }\n  .chart-title { font-size: 16px !important; }\n  .big-value { font-size: 30px !important; font-weight: 700 !important; }\n  .label { font-size: 13px !important; }\n  .delta { font-size: 24px !important; }\n  .delta .value { font-size: 24px !important; }\n  .delta .arrow { font-size: 24px !important; }\n  .delta .label { font-size: 13px !important; }\n  .row { gap: 12px !important; margin-bottom: 12px !important; }\n  .alert .message { font-size: 13px !important; }\n  .data-table {\n    border-radius: 10px !important;\n    overflow: hidden !important;\n  }\n  .data-table th {\n    border-bottom-color: var(--grid) !important;\n    font-size: 12px !important;\n    font-weight: 600 !important;\n    padding: 8px 12px !important;\n  }\n  .data-table td {\n    font-size: 12px !important;\n    padding: 8px 12px !important;\n  }\n  .note-content, .text-content { font-size: 13px !important; line-height: 1.5 !important; }\n  .markdown-content { font-size: 14px !important; line-height: 1.6 !important; }\n  .markdown-content h1 { font-size: 28px !important; }\n  .markdown-content h2 { font-size: 22px !important; }\n  .markdown-content h3 { font-size: 18px !important; }\n  .markdown-content p, .markdown-content li { font-size: 14px !important; }\n  .markdown-content code { font-size: 13px !important; }\n  .card, .chart-card, .note, .alert, .text-card {\n    border-radius: 10px !important;\n    box-shadow: none !important;\n  }\n</style>\n</head><body class=\"theme-light\"><div class=\"dashboard dashboard-embed\"><section class=\"dashboard-section\"><div class=\"row\"><div class=\"grid-item\" style=\"--col-span: 16; grid-column: span 16;\"><h3 class=\"chart-title\">Recent NBA Seasons</h3><table id=\"mviz-dash-table-1\" class=\"data-table table-compact\" style=\"width: 100%; border-collapse: collapse; font-size: 10px;\"><thead><tr><th class=\"sortable\" data-col=\"0\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;\">Season<span class=\"mviz-sort-ind\"></span></th><th class=\"sortable\" data-col=\"1\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;\">Games<span class=\"mviz-sort-ind\"></span></th></tr></thead><tbody><tr><td data-sort=\"2024\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>2,024</strong></td><td data-sort=\"1319\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">1,319</td></tr><tr><td data-sort=\"2023\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>2,023</strong></td><td data-sort=\"1318\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">1,318</td></tr><tr><td data-sort=\"2022\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>2,022</strong></td><td data-sort=\"1317\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">1,317</td></tr></tbody></table></div></div></section></div>\n  <script>(function(){if(window.mvizTableInit) return;function compareCells(a,b){var an=parseFloat(a),bn=parseFloat(b);if(!isNaN(an)&&!isNaN(bn)) return an-bn;return String(a).localeCompare(String(b));}function getSortKey(cell){var v=cell.getAttribute('data-sort');return v!=null?v:cell.textContent.trim();}window.mvizTableInit=function(tableId){var table=document.getElementById(tableId);if(!table) return;var thead=table.tHead;var tbody=table.tBodies[0];if(!thead||!tbody) return;var origRows=Array.prototype.slice.call(tbody.rows);var visibility={};origRows.forEach(function(r,i){visibility[i]=true;});function applyVisibility(){origRows.forEach(function(r,i){r.style.display=visibility[i]?'':'none';});}var sortableHeaders=thead.querySelectorAll('th.sortable');var activeTh=null;var activeState=0;sortableHeaders.forEach(function(th){th.style.cursor='pointer';th.style.userSelect='none';th.addEventListener('click',function(){var colIdx=parseInt(th.getAttribute('data-col'),10);if(isNaN(colIdx)) return;if(activeTh===th){activeState=activeState===1?-1:activeState===-1?0:1;}else{if(activeTh){activeTh.removeAttribute('data-sort-dir');var prevInd=activeTh.querySelector('.mviz-sort-ind');if(prevInd) prevInd.textContent='';}activeTh=th;activeState=1;}var ind=th.querySelector('.mviz-sort-ind');if(activeState===0){th.removeAttribute('data-sort-dir');if(ind) ind.textContent='';activeTh=null;origRows.forEach(function(r){tbody.appendChild(r);});applyVisibility();return;}th.setAttribute('data-sort-dir',activeState===1?'asc':'desc');if(ind) ind.textContent=activeState===1?'▲':'▼';var sorted=origRows.slice().sort(function(a,b){var av=getSortKey(a.cells[colIdx]);var bv=getSortKey(b.cells[colIdx]);var cmp=compareCells(av,bv);return activeState===1?cmp:-cmp;});sorted.forEach(function(r){tbody.appendChild(r);});applyVisibility();});});var container=table.parentElement;var globalInput=container&&container.querySelector('.mviz-filter-global[data-table=\"'+tableId+'\"]');if(globalInput){globalInput.addEventListener('input',function(){var q=globalInput.value.toLowerCase();origRows.forEach(function(r,i){visibility[i]=!q||r.textContent.toLowerCase().indexOf(q)!==-1;});applyVisibility();});}};})();if(window.mvizTableInit) window.mvizTableInit(\"mviz-dash-table-1\");</script>\n\n<script>\n(function() {\n  function reportHeight() {\n    var h = document.body ? document.body.scrollHeight : 0;\n    if (h > 0) parent.postMessage({ type: 'mviz-height', height: h }, '*');\n  }\n  if (document.readyState === 'complete') reportHeight();\n  else window.addEventListener('load', reportHeight);\n  new MutationObserver(reportHeight).observe(document.documentElement, { childList: true, subtree: true });\n  setTimeout(reportHeight, 300);\n  setTimeout(reportHeight, 1000);\n})();\n</script>\n</body></html>",
       "source": "```table size=[16,5]\n{\"title\":\"Recent NBA Seasons\",\"columns\":[{\"id\":\"season_year\",\"title\":\"Season\",\"bold\":true},{\"id\":\"games\",\"title\":\"Games\",\"fmt\":\"auto\",\"align\":\"right\"}],\"data\":[{\"season_year\":2024,\"games\":1319},{\"season_year\":2023,\"games\":1318},{\"season_year\":2022,\"games\":1317}],\"compact\":true}\n```",
-      "id": "5ce524d2-2f2f-42a3-9de9-35a0fa6c47ed"
+      "id": "41a31c03-8c7a-4aa5-9d59-e987a7a79509"
     },
     {
       "type": "text",
@@ -1059,7 +1059,7 @@
     },
     {
       "type": "mviz_pending",
-      "id": "3d74177e-e72f-410b-92f5-2f7bc5aafe97"
+      "id": "62dd94c5-7f88-493f-b5f7-57c344918b60"
     },
     {
       "type": "text",
@@ -1069,7 +1069,7 @@
       "type": "mviz_html",
       "content": "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Dashboard</title>\n  <style>*{box-sizing:border-box;margin:0;padding:0}:root{--bg:#FFFFFF;--fg:#1C1E26;--text:#1C1E26;--text-muted:#6B7280;--grid:#ECEDEF;--red:#2563EB;--link:#0777b3;--font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;--font-mono:'JetBrains Mono','Roboto Mono',ui-monospace,monospace}body.theme-dark{--bg:#231f20;--fg:#ffffff;--text:#ffffff;--text-muted:#888888;--grid:#3a3a3a;--red:#bc1200;--link:#0777b3}html,body{width:100%;min-height:100%;font-family:var(--font-family);color:var(--text);font-size:12px;transition:background-color 0.3s,color 0.3s}.dashboard{max-width:720px;margin:0 auto;padding:16px;position:relative;overflow-x:hidden}body.theme-dark .theme-toggle .icon-moon{display:none}body.theme-dark .theme-toggle .icon-sun{display:block}.dashboard-section{margin-bottom:16px}.chart-title{font-family:var(--font-family);font-weight:700;font-size:10px;font-weight:bold;color:var(--text);margin-bottom:4px}.row{display:grid;grid-template-columns:repeat(16,1fr);gap:8px;margin-bottom:8px}@media (max-width:720px){.row{grid-template-columns:repeat(8,1fr)}.row>*{grid-column:span min(var(--col-span,8),8)}}@media (max-width:480px){.row{grid-template-columns:1fr}.row>*{grid-column:span 1}.grid-item{overflow-x:auto;-webkit-overflow-scrolling:touch}}.grid-item{padding:4px;transition:background-color 0.3s}.data-table{width:100%;border-collapse:collapse;font-size:11px}.data-table th{font-family:var(--font-family);font-size:9px;font-weight:bold;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.03em;padding:6px 8px;border-bottom:1px solid var(--text);text-align:left}.data-table td{padding:5px 8px;color:var(--text);border-bottom:1px solid var(--grid)}.data-table.table-compact th,.data-table.table-compact td{padding:4px 6px}.dashboard.dashboard-embed{max-width:100%;padding:8px}@media (max-width:720px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}}@media (max-width:480px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}.dashboard.dashboard-embed .grid-item{overflow-x:visible}}th.sortable{cursor:pointer}th.sortable[data-sort-dir]{color:inherit}.mviz-sort-ind{display:inline-block;min-width:0.9em;margin-left:2px;font-size:9px;opacity:0.7;text-align:left;white-space:nowrap}</style>\n\n<style>\n  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');\n  /* Kill the browser default body margin so the frame hugs its host card. */\n  html, body {\n    margin: 0 !important;\n  }\n  .dashboard {\n    max-width: 100% !important;\n    padding: 20px !important;\n  }\n  .dashboard-section:last-child {\n    margin-bottom: 0 !important;\n    padding-bottom: 0 !important;\n  }\n  .row:last-child {\n    margin-bottom: 0 !important;\n  }\n  html, body { font-size: 14px !important; }\n  .section-title { font-size: 16px !important; font-weight: 600 !important; }\n  .chart-title { font-size: 16px !important; }\n  .big-value { font-size: 30px !important; font-weight: 700 !important; }\n  .label { font-size: 13px !important; }\n  .delta { font-size: 24px !important; }\n  .delta .value { font-size: 24px !important; }\n  .delta .arrow { font-size: 24px !important; }\n  .delta .label { font-size: 13px !important; }\n  .row { gap: 12px !important; margin-bottom: 12px !important; }\n  .alert .message { font-size: 13px !important; }\n  .data-table {\n    border-radius: 10px !important;\n    overflow: hidden !important;\n  }\n  .data-table th {\n    border-bottom-color: var(--grid) !important;\n    font-size: 12px !important;\n    font-weight: 600 !important;\n    padding: 8px 12px !important;\n  }\n  .data-table td {\n    font-size: 12px !important;\n    padding: 8px 12px !important;\n  }\n  .note-content, .text-content { font-size: 13px !important; line-height: 1.5 !important; }\n  .markdown-content { font-size: 14px !important; line-height: 1.6 !important; }\n  .markdown-content h1 { font-size: 28px !important; }\n  .markdown-content h2 { font-size: 22px !important; }\n  .markdown-content h3 { font-size: 18px !important; }\n  .markdown-content p, .markdown-content li { font-size: 14px !important; }\n  .markdown-content code { font-size: 13px !important; }\n  .card, .chart-card, .note, .alert, .text-card {\n    border-radius: 10px !important;\n    box-shadow: none !important;\n  }\n</style>\n</head><body class=\"theme-light\"><div class=\"dashboard dashboard-embed\"><section class=\"dashboard-section\"><div class=\"row\"><div class=\"grid-item\" style=\"--col-span: 16; grid-column: span 16;\"><h3 class=\"chart-title\">2024 Regular Season Team Scoring Leaders</h3><table id=\"mviz-dash-table-2\" class=\"data-table table-compact\" style=\"width: 100%; border-collapse: collapse; font-size: 10px;\"><thead><tr><th class=\"sortable\" data-col=\"0\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;\">Team<span class=\"mviz-sort-ind\"></span></th><th class=\"sortable\" data-col=\"1\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;\">Points<span class=\"mviz-sort-ind\"></span></th></tr></thead><tbody><tr><td data-sort=\"BOS\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>BOS</strong></td><td data-sort=\"10422\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">10.42k</td></tr><tr><td data-sort=\"DEN\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>DEN</strong></td><td data-sort=\"10051\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">10.05k</td></tr><tr><td data-sort=\"OKC\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>OKC</strong></td><td data-sort=\"9964\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">9,964</td></tr><tr><td data-sort=\"MIN\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>MIN</strong></td><td data-sort=\"9818\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">9,818</td></tr><tr><td data-sort=\"NYK\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>NYK</strong></td><td data-sort=\"9721\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">9,721</td></tr></tbody></table></div></div></section></div>\n  <script>(function(){if(window.mvizTableInit) return;function compareCells(a,b){var an=parseFloat(a),bn=parseFloat(b);if(!isNaN(an)&&!isNaN(bn)) return an-bn;return String(a).localeCompare(String(b));}function getSortKey(cell){var v=cell.getAttribute('data-sort');return v!=null?v:cell.textContent.trim();}window.mvizTableInit=function(tableId){var table=document.getElementById(tableId);if(!table) return;var thead=table.tHead;var tbody=table.tBodies[0];if(!thead||!tbody) return;var origRows=Array.prototype.slice.call(tbody.rows);var visibility={};origRows.forEach(function(r,i){visibility[i]=true;});function applyVisibility(){origRows.forEach(function(r,i){r.style.display=visibility[i]?'':'none';});}var sortableHeaders=thead.querySelectorAll('th.sortable');var activeTh=null;var activeState=0;sortableHeaders.forEach(function(th){th.style.cursor='pointer';th.style.userSelect='none';th.addEventListener('click',function(){var colIdx=parseInt(th.getAttribute('data-col'),10);if(isNaN(colIdx)) return;if(activeTh===th){activeState=activeState===1?-1:activeState===-1?0:1;}else{if(activeTh){activeTh.removeAttribute('data-sort-dir');var prevInd=activeTh.querySelector('.mviz-sort-ind');if(prevInd) prevInd.textContent='';}activeTh=th;activeState=1;}var ind=th.querySelector('.mviz-sort-ind');if(activeState===0){th.removeAttribute('data-sort-dir');if(ind) ind.textContent='';activeTh=null;origRows.forEach(function(r){tbody.appendChild(r);});applyVisibility();return;}th.setAttribute('data-sort-dir',activeState===1?'asc':'desc');if(ind) ind.textContent=activeState===1?'▲':'▼';var sorted=origRows.slice().sort(function(a,b){var av=getSortKey(a.cells[colIdx]);var bv=getSortKey(b.cells[colIdx]);var cmp=compareCells(av,bv);return activeState===1?cmp:-cmp;});sorted.forEach(function(r){tbody.appendChild(r);});applyVisibility();});});var container=table.parentElement;var globalInput=container&&container.querySelector('.mviz-filter-global[data-table=\"'+tableId+'\"]');if(globalInput){globalInput.addEventListener('input',function(){var q=globalInput.value.toLowerCase();origRows.forEach(function(r,i){visibility[i]=!q||r.textContent.toLowerCase().indexOf(q)!==-1;});applyVisibility();});}};})();if(window.mvizTableInit) window.mvizTableInit(\"mviz-dash-table-2\");</script>\n\n<script>\n(function() {\n  function reportHeight() {\n    var h = document.body ? document.body.scrollHeight : 0;\n    if (h > 0) parent.postMessage({ type: 'mviz-height', height: h }, '*');\n  }\n  if (document.readyState === 'complete') reportHeight();\n  else window.addEventListener('load', reportHeight);\n  new MutationObserver(reportHeight).observe(document.documentElement, { childList: true, subtree: true });\n  setTimeout(reportHeight, 300);\n  setTimeout(reportHeight, 1000);\n})();\n</script>\n</body></html>",
       "source": "```table size=[16,5]\n{\"title\":\"2024 Regular Season Team Scoring Leaders\",\"columns\":[{\"id\":\"team\",\"title\":\"Team\",\"bold\":true},{\"id\":\"points\",\"title\":\"Points\",\"fmt\":\"auto\",\"align\":\"right\"}],\"data\":[{\"team\":\"BOS\",\"points\":10422},{\"team\":\"DEN\",\"points\":10051},{\"team\":\"OKC\",\"points\":9964},{\"team\":\"MIN\",\"points\":9818},{\"team\":\"NYK\",\"points\":9721}],\"compact\":true}\n```",
-      "id": "3d74177e-e72f-410b-92f5-2f7bc5aafe97"
+      "id": "62dd94c5-7f88-493f-b5f7-57c344918b60"
     },
     {
       "type": "text",
@@ -1192,7 +1192,7 @@
     },
     {
       "type": "mviz_pending",
-      "id": "120fbbd4-529d-4e88-978d-f4e327b6b388"
+      "id": "90397b3e-0f89-4592-9a8b-8bc67785b25a"
     },
     {
       "type": "text",
@@ -1202,7 +1202,7 @@
       "type": "mviz_html",
       "content": "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Dashboard</title>\n  <script src=\"https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js\"></script>\n  <style>*{box-sizing:border-box;margin:0;padding:0}:root{--bg:#FFFFFF;--fg:#1C1E26;--text:#1C1E26;--text-muted:#6B7280;--grid:#ECEDEF;--red:#2563EB;--link:#0777b3;--font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;--font-mono:'JetBrains Mono','Roboto Mono',ui-monospace,monospace}body.theme-dark{--bg:#231f20;--fg:#ffffff;--text:#ffffff;--text-muted:#888888;--grid:#3a3a3a;--red:#bc1200;--link:#0777b3}html,body{width:100%;min-height:100%;font-family:var(--font-family);color:var(--text);font-size:12px;transition:background-color 0.3s,color 0.3s}.dashboard{max-width:720px;margin:0 auto;padding:16px;position:relative;overflow-x:hidden}body.theme-dark .theme-toggle .icon-moon{display:none}body.theme-dark .theme-toggle .icon-sun{display:block}.dashboard-section{margin-bottom:16px}.chart-title{font-family:var(--font-family);font-weight:700;font-size:10px;font-weight:bold;color:var(--text);margin-bottom:4px}.row{display:grid;grid-template-columns:repeat(16,1fr);gap:8px;margin-bottom:8px}@media (max-width:720px){.row{grid-template-columns:repeat(8,1fr)}.row>*{grid-column:span min(var(--col-span,8),8)}}@media (max-width:480px){.row{grid-template-columns:1fr}.row>*{grid-column:span 1}.grid-item{overflow-x:auto;-webkit-overflow-scrolling:touch}}.grid-item{padding:4px;transition:background-color 0.3s}.dashboard.dashboard-embed{max-width:100%;padding:8px}@media (max-width:720px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}}@media (max-width:480px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}.dashboard.dashboard-embed .grid-item{overflow-x:visible}}</style>\n\n<style>\n  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');\n  /* Kill the browser default body margin so the frame hugs its host card. */\n  html, body {\n    margin: 0 !important;\n  }\n  .dashboard {\n    max-width: 100% !important;\n    padding: 20px !important;\n  }\n  .dashboard-section:last-child {\n    margin-bottom: 0 !important;\n    padding-bottom: 0 !important;\n  }\n  .row:last-child {\n    margin-bottom: 0 !important;\n  }\n  html, body { font-size: 14px !important; }\n  .section-title { font-size: 16px !important; font-weight: 600 !important; }\n  .chart-title { font-size: 16px !important; }\n  .big-value { font-size: 30px !important; font-weight: 700 !important; }\n  .label { font-size: 13px !important; }\n  .delta { font-size: 24px !important; }\n  .delta .value { font-size: 24px !important; }\n  .delta .arrow { font-size: 24px !important; }\n  .delta .label { font-size: 13px !important; }\n  .row { gap: 12px !important; margin-bottom: 12px !important; }\n  .alert .message { font-size: 13px !important; }\n  .data-table {\n    border-radius: 10px !important;\n    overflow: hidden !important;\n  }\n  .data-table th {\n    border-bottom-color: var(--grid) !important;\n    font-size: 12px !important;\n    font-weight: 600 !important;\n    padding: 8px 12px !important;\n  }\n  .data-table td {\n    font-size: 12px !important;\n    padding: 8px 12px !important;\n  }\n  .note-content, .text-content { font-size: 13px !important; line-height: 1.5 !important; }\n  .markdown-content { font-size: 14px !important; line-height: 1.6 !important; }\n  .markdown-content h1 { font-size: 28px !important; }\n  .markdown-content h2 { font-size: 22px !important; }\n  .markdown-content h3 { font-size: 18px !important; }\n  .markdown-content p, .markdown-content li { font-size: 14px !important; }\n  .markdown-content code { font-size: 13px !important; }\n  .card, .chart-card, .note, .alert, .text-card {\n    border-radius: 10px !important;\n    box-shadow: none !important;\n  }\n</style>\n</head><body class=\"theme-light\"><div class=\"dashboard dashboard-embed\"><section class=\"dashboard-section\"><div class=\"row\"><div class=\"grid-item\" style=\"--col-span: 8; grid-column: span 8;\"><h3 class=\"chart-title\">Top Teams by Points</h3><div id=\"chart_1\" style=\"width: 100%; height: 360px;\"></div></div></div></section></div>\n  <script>(function(){var chart=echarts.init(document.getElementById('chart_1'),null,{renderer:'svg'});chart.setOption({\"backgroundColor\":\"transparent\",\"animation\":false,\"tooltip\":{\"trigger\":\"axis\",\"axisPointer\":{\"type\":\"shadow\"},\"backgroundColor\":\"#ffffff\",\"borderColor\":\"#d4d4d4\",\"textStyle\":{\"color\":\"#231f20\"}},\"grid\":{\"left\":\"2%\",\"right\":\"2%\",\"top\":\"14%\",\"bottom\":\"8%\",\"containLabel\":true},\"xAxis\":{\"type\":\"category\",\"data\":[\"BOS\",\"DEN\",\"OKC\",\"MIN\",\"NYK\"],\"axisLine\":{\"show\":false},\"axisTick\":{\"show\":false},\"axisLabel\":{\"color\":\"#6a6a6a\",\"interval\":0,\"rotate\":45,\"overflow\":\"truncate\",\"ellipsis\":\"...\",\"width\":100}},\"yAxis\":{\"type\":\"value\",\"axisLine\":{\"show\":false},\"axisTick\":{\"show\":false},\"axisLabel\":{\"color\":\"#6a6a6a\",\"fontSize\":11,\"margin\":10,\"formatter\":function(value){return value.toLocaleString();}},\"splitLine\":{\"lineStyle\":{\"color\":\"#d4d4d4\",\"type\":[2,3],\"opacity\":0.6}}},\"series\":[{\"name\":\"points\",\"type\":\"bar\",\"data\":[10422,10051,9964,9818,9721],\"barMaxWidth\":32,\"itemStyle\":{\"color\":\"#9F7AEA\"},\"label\":{\"show\":true,\"position\":\"top\",\"color\":\"#6a6a6a\",\"fontSize\":10,\"offset\":[0,-2],\"formatter\":function(params){var value=params.value;if(Array.isArray(value)) value=value[1];return value.toLocaleString();}}}]});window.addEventListener('resize',function(){chart.resize();});})();</script>\n\n<script>\n(function() {\n  function reportHeight() {\n    var h = document.body ? document.body.scrollHeight : 0;\n    if (h > 0) parent.postMessage({ type: 'mviz-height', height: h }, '*');\n  }\n  if (document.readyState === 'complete') reportHeight();\n  else window.addEventListener('load', reportHeight);\n  new MutationObserver(reportHeight).observe(document.documentElement, { childList: true, subtree: true });\n  setTimeout(reportHeight, 300);\n  setTimeout(reportHeight, 1000);\n})();\n</script>\n</body></html>",
       "source": "```bar size=[8,12]\n{\"type\":\"bar\",\"title\":\"Top Teams by Points\",\"x\":\"team\",\"y\":\"points\",\"format\":\"num0\",\"data\":[{\"team\":\"BOS\",\"points\":10422},{\"team\":\"DEN\",\"points\":10051},{\"team\":\"OKC\",\"points\":9964},{\"team\":\"MIN\",\"points\":9818},{\"team\":\"NYK\",\"points\":9721}]}\n```",
-      "id": "120fbbd4-529d-4e88-978d-f4e327b6b388"
+      "id": "90397b3e-0f89-4592-9a8b-8bc67785b25a"
     },
     {
       "type": "text",
@@ -1426,7 +1426,7 @@
         "name": "update_context_layer",
         "args": {
           "action": "update",
-          "id": "019f926e-4ecf-78b0-a3af-bc8ded6190ee",
+          "id": "019f92b3-9da0-7542-922b-2405716cf7f0",
           "title": "box_scores to schedule join key",
           "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
           "references": [
@@ -1448,7 +1448,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "update",
-                "id": "019f926e-4ecf-78b0-a3af-bc8ded6190ee",
+                "id": "019f92b3-9da0-7542-922b-2405716cf7f0",
                 "title": "box_scores to schedule join key",
                 "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
                 "references": [
@@ -1488,7 +1488,7 @@
         "name": "update_context_layer",
         "args": {
           "action": "delete",
-          "id": "019f926e-4ecf-78b0-a3af-bc8ded6190ee"
+          "id": "019f92b3-9da0-7542-922b-2405716cf7f0"
         }
       }
     },
@@ -1504,7 +1504,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "delete",
-                "id": "019f926e-4ecf-78b0-a3af-bc8ded6190ee"
+                "id": "019f92b3-9da0-7542-922b-2405716cf7f0"
               }
             }
           ]
@@ -1624,7 +1624,7 @@
               "database:nba_box_scores_v2.main.schedule"
             ]
           },
-          "resultText": "Created fragment \"box_scores to schedule join key\" (id 019f926e-4ecf-78b0-a3af-bc8ded6190ee).",
+          "resultText": "Created fragment \"box_scores to schedule join key\" (id 019f92b3-9da0-7542-922b-2405716cf7f0).",
           "isError": false
         }
       ],
@@ -1731,7 +1731,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_save_1",
-              "content": "Created fragment \"box_scores to schedule join key\" (id 019f926e-4ecf-78b0-a3af-bc8ded6190ee)."
+              "content": "Created fragment \"box_scores to schedule join key\" (id 019f92b3-9da0-7542-922b-2405716cf7f0)."
             }
           ]
         },
@@ -1814,7 +1814,7 @@
             "query": "full-game team scoring grain double count",
             "reference": "database:nba_box_scores_v2.main.box_scores"
           },
-          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f926e-4ecf-78b0-a3af-bc8ded6190ee\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
+          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92b3-9da0-7542-922b-2405716cf7f0\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
           "isError": false
         },
         {
@@ -1828,7 +1828,7 @@
               "database:nba_box_scores_v2.main.box_scores"
             ]
           },
-          "resultText": "Created fragment \"full-game team scoring grain\" (id 019f926e-4f5e-7efa-be22-0590aaaaa1c2).",
+          "resultText": "Created fragment \"full-game team scoring grain\" (id 019f92b3-9e30-71f8-a674-2eaa2b79306f).",
           "isError": false
         }
       ],
@@ -1853,7 +1853,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_lookup_grain",
-              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f926e-4ecf-78b0-a3af-bc8ded6190ee\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
+              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92b3-9da0-7542-922b-2405716cf7f0\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
             }
           ]
         },
@@ -1905,7 +1905,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_save_grain",
-              "content": "Created fragment \"full-game team scoring grain\" (id 019f926e-4f5e-7efa-be22-0590aaaaa1c2)."
+              "content": "Created fragment \"full-game team scoring grain\" (id 019f92b3-9e30-71f8-a674-2eaa2b79306f)."
             }
           ]
         },
@@ -1957,7 +1957,7 @@
             "query": "full-game team scoring grain",
             "reference": "database:nba_box_scores_v2.main.box_scores"
           },
-          "resultText": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f926e-4f5e-7efa-be22-0590aaaaa1c2\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals.",
+          "resultText": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f92b3-9e30-71f8-a674-2eaa2b79306f\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals.",
           "isError": false
         }
       ],
@@ -1982,7 +1982,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_lookup_2",
-              "content": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f926e-4f5e-7efa-be22-0590aaaaa1c2\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals."
+              "content": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f92b3-9e30-71f8-a674-2eaa2b79306f\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals."
             }
           ]
         },
@@ -2118,7 +2118,7 @@
           "args": {
             "query": "FullGame join"
           },
-          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f926e-4ecf-78b0-a3af-bc8ded6190ee\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
+          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92b3-9da0-7542-922b-2405716cf7f0\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
           "isError": false
         },
         {
@@ -2126,7 +2126,7 @@
           "name": "update_context_layer",
           "args": {
             "action": "update",
-            "id": "019f926e-4ecf-78b0-a3af-bc8ded6190ee",
+            "id": "019f92b3-9da0-7542-922b-2405716cf7f0",
             "title": "box_scores to schedule join key",
             "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
             "references": [
@@ -2142,9 +2142,9 @@
           "name": "update_context_layer",
           "args": {
             "action": "delete",
-            "id": "019f926e-4ecf-78b0-a3af-bc8ded6190ee"
+            "id": "019f92b3-9da0-7542-922b-2405716cf7f0"
           },
-          "resultText": "Deleted fragment 019f926e-4ecf-78b0-a3af-bc8ded6190ee.",
+          "resultText": "Deleted fragment 019f92b3-9da0-7542-922b-2405716cf7f0.",
           "isError": false
         }
       ],
@@ -2168,7 +2168,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_lookup_3",
-              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f926e-4ecf-78b0-a3af-bc8ded6190ee\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
+              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92b3-9da0-7542-922b-2405716cf7f0\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
             }
           ]
         },
@@ -2181,7 +2181,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "update",
-                "id": "019f926e-4ecf-78b0-a3af-bc8ded6190ee",
+                "id": "019f92b3-9da0-7542-922b-2405716cf7f0",
                 "title": "box_scores to schedule join key",
                 "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
                 "references": [
@@ -2211,7 +2211,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "delete",
-                "id": "019f926e-4ecf-78b0-a3af-bc8ded6190ee"
+                "id": "019f92b3-9da0-7542-922b-2405716cf7f0"
               }
             }
           ]
@@ -2222,7 +2222,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_delete_1",
-              "content": "Deleted fragment 019f926e-4ecf-78b0-a3af-bc8ded6190ee."
+              "content": "Deleted fragment 019f92b3-9da0-7542-922b-2405716cf7f0."
             }
           ]
         },

--- a/projects/data-chat-mini/reports/demo-validation/latest.json
+++ b/projects/data-chat-mini/reports/demo-validation/latest.json
@@ -1,9 +1,9 @@
 {
-  "runId": "2026-07-24T06-23-37-533Z-mock",
+  "runId": "2026-07-24T06-36-17-283Z-mock",
   "mode": "mock",
   "dataset": "nba_box_scores_v2",
-  "startedAt": "2026-07-24T06:23:37.533Z",
-  "completedAt": "2026-07-24T06:23:37.696Z",
+  "startedAt": "2026-07-24T06:36:17.283Z",
+  "completedAt": "2026-07-24T06:36:17.439Z",
   "assertions": [
     {
       "name": "database selection lists canonical dataset",
@@ -135,7 +135,7 @@
       "name": "context query/update/delete lifecycle succeeds",
       "pass": true,
       "severity": "P2",
-      "detail": "context services: query_context_layer:1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92cb-3042-7605-9867-f216dc7a7fa1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment \"box_scores to schedule join key\". | update_context_layer:Deleted fragment 019f92cb-3042-7605-9867-f216dc7a7fa1."
+      "detail": "context services: query_context_layer:1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92d6-c808-7d59-9163-296c17613ee1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment \"box_scores to schedule join key\". | update_context_layer:Deleted fragment 019f92d6-c808-7d59-9163-296c17613ee1."
     },
     {
       "name": "presenter reset clears local conversations and context",
@@ -816,7 +816,7 @@
     },
     {
       "type": "mviz_pending",
-      "id": "777d848c-a891-41de-aa9f-77bb72ca758d"
+      "id": "c4cb9b84-a8e8-402b-8e46-14181e801485"
     },
     {
       "type": "text",
@@ -826,7 +826,7 @@
       "type": "mviz_html",
       "content": "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Dashboard</title>\n  <style>*{box-sizing:border-box;margin:0;padding:0}:root{--bg:#FFFFFF;--fg:#1C1E26;--text:#1C1E26;--text-muted:#6B7280;--grid:#ECEDEF;--red:#2563EB;--link:#0777b3;--font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;--font-mono:'JetBrains Mono','Roboto Mono',ui-monospace,monospace}body.theme-dark{--bg:#231f20;--fg:#ffffff;--text:#ffffff;--text-muted:#888888;--grid:#3a3a3a;--red:#bc1200;--link:#0777b3}html,body{width:100%;min-height:100%;font-family:var(--font-family);color:var(--text);font-size:12px;transition:background-color 0.3s,color 0.3s}.dashboard{max-width:720px;margin:0 auto;padding:16px;position:relative;overflow-x:hidden}body.theme-dark .theme-toggle .icon-moon{display:none}body.theme-dark .theme-toggle .icon-sun{display:block}.dashboard-section{margin-bottom:16px}.chart-title{font-family:var(--font-family);font-weight:700;font-size:10px;font-weight:bold;color:var(--text);margin-bottom:4px}.row{display:grid;grid-template-columns:repeat(16,1fr);gap:8px;margin-bottom:8px}@media (max-width:720px){.row{grid-template-columns:repeat(8,1fr)}.row>*{grid-column:span min(var(--col-span,8),8)}}@media (max-width:480px){.row{grid-template-columns:1fr}.row>*{grid-column:span 1}.grid-item{overflow-x:auto;-webkit-overflow-scrolling:touch}}.grid-item{padding:4px;transition:background-color 0.3s}.data-table{width:100%;border-collapse:collapse;font-size:11px}.data-table th{font-family:var(--font-family);font-size:9px;font-weight:bold;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.03em;padding:6px 8px;border-bottom:1px solid var(--text);text-align:left}.data-table td{padding:5px 8px;color:var(--text);border-bottom:1px solid var(--grid)}.data-table.table-compact th,.data-table.table-compact td{padding:4px 6px}.dashboard.dashboard-embed{max-width:100%;padding:8px}@media (max-width:720px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}}@media (max-width:480px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}.dashboard.dashboard-embed .grid-item{overflow-x:visible}}th.sortable{cursor:pointer}th.sortable[data-sort-dir]{color:inherit}.mviz-sort-ind{display:inline-block;min-width:0.9em;margin-left:2px;font-size:9px;opacity:0.7;text-align:left;white-space:nowrap}</style>\n\n<style>\n  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');\n  /* Kill the browser default body margin so the frame hugs its host card. */\n  html, body {\n    margin: 0 !important;\n  }\n  .dashboard {\n    max-width: 100% !important;\n    padding: 20px !important;\n  }\n  .dashboard-section:last-child {\n    margin-bottom: 0 !important;\n    padding-bottom: 0 !important;\n  }\n  .row:last-child {\n    margin-bottom: 0 !important;\n  }\n  html, body { font-size: 14px !important; }\n  .section-title { font-size: 16px !important; font-weight: 600 !important; }\n  .chart-title { font-size: 16px !important; }\n  .big-value { font-size: 30px !important; font-weight: 700 !important; }\n  .label { font-size: 13px !important; }\n  .delta { font-size: 24px !important; }\n  .delta .value { font-size: 24px !important; }\n  .delta .arrow { font-size: 24px !important; }\n  .delta .label { font-size: 13px !important; }\n  .row { gap: 12px !important; margin-bottom: 12px !important; }\n  .alert .message { font-size: 13px !important; }\n  .data-table {\n    border-radius: 10px !important;\n    overflow: hidden !important;\n  }\n  .data-table th {\n    border-bottom-color: var(--grid) !important;\n    font-size: 12px !important;\n    font-weight: 600 !important;\n    padding: 8px 12px !important;\n  }\n  .data-table td {\n    font-size: 12px !important;\n    padding: 8px 12px !important;\n  }\n  .note-content, .text-content { font-size: 13px !important; line-height: 1.5 !important; }\n  .markdown-content { font-size: 14px !important; line-height: 1.6 !important; }\n  .markdown-content h1 { font-size: 28px !important; }\n  .markdown-content h2 { font-size: 22px !important; }\n  .markdown-content h3 { font-size: 18px !important; }\n  .markdown-content p, .markdown-content li { font-size: 14px !important; }\n  .markdown-content code { font-size: 13px !important; }\n  .card, .chart-card, .note, .alert, .text-card {\n    border-radius: 10px !important;\n    box-shadow: none !important;\n  }\n</style>\n</head><body class=\"theme-light\"><div class=\"dashboard dashboard-embed\"><section class=\"dashboard-section\"><div class=\"row\"><div class=\"grid-item\" style=\"--col-span: 16; grid-column: span 16;\"><h3 class=\"chart-title\">Recent NBA Seasons</h3><table id=\"mviz-dash-table-1\" class=\"data-table table-compact\" style=\"width: 100%; border-collapse: collapse; font-size: 10px;\"><thead><tr><th class=\"sortable\" data-col=\"0\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;\">Season<span class=\"mviz-sort-ind\"></span></th><th class=\"sortable\" data-col=\"1\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;\">Games<span class=\"mviz-sort-ind\"></span></th></tr></thead><tbody><tr><td data-sort=\"2024\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>2,024</strong></td><td data-sort=\"1319\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">1,319</td></tr><tr><td data-sort=\"2023\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>2,023</strong></td><td data-sort=\"1318\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">1,318</td></tr><tr><td data-sort=\"2022\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>2,022</strong></td><td data-sort=\"1317\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">1,317</td></tr></tbody></table></div></div></section></div>\n  <script>(function(){if(window.mvizTableInit) return;function compareCells(a,b){var an=parseFloat(a),bn=parseFloat(b);if(!isNaN(an)&&!isNaN(bn)) return an-bn;return String(a).localeCompare(String(b));}function getSortKey(cell){var v=cell.getAttribute('data-sort');return v!=null?v:cell.textContent.trim();}window.mvizTableInit=function(tableId){var table=document.getElementById(tableId);if(!table) return;var thead=table.tHead;var tbody=table.tBodies[0];if(!thead||!tbody) return;var origRows=Array.prototype.slice.call(tbody.rows);var visibility={};origRows.forEach(function(r,i){visibility[i]=true;});function applyVisibility(){origRows.forEach(function(r,i){r.style.display=visibility[i]?'':'none';});}var sortableHeaders=thead.querySelectorAll('th.sortable');var activeTh=null;var activeState=0;sortableHeaders.forEach(function(th){th.style.cursor='pointer';th.style.userSelect='none';th.addEventListener('click',function(){var colIdx=parseInt(th.getAttribute('data-col'),10);if(isNaN(colIdx)) return;if(activeTh===th){activeState=activeState===1?-1:activeState===-1?0:1;}else{if(activeTh){activeTh.removeAttribute('data-sort-dir');var prevInd=activeTh.querySelector('.mviz-sort-ind');if(prevInd) prevInd.textContent='';}activeTh=th;activeState=1;}var ind=th.querySelector('.mviz-sort-ind');if(activeState===0){th.removeAttribute('data-sort-dir');if(ind) ind.textContent='';activeTh=null;origRows.forEach(function(r){tbody.appendChild(r);});applyVisibility();return;}th.setAttribute('data-sort-dir',activeState===1?'asc':'desc');if(ind) ind.textContent=activeState===1?'▲':'▼';var sorted=origRows.slice().sort(function(a,b){var av=getSortKey(a.cells[colIdx]);var bv=getSortKey(b.cells[colIdx]);var cmp=compareCells(av,bv);return activeState===1?cmp:-cmp;});sorted.forEach(function(r){tbody.appendChild(r);});applyVisibility();});});var container=table.parentElement;var globalInput=container&&container.querySelector('.mviz-filter-global[data-table=\"'+tableId+'\"]');if(globalInput){globalInput.addEventListener('input',function(){var q=globalInput.value.toLowerCase();origRows.forEach(function(r,i){visibility[i]=!q||r.textContent.toLowerCase().indexOf(q)!==-1;});applyVisibility();});}};})();if(window.mvizTableInit) window.mvizTableInit(\"mviz-dash-table-1\");</script>\n\n<script>\n(function() {\n  function reportHeight() {\n    var h = document.body ? document.body.scrollHeight : 0;\n    if (h > 0) parent.postMessage({ type: 'mviz-height', height: h }, '*');\n  }\n  if (document.readyState === 'complete') reportHeight();\n  else window.addEventListener('load', reportHeight);\n  new MutationObserver(reportHeight).observe(document.documentElement, { childList: true, subtree: true });\n  setTimeout(reportHeight, 300);\n  setTimeout(reportHeight, 1000);\n})();\n</script>\n</body></html>",
       "source": "```table size=[16,5]\n{\"title\":\"Recent NBA Seasons\",\"columns\":[{\"id\":\"season_year\",\"title\":\"Season\",\"bold\":true},{\"id\":\"games\",\"title\":\"Games\",\"fmt\":\"auto\",\"align\":\"right\"}],\"data\":[{\"season_year\":2024,\"games\":1319},{\"season_year\":2023,\"games\":1318},{\"season_year\":2022,\"games\":1317}],\"compact\":true}\n```",
-      "id": "777d848c-a891-41de-aa9f-77bb72ca758d"
+      "id": "c4cb9b84-a8e8-402b-8e46-14181e801485"
     },
     {
       "type": "text",
@@ -1059,7 +1059,7 @@
     },
     {
       "type": "mviz_pending",
-      "id": "ce66c7fe-7ec5-4cc8-b3dc-7e5055e07251"
+      "id": "ed575025-7c42-467c-9c65-c4900aa377b1"
     },
     {
       "type": "text",
@@ -1069,7 +1069,7 @@
       "type": "mviz_html",
       "content": "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Dashboard</title>\n  <style>*{box-sizing:border-box;margin:0;padding:0}:root{--bg:#FFFFFF;--fg:#1C1E26;--text:#1C1E26;--text-muted:#6B7280;--grid:#ECEDEF;--red:#2563EB;--link:#0777b3;--font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;--font-mono:'JetBrains Mono','Roboto Mono',ui-monospace,monospace}body.theme-dark{--bg:#231f20;--fg:#ffffff;--text:#ffffff;--text-muted:#888888;--grid:#3a3a3a;--red:#bc1200;--link:#0777b3}html,body{width:100%;min-height:100%;font-family:var(--font-family);color:var(--text);font-size:12px;transition:background-color 0.3s,color 0.3s}.dashboard{max-width:720px;margin:0 auto;padding:16px;position:relative;overflow-x:hidden}body.theme-dark .theme-toggle .icon-moon{display:none}body.theme-dark .theme-toggle .icon-sun{display:block}.dashboard-section{margin-bottom:16px}.chart-title{font-family:var(--font-family);font-weight:700;font-size:10px;font-weight:bold;color:var(--text);margin-bottom:4px}.row{display:grid;grid-template-columns:repeat(16,1fr);gap:8px;margin-bottom:8px}@media (max-width:720px){.row{grid-template-columns:repeat(8,1fr)}.row>*{grid-column:span min(var(--col-span,8),8)}}@media (max-width:480px){.row{grid-template-columns:1fr}.row>*{grid-column:span 1}.grid-item{overflow-x:auto;-webkit-overflow-scrolling:touch}}.grid-item{padding:4px;transition:background-color 0.3s}.data-table{width:100%;border-collapse:collapse;font-size:11px}.data-table th{font-family:var(--font-family);font-size:9px;font-weight:bold;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.03em;padding:6px 8px;border-bottom:1px solid var(--text);text-align:left}.data-table td{padding:5px 8px;color:var(--text);border-bottom:1px solid var(--grid)}.data-table.table-compact th,.data-table.table-compact td{padding:4px 6px}.dashboard.dashboard-embed{max-width:100%;padding:8px}@media (max-width:720px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}}@media (max-width:480px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}.dashboard.dashboard-embed .grid-item{overflow-x:visible}}th.sortable{cursor:pointer}th.sortable[data-sort-dir]{color:inherit}.mviz-sort-ind{display:inline-block;min-width:0.9em;margin-left:2px;font-size:9px;opacity:0.7;text-align:left;white-space:nowrap}</style>\n\n<style>\n  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');\n  /* Kill the browser default body margin so the frame hugs its host card. */\n  html, body {\n    margin: 0 !important;\n  }\n  .dashboard {\n    max-width: 100% !important;\n    padding: 20px !important;\n  }\n  .dashboard-section:last-child {\n    margin-bottom: 0 !important;\n    padding-bottom: 0 !important;\n  }\n  .row:last-child {\n    margin-bottom: 0 !important;\n  }\n  html, body { font-size: 14px !important; }\n  .section-title { font-size: 16px !important; font-weight: 600 !important; }\n  .chart-title { font-size: 16px !important; }\n  .big-value { font-size: 30px !important; font-weight: 700 !important; }\n  .label { font-size: 13px !important; }\n  .delta { font-size: 24px !important; }\n  .delta .value { font-size: 24px !important; }\n  .delta .arrow { font-size: 24px !important; }\n  .delta .label { font-size: 13px !important; }\n  .row { gap: 12px !important; margin-bottom: 12px !important; }\n  .alert .message { font-size: 13px !important; }\n  .data-table {\n    border-radius: 10px !important;\n    overflow: hidden !important;\n  }\n  .data-table th {\n    border-bottom-color: var(--grid) !important;\n    font-size: 12px !important;\n    font-weight: 600 !important;\n    padding: 8px 12px !important;\n  }\n  .data-table td {\n    font-size: 12px !important;\n    padding: 8px 12px !important;\n  }\n  .note-content, .text-content { font-size: 13px !important; line-height: 1.5 !important; }\n  .markdown-content { font-size: 14px !important; line-height: 1.6 !important; }\n  .markdown-content h1 { font-size: 28px !important; }\n  .markdown-content h2 { font-size: 22px !important; }\n  .markdown-content h3 { font-size: 18px !important; }\n  .markdown-content p, .markdown-content li { font-size: 14px !important; }\n  .markdown-content code { font-size: 13px !important; }\n  .card, .chart-card, .note, .alert, .text-card {\n    border-radius: 10px !important;\n    box-shadow: none !important;\n  }\n</style>\n</head><body class=\"theme-light\"><div class=\"dashboard dashboard-embed\"><section class=\"dashboard-section\"><div class=\"row\"><div class=\"grid-item\" style=\"--col-span: 16; grid-column: span 16;\"><h3 class=\"chart-title\">2024 Regular Season Team Scoring Leaders</h3><table id=\"mviz-dash-table-2\" class=\"data-table table-compact\" style=\"width: 100%; border-collapse: collapse; font-size: 10px;\"><thead><tr><th class=\"sortable\" data-col=\"0\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;\">Team<span class=\"mviz-sort-ind\"></span></th><th class=\"sortable\" data-col=\"1\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;\">Points<span class=\"mviz-sort-ind\"></span></th></tr></thead><tbody><tr><td data-sort=\"BOS\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>BOS</strong></td><td data-sort=\"10422\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">10.42k</td></tr><tr><td data-sort=\"DEN\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>DEN</strong></td><td data-sort=\"10051\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">10.05k</td></tr><tr><td data-sort=\"OKC\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>OKC</strong></td><td data-sort=\"9964\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">9,964</td></tr><tr><td data-sort=\"MIN\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>MIN</strong></td><td data-sort=\"9818\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">9,818</td></tr><tr><td data-sort=\"NYK\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>NYK</strong></td><td data-sort=\"9721\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">9,721</td></tr></tbody></table></div></div></section></div>\n  <script>(function(){if(window.mvizTableInit) return;function compareCells(a,b){var an=parseFloat(a),bn=parseFloat(b);if(!isNaN(an)&&!isNaN(bn)) return an-bn;return String(a).localeCompare(String(b));}function getSortKey(cell){var v=cell.getAttribute('data-sort');return v!=null?v:cell.textContent.trim();}window.mvizTableInit=function(tableId){var table=document.getElementById(tableId);if(!table) return;var thead=table.tHead;var tbody=table.tBodies[0];if(!thead||!tbody) return;var origRows=Array.prototype.slice.call(tbody.rows);var visibility={};origRows.forEach(function(r,i){visibility[i]=true;});function applyVisibility(){origRows.forEach(function(r,i){r.style.display=visibility[i]?'':'none';});}var sortableHeaders=thead.querySelectorAll('th.sortable');var activeTh=null;var activeState=0;sortableHeaders.forEach(function(th){th.style.cursor='pointer';th.style.userSelect='none';th.addEventListener('click',function(){var colIdx=parseInt(th.getAttribute('data-col'),10);if(isNaN(colIdx)) return;if(activeTh===th){activeState=activeState===1?-1:activeState===-1?0:1;}else{if(activeTh){activeTh.removeAttribute('data-sort-dir');var prevInd=activeTh.querySelector('.mviz-sort-ind');if(prevInd) prevInd.textContent='';}activeTh=th;activeState=1;}var ind=th.querySelector('.mviz-sort-ind');if(activeState===0){th.removeAttribute('data-sort-dir');if(ind) ind.textContent='';activeTh=null;origRows.forEach(function(r){tbody.appendChild(r);});applyVisibility();return;}th.setAttribute('data-sort-dir',activeState===1?'asc':'desc');if(ind) ind.textContent=activeState===1?'▲':'▼';var sorted=origRows.slice().sort(function(a,b){var av=getSortKey(a.cells[colIdx]);var bv=getSortKey(b.cells[colIdx]);var cmp=compareCells(av,bv);return activeState===1?cmp:-cmp;});sorted.forEach(function(r){tbody.appendChild(r);});applyVisibility();});});var container=table.parentElement;var globalInput=container&&container.querySelector('.mviz-filter-global[data-table=\"'+tableId+'\"]');if(globalInput){globalInput.addEventListener('input',function(){var q=globalInput.value.toLowerCase();origRows.forEach(function(r,i){visibility[i]=!q||r.textContent.toLowerCase().indexOf(q)!==-1;});applyVisibility();});}};})();if(window.mvizTableInit) window.mvizTableInit(\"mviz-dash-table-2\");</script>\n\n<script>\n(function() {\n  function reportHeight() {\n    var h = document.body ? document.body.scrollHeight : 0;\n    if (h > 0) parent.postMessage({ type: 'mviz-height', height: h }, '*');\n  }\n  if (document.readyState === 'complete') reportHeight();\n  else window.addEventListener('load', reportHeight);\n  new MutationObserver(reportHeight).observe(document.documentElement, { childList: true, subtree: true });\n  setTimeout(reportHeight, 300);\n  setTimeout(reportHeight, 1000);\n})();\n</script>\n</body></html>",
       "source": "```table size=[16,5]\n{\"title\":\"2024 Regular Season Team Scoring Leaders\",\"columns\":[{\"id\":\"team\",\"title\":\"Team\",\"bold\":true},{\"id\":\"points\",\"title\":\"Points\",\"fmt\":\"auto\",\"align\":\"right\"}],\"data\":[{\"team\":\"BOS\",\"points\":10422},{\"team\":\"DEN\",\"points\":10051},{\"team\":\"OKC\",\"points\":9964},{\"team\":\"MIN\",\"points\":9818},{\"team\":\"NYK\",\"points\":9721}],\"compact\":true}\n```",
-      "id": "ce66c7fe-7ec5-4cc8-b3dc-7e5055e07251"
+      "id": "ed575025-7c42-467c-9c65-c4900aa377b1"
     },
     {
       "type": "text",
@@ -1192,7 +1192,7 @@
     },
     {
       "type": "mviz_pending",
-      "id": "d3791f7d-166f-4004-a85b-9fa7e58477d6"
+      "id": "7192e5a6-0bb2-4b20-a419-6da7237bee63"
     },
     {
       "type": "text",
@@ -1202,7 +1202,7 @@
       "type": "mviz_html",
       "content": "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Dashboard</title>\n  <script src=\"https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js\"></script>\n  <style>*{box-sizing:border-box;margin:0;padding:0}:root{--bg:#FFFFFF;--fg:#1C1E26;--text:#1C1E26;--text-muted:#6B7280;--grid:#ECEDEF;--red:#2563EB;--link:#0777b3;--font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;--font-mono:'JetBrains Mono','Roboto Mono',ui-monospace,monospace}body.theme-dark{--bg:#231f20;--fg:#ffffff;--text:#ffffff;--text-muted:#888888;--grid:#3a3a3a;--red:#bc1200;--link:#0777b3}html,body{width:100%;min-height:100%;font-family:var(--font-family);color:var(--text);font-size:12px;transition:background-color 0.3s,color 0.3s}.dashboard{max-width:720px;margin:0 auto;padding:16px;position:relative;overflow-x:hidden}body.theme-dark .theme-toggle .icon-moon{display:none}body.theme-dark .theme-toggle .icon-sun{display:block}.dashboard-section{margin-bottom:16px}.chart-title{font-family:var(--font-family);font-weight:700;font-size:10px;font-weight:bold;color:var(--text);margin-bottom:4px}.row{display:grid;grid-template-columns:repeat(16,1fr);gap:8px;margin-bottom:8px}@media (max-width:720px){.row{grid-template-columns:repeat(8,1fr)}.row>*{grid-column:span min(var(--col-span,8),8)}}@media (max-width:480px){.row{grid-template-columns:1fr}.row>*{grid-column:span 1}.grid-item{overflow-x:auto;-webkit-overflow-scrolling:touch}}.grid-item{padding:4px;transition:background-color 0.3s}.dashboard.dashboard-embed{max-width:100%;padding:8px}@media (max-width:720px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}}@media (max-width:480px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}.dashboard.dashboard-embed .grid-item{overflow-x:visible}}</style>\n\n<style>\n  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');\n  /* Kill the browser default body margin so the frame hugs its host card. */\n  html, body {\n    margin: 0 !important;\n  }\n  .dashboard {\n    max-width: 100% !important;\n    padding: 20px !important;\n  }\n  .dashboard-section:last-child {\n    margin-bottom: 0 !important;\n    padding-bottom: 0 !important;\n  }\n  .row:last-child {\n    margin-bottom: 0 !important;\n  }\n  html, body { font-size: 14px !important; }\n  .section-title { font-size: 16px !important; font-weight: 600 !important; }\n  .chart-title { font-size: 16px !important; }\n  .big-value { font-size: 30px !important; font-weight: 700 !important; }\n  .label { font-size: 13px !important; }\n  .delta { font-size: 24px !important; }\n  .delta .value { font-size: 24px !important; }\n  .delta .arrow { font-size: 24px !important; }\n  .delta .label { font-size: 13px !important; }\n  .row { gap: 12px !important; margin-bottom: 12px !important; }\n  .alert .message { font-size: 13px !important; }\n  .data-table {\n    border-radius: 10px !important;\n    overflow: hidden !important;\n  }\n  .data-table th {\n    border-bottom-color: var(--grid) !important;\n    font-size: 12px !important;\n    font-weight: 600 !important;\n    padding: 8px 12px !important;\n  }\n  .data-table td {\n    font-size: 12px !important;\n    padding: 8px 12px !important;\n  }\n  .note-content, .text-content { font-size: 13px !important; line-height: 1.5 !important; }\n  .markdown-content { font-size: 14px !important; line-height: 1.6 !important; }\n  .markdown-content h1 { font-size: 28px !important; }\n  .markdown-content h2 { font-size: 22px !important; }\n  .markdown-content h3 { font-size: 18px !important; }\n  .markdown-content p, .markdown-content li { font-size: 14px !important; }\n  .markdown-content code { font-size: 13px !important; }\n  .card, .chart-card, .note, .alert, .text-card {\n    border-radius: 10px !important;\n    box-shadow: none !important;\n  }\n</style>\n</head><body class=\"theme-light\"><div class=\"dashboard dashboard-embed\"><section class=\"dashboard-section\"><div class=\"row\"><div class=\"grid-item\" style=\"--col-span: 8; grid-column: span 8;\"><h3 class=\"chart-title\">Top Teams by Points</h3><div id=\"chart_1\" style=\"width: 100%; height: 360px;\"></div></div></div></section></div>\n  <script>(function(){var chart=echarts.init(document.getElementById('chart_1'),null,{renderer:'svg'});chart.setOption({\"backgroundColor\":\"transparent\",\"animation\":false,\"tooltip\":{\"trigger\":\"axis\",\"axisPointer\":{\"type\":\"shadow\"},\"backgroundColor\":\"#ffffff\",\"borderColor\":\"#d4d4d4\",\"textStyle\":{\"color\":\"#231f20\"}},\"grid\":{\"left\":\"2%\",\"right\":\"2%\",\"top\":\"14%\",\"bottom\":\"8%\",\"containLabel\":true},\"xAxis\":{\"type\":\"category\",\"data\":[\"BOS\",\"DEN\",\"OKC\",\"MIN\",\"NYK\"],\"axisLine\":{\"show\":false},\"axisTick\":{\"show\":false},\"axisLabel\":{\"color\":\"#6a6a6a\",\"interval\":0,\"rotate\":45,\"overflow\":\"truncate\",\"ellipsis\":\"...\",\"width\":100}},\"yAxis\":{\"type\":\"value\",\"axisLine\":{\"show\":false},\"axisTick\":{\"show\":false},\"axisLabel\":{\"color\":\"#6a6a6a\",\"fontSize\":11,\"margin\":10,\"formatter\":function(value){return value.toLocaleString();}},\"splitLine\":{\"lineStyle\":{\"color\":\"#d4d4d4\",\"type\":[2,3],\"opacity\":0.6}}},\"series\":[{\"name\":\"points\",\"type\":\"bar\",\"data\":[10422,10051,9964,9818,9721],\"barMaxWidth\":32,\"itemStyle\":{\"color\":\"#9F7AEA\"},\"label\":{\"show\":true,\"position\":\"top\",\"color\":\"#6a6a6a\",\"fontSize\":10,\"offset\":[0,-2],\"formatter\":function(params){var value=params.value;if(Array.isArray(value)) value=value[1];return value.toLocaleString();}}}]});window.addEventListener('resize',function(){chart.resize();});})();</script>\n\n<script>\n(function() {\n  function reportHeight() {\n    var h = document.body ? document.body.scrollHeight : 0;\n    if (h > 0) parent.postMessage({ type: 'mviz-height', height: h }, '*');\n  }\n  if (document.readyState === 'complete') reportHeight();\n  else window.addEventListener('load', reportHeight);\n  new MutationObserver(reportHeight).observe(document.documentElement, { childList: true, subtree: true });\n  setTimeout(reportHeight, 300);\n  setTimeout(reportHeight, 1000);\n})();\n</script>\n</body></html>",
       "source": "```bar size=[8,12]\n{\"type\":\"bar\",\"title\":\"Top Teams by Points\",\"x\":\"team\",\"y\":\"points\",\"format\":\"num0\",\"data\":[{\"team\":\"BOS\",\"points\":10422},{\"team\":\"DEN\",\"points\":10051},{\"team\":\"OKC\",\"points\":9964},{\"team\":\"MIN\",\"points\":9818},{\"team\":\"NYK\",\"points\":9721}]}\n```",
-      "id": "d3791f7d-166f-4004-a85b-9fa7e58477d6"
+      "id": "7192e5a6-0bb2-4b20-a419-6da7237bee63"
     },
     {
       "type": "text",
@@ -1426,7 +1426,7 @@
         "name": "update_context_layer",
         "args": {
           "action": "update",
-          "id": "019f92cb-3042-7605-9867-f216dc7a7fa1",
+          "id": "019f92d6-c808-7d59-9163-296c17613ee1",
           "title": "box_scores to schedule join key",
           "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
           "references": [
@@ -1448,7 +1448,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "update",
-                "id": "019f92cb-3042-7605-9867-f216dc7a7fa1",
+                "id": "019f92d6-c808-7d59-9163-296c17613ee1",
                 "title": "box_scores to schedule join key",
                 "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
                 "references": [
@@ -1488,7 +1488,7 @@
         "name": "update_context_layer",
         "args": {
           "action": "delete",
-          "id": "019f92cb-3042-7605-9867-f216dc7a7fa1"
+          "id": "019f92d6-c808-7d59-9163-296c17613ee1"
         }
       }
     },
@@ -1504,7 +1504,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "delete",
-                "id": "019f92cb-3042-7605-9867-f216dc7a7fa1"
+                "id": "019f92d6-c808-7d59-9163-296c17613ee1"
               }
             }
           ]
@@ -1624,7 +1624,7 @@
               "database:nba_box_scores_v2.main.schedule"
             ]
           },
-          "resultText": "Created fragment \"box_scores to schedule join key\" (id 019f92cb-3042-7605-9867-f216dc7a7fa1).",
+          "resultText": "Created fragment \"box_scores to schedule join key\" (id 019f92d6-c808-7d59-9163-296c17613ee1).",
           "isError": false
         }
       ],
@@ -1731,7 +1731,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_save_1",
-              "content": "Created fragment \"box_scores to schedule join key\" (id 019f92cb-3042-7605-9867-f216dc7a7fa1)."
+              "content": "Created fragment \"box_scores to schedule join key\" (id 019f92d6-c808-7d59-9163-296c17613ee1)."
             }
           ]
         },
@@ -1814,7 +1814,7 @@
             "query": "full-game team scoring grain double count",
             "reference": "database:nba_box_scores_v2.main.box_scores"
           },
-          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92cb-3042-7605-9867-f216dc7a7fa1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
+          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92d6-c808-7d59-9163-296c17613ee1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
           "isError": false
         },
         {
@@ -1828,7 +1828,7 @@
               "database:nba_box_scores_v2.main.box_scores"
             ]
           },
-          "resultText": "Created fragment \"full-game team scoring grain\" (id 019f92cb-30da-7926-be87-d3c52a1f8203).",
+          "resultText": "Created fragment \"full-game team scoring grain\" (id 019f92d6-c898-7fb9-836e-fc394b035ac8).",
           "isError": false
         }
       ],
@@ -1853,7 +1853,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_lookup_grain",
-              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92cb-3042-7605-9867-f216dc7a7fa1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
+              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92d6-c808-7d59-9163-296c17613ee1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
             }
           ]
         },
@@ -1905,7 +1905,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_save_grain",
-              "content": "Created fragment \"full-game team scoring grain\" (id 019f92cb-30da-7926-be87-d3c52a1f8203)."
+              "content": "Created fragment \"full-game team scoring grain\" (id 019f92d6-c898-7fb9-836e-fc394b035ac8)."
             }
           ]
         },
@@ -1957,7 +1957,7 @@
             "query": "full-game team scoring grain",
             "reference": "database:nba_box_scores_v2.main.box_scores"
           },
-          "resultText": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f92cb-30da-7926-be87-d3c52a1f8203\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals.",
+          "resultText": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f92d6-c898-7fb9-836e-fc394b035ac8\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals.",
           "isError": false
         }
       ],
@@ -1982,7 +1982,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_lookup_2",
-              "content": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f92cb-30da-7926-be87-d3c52a1f8203\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals."
+              "content": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f92d6-c898-7fb9-836e-fc394b035ac8\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals."
             }
           ]
         },
@@ -2118,7 +2118,7 @@
           "args": {
             "query": "FullGame join"
           },
-          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92cb-3042-7605-9867-f216dc7a7fa1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
+          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92d6-c808-7d59-9163-296c17613ee1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
           "isError": false
         },
         {
@@ -2126,7 +2126,7 @@
           "name": "update_context_layer",
           "args": {
             "action": "update",
-            "id": "019f92cb-3042-7605-9867-f216dc7a7fa1",
+            "id": "019f92d6-c808-7d59-9163-296c17613ee1",
             "title": "box_scores to schedule join key",
             "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
             "references": [
@@ -2142,9 +2142,9 @@
           "name": "update_context_layer",
           "args": {
             "action": "delete",
-            "id": "019f92cb-3042-7605-9867-f216dc7a7fa1"
+            "id": "019f92d6-c808-7d59-9163-296c17613ee1"
           },
-          "resultText": "Deleted fragment 019f92cb-3042-7605-9867-f216dc7a7fa1.",
+          "resultText": "Deleted fragment 019f92d6-c808-7d59-9163-296c17613ee1.",
           "isError": false
         }
       ],
@@ -2168,7 +2168,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_lookup_3",
-              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92cb-3042-7605-9867-f216dc7a7fa1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
+              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92d6-c808-7d59-9163-296c17613ee1\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
             }
           ]
         },
@@ -2181,7 +2181,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "update",
-                "id": "019f92cb-3042-7605-9867-f216dc7a7fa1",
+                "id": "019f92d6-c808-7d59-9163-296c17613ee1",
                 "title": "box_scores to schedule join key",
                 "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
                 "references": [
@@ -2211,7 +2211,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "delete",
-                "id": "019f92cb-3042-7605-9867-f216dc7a7fa1"
+                "id": "019f92d6-c808-7d59-9163-296c17613ee1"
               }
             }
           ]
@@ -2222,7 +2222,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_delete_1",
-              "content": "Deleted fragment 019f92cb-3042-7605-9867-f216dc7a7fa1."
+              "content": "Deleted fragment 019f92d6-c808-7d59-9163-296c17613ee1."
             }
           ]
         },

--- a/projects/data-chat-mini/reports/demo-validation/latest.json
+++ b/projects/data-chat-mini/reports/demo-validation/latest.json
@@ -1,9 +1,9 @@
 {
-  "runId": "2026-07-24T05-57-52-667Z-mock",
+  "runId": "2026-07-24T06-11-12-391Z-mock",
   "mode": "mock",
   "dataset": "nba_box_scores_v2",
-  "startedAt": "2026-07-24T05:57:52.667Z",
-  "completedAt": "2026-07-24T05:57:52.822Z",
+  "startedAt": "2026-07-24T06:11:12.391Z",
+  "completedAt": "2026-07-24T06:11:12.545Z",
   "assertions": [
     {
       "name": "database selection lists canonical dataset",
@@ -135,7 +135,7 @@
       "name": "context query/update/delete lifecycle succeeds",
       "pass": true,
       "severity": "P2",
-      "detail": "context services: query_context_layer:1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92b3-9da0-7542-922b-2405716cf7f0\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment \"box_scores to schedule join key\". | update_context_layer:Deleted fragment 019f92b3-9da0-7542-922b-2405716cf7f0."
+      "detail": "context services: query_context_layer:1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92bf-d18b-726a-99d2-e4b39baac1ba\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment \"box_scores to schedule join key\". | update_context_layer:Deleted fragment 019f92bf-d18b-726a-99d2-e4b39baac1ba."
     },
     {
       "name": "presenter reset clears local conversations and context",
@@ -816,7 +816,7 @@
     },
     {
       "type": "mviz_pending",
-      "id": "41a31c03-8c7a-4aa5-9d59-e987a7a79509"
+      "id": "3971d69d-670a-4270-a91c-56f78f92ce79"
     },
     {
       "type": "text",
@@ -826,7 +826,7 @@
       "type": "mviz_html",
       "content": "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Dashboard</title>\n  <style>*{box-sizing:border-box;margin:0;padding:0}:root{--bg:#FFFFFF;--fg:#1C1E26;--text:#1C1E26;--text-muted:#6B7280;--grid:#ECEDEF;--red:#2563EB;--link:#0777b3;--font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;--font-mono:'JetBrains Mono','Roboto Mono',ui-monospace,monospace}body.theme-dark{--bg:#231f20;--fg:#ffffff;--text:#ffffff;--text-muted:#888888;--grid:#3a3a3a;--red:#bc1200;--link:#0777b3}html,body{width:100%;min-height:100%;font-family:var(--font-family);color:var(--text);font-size:12px;transition:background-color 0.3s,color 0.3s}.dashboard{max-width:720px;margin:0 auto;padding:16px;position:relative;overflow-x:hidden}body.theme-dark .theme-toggle .icon-moon{display:none}body.theme-dark .theme-toggle .icon-sun{display:block}.dashboard-section{margin-bottom:16px}.chart-title{font-family:var(--font-family);font-weight:700;font-size:10px;font-weight:bold;color:var(--text);margin-bottom:4px}.row{display:grid;grid-template-columns:repeat(16,1fr);gap:8px;margin-bottom:8px}@media (max-width:720px){.row{grid-template-columns:repeat(8,1fr)}.row>*{grid-column:span min(var(--col-span,8),8)}}@media (max-width:480px){.row{grid-template-columns:1fr}.row>*{grid-column:span 1}.grid-item{overflow-x:auto;-webkit-overflow-scrolling:touch}}.grid-item{padding:4px;transition:background-color 0.3s}.data-table{width:100%;border-collapse:collapse;font-size:11px}.data-table th{font-family:var(--font-family);font-size:9px;font-weight:bold;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.03em;padding:6px 8px;border-bottom:1px solid var(--text);text-align:left}.data-table td{padding:5px 8px;color:var(--text);border-bottom:1px solid var(--grid)}.data-table.table-compact th,.data-table.table-compact td{padding:4px 6px}.dashboard.dashboard-embed{max-width:100%;padding:8px}@media (max-width:720px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}}@media (max-width:480px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}.dashboard.dashboard-embed .grid-item{overflow-x:visible}}th.sortable{cursor:pointer}th.sortable[data-sort-dir]{color:inherit}.mviz-sort-ind{display:inline-block;min-width:0.9em;margin-left:2px;font-size:9px;opacity:0.7;text-align:left;white-space:nowrap}</style>\n\n<style>\n  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');\n  /* Kill the browser default body margin so the frame hugs its host card. */\n  html, body {\n    margin: 0 !important;\n  }\n  .dashboard {\n    max-width: 100% !important;\n    padding: 20px !important;\n  }\n  .dashboard-section:last-child {\n    margin-bottom: 0 !important;\n    padding-bottom: 0 !important;\n  }\n  .row:last-child {\n    margin-bottom: 0 !important;\n  }\n  html, body { font-size: 14px !important; }\n  .section-title { font-size: 16px !important; font-weight: 600 !important; }\n  .chart-title { font-size: 16px !important; }\n  .big-value { font-size: 30px !important; font-weight: 700 !important; }\n  .label { font-size: 13px !important; }\n  .delta { font-size: 24px !important; }\n  .delta .value { font-size: 24px !important; }\n  .delta .arrow { font-size: 24px !important; }\n  .delta .label { font-size: 13px !important; }\n  .row { gap: 12px !important; margin-bottom: 12px !important; }\n  .alert .message { font-size: 13px !important; }\n  .data-table {\n    border-radius: 10px !important;\n    overflow: hidden !important;\n  }\n  .data-table th {\n    border-bottom-color: var(--grid) !important;\n    font-size: 12px !important;\n    font-weight: 600 !important;\n    padding: 8px 12px !important;\n  }\n  .data-table td {\n    font-size: 12px !important;\n    padding: 8px 12px !important;\n  }\n  .note-content, .text-content { font-size: 13px !important; line-height: 1.5 !important; }\n  .markdown-content { font-size: 14px !important; line-height: 1.6 !important; }\n  .markdown-content h1 { font-size: 28px !important; }\n  .markdown-content h2 { font-size: 22px !important; }\n  .markdown-content h3 { font-size: 18px !important; }\n  .markdown-content p, .markdown-content li { font-size: 14px !important; }\n  .markdown-content code { font-size: 13px !important; }\n  .card, .chart-card, .note, .alert, .text-card {\n    border-radius: 10px !important;\n    box-shadow: none !important;\n  }\n</style>\n</head><body class=\"theme-light\"><div class=\"dashboard dashboard-embed\"><section class=\"dashboard-section\"><div class=\"row\"><div class=\"grid-item\" style=\"--col-span: 16; grid-column: span 16;\"><h3 class=\"chart-title\">Recent NBA Seasons</h3><table id=\"mviz-dash-table-1\" class=\"data-table table-compact\" style=\"width: 100%; border-collapse: collapse; font-size: 10px;\"><thead><tr><th class=\"sortable\" data-col=\"0\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;\">Season<span class=\"mviz-sort-ind\"></span></th><th class=\"sortable\" data-col=\"1\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;\">Games<span class=\"mviz-sort-ind\"></span></th></tr></thead><tbody><tr><td data-sort=\"2024\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>2,024</strong></td><td data-sort=\"1319\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">1,319</td></tr><tr><td data-sort=\"2023\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>2,023</strong></td><td data-sort=\"1318\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">1,318</td></tr><tr><td data-sort=\"2022\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>2,022</strong></td><td data-sort=\"1317\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">1,317</td></tr></tbody></table></div></div></section></div>\n  <script>(function(){if(window.mvizTableInit) return;function compareCells(a,b){var an=parseFloat(a),bn=parseFloat(b);if(!isNaN(an)&&!isNaN(bn)) return an-bn;return String(a).localeCompare(String(b));}function getSortKey(cell){var v=cell.getAttribute('data-sort');return v!=null?v:cell.textContent.trim();}window.mvizTableInit=function(tableId){var table=document.getElementById(tableId);if(!table) return;var thead=table.tHead;var tbody=table.tBodies[0];if(!thead||!tbody) return;var origRows=Array.prototype.slice.call(tbody.rows);var visibility={};origRows.forEach(function(r,i){visibility[i]=true;});function applyVisibility(){origRows.forEach(function(r,i){r.style.display=visibility[i]?'':'none';});}var sortableHeaders=thead.querySelectorAll('th.sortable');var activeTh=null;var activeState=0;sortableHeaders.forEach(function(th){th.style.cursor='pointer';th.style.userSelect='none';th.addEventListener('click',function(){var colIdx=parseInt(th.getAttribute('data-col'),10);if(isNaN(colIdx)) return;if(activeTh===th){activeState=activeState===1?-1:activeState===-1?0:1;}else{if(activeTh){activeTh.removeAttribute('data-sort-dir');var prevInd=activeTh.querySelector('.mviz-sort-ind');if(prevInd) prevInd.textContent='';}activeTh=th;activeState=1;}var ind=th.querySelector('.mviz-sort-ind');if(activeState===0){th.removeAttribute('data-sort-dir');if(ind) ind.textContent='';activeTh=null;origRows.forEach(function(r){tbody.appendChild(r);});applyVisibility();return;}th.setAttribute('data-sort-dir',activeState===1?'asc':'desc');if(ind) ind.textContent=activeState===1?'▲':'▼';var sorted=origRows.slice().sort(function(a,b){var av=getSortKey(a.cells[colIdx]);var bv=getSortKey(b.cells[colIdx]);var cmp=compareCells(av,bv);return activeState===1?cmp:-cmp;});sorted.forEach(function(r){tbody.appendChild(r);});applyVisibility();});});var container=table.parentElement;var globalInput=container&&container.querySelector('.mviz-filter-global[data-table=\"'+tableId+'\"]');if(globalInput){globalInput.addEventListener('input',function(){var q=globalInput.value.toLowerCase();origRows.forEach(function(r,i){visibility[i]=!q||r.textContent.toLowerCase().indexOf(q)!==-1;});applyVisibility();});}};})();if(window.mvizTableInit) window.mvizTableInit(\"mviz-dash-table-1\");</script>\n\n<script>\n(function() {\n  function reportHeight() {\n    var h = document.body ? document.body.scrollHeight : 0;\n    if (h > 0) parent.postMessage({ type: 'mviz-height', height: h }, '*');\n  }\n  if (document.readyState === 'complete') reportHeight();\n  else window.addEventListener('load', reportHeight);\n  new MutationObserver(reportHeight).observe(document.documentElement, { childList: true, subtree: true });\n  setTimeout(reportHeight, 300);\n  setTimeout(reportHeight, 1000);\n})();\n</script>\n</body></html>",
       "source": "```table size=[16,5]\n{\"title\":\"Recent NBA Seasons\",\"columns\":[{\"id\":\"season_year\",\"title\":\"Season\",\"bold\":true},{\"id\":\"games\",\"title\":\"Games\",\"fmt\":\"auto\",\"align\":\"right\"}],\"data\":[{\"season_year\":2024,\"games\":1319},{\"season_year\":2023,\"games\":1318},{\"season_year\":2022,\"games\":1317}],\"compact\":true}\n```",
-      "id": "41a31c03-8c7a-4aa5-9d59-e987a7a79509"
+      "id": "3971d69d-670a-4270-a91c-56f78f92ce79"
     },
     {
       "type": "text",
@@ -1059,7 +1059,7 @@
     },
     {
       "type": "mviz_pending",
-      "id": "62dd94c5-7f88-493f-b5f7-57c344918b60"
+      "id": "6dd46e57-b56a-4722-9630-eca95addb7dd"
     },
     {
       "type": "text",
@@ -1069,7 +1069,7 @@
       "type": "mviz_html",
       "content": "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Dashboard</title>\n  <style>*{box-sizing:border-box;margin:0;padding:0}:root{--bg:#FFFFFF;--fg:#1C1E26;--text:#1C1E26;--text-muted:#6B7280;--grid:#ECEDEF;--red:#2563EB;--link:#0777b3;--font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;--font-mono:'JetBrains Mono','Roboto Mono',ui-monospace,monospace}body.theme-dark{--bg:#231f20;--fg:#ffffff;--text:#ffffff;--text-muted:#888888;--grid:#3a3a3a;--red:#bc1200;--link:#0777b3}html,body{width:100%;min-height:100%;font-family:var(--font-family);color:var(--text);font-size:12px;transition:background-color 0.3s,color 0.3s}.dashboard{max-width:720px;margin:0 auto;padding:16px;position:relative;overflow-x:hidden}body.theme-dark .theme-toggle .icon-moon{display:none}body.theme-dark .theme-toggle .icon-sun{display:block}.dashboard-section{margin-bottom:16px}.chart-title{font-family:var(--font-family);font-weight:700;font-size:10px;font-weight:bold;color:var(--text);margin-bottom:4px}.row{display:grid;grid-template-columns:repeat(16,1fr);gap:8px;margin-bottom:8px}@media (max-width:720px){.row{grid-template-columns:repeat(8,1fr)}.row>*{grid-column:span min(var(--col-span,8),8)}}@media (max-width:480px){.row{grid-template-columns:1fr}.row>*{grid-column:span 1}.grid-item{overflow-x:auto;-webkit-overflow-scrolling:touch}}.grid-item{padding:4px;transition:background-color 0.3s}.data-table{width:100%;border-collapse:collapse;font-size:11px}.data-table th{font-family:var(--font-family);font-size:9px;font-weight:bold;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.03em;padding:6px 8px;border-bottom:1px solid var(--text);text-align:left}.data-table td{padding:5px 8px;color:var(--text);border-bottom:1px solid var(--grid)}.data-table.table-compact th,.data-table.table-compact td{padding:4px 6px}.dashboard.dashboard-embed{max-width:100%;padding:8px}@media (max-width:720px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}}@media (max-width:480px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}.dashboard.dashboard-embed .grid-item{overflow-x:visible}}th.sortable{cursor:pointer}th.sortable[data-sort-dir]{color:inherit}.mviz-sort-ind{display:inline-block;min-width:0.9em;margin-left:2px;font-size:9px;opacity:0.7;text-align:left;white-space:nowrap}</style>\n\n<style>\n  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');\n  /* Kill the browser default body margin so the frame hugs its host card. */\n  html, body {\n    margin: 0 !important;\n  }\n  .dashboard {\n    max-width: 100% !important;\n    padding: 20px !important;\n  }\n  .dashboard-section:last-child {\n    margin-bottom: 0 !important;\n    padding-bottom: 0 !important;\n  }\n  .row:last-child {\n    margin-bottom: 0 !important;\n  }\n  html, body { font-size: 14px !important; }\n  .section-title { font-size: 16px !important; font-weight: 600 !important; }\n  .chart-title { font-size: 16px !important; }\n  .big-value { font-size: 30px !important; font-weight: 700 !important; }\n  .label { font-size: 13px !important; }\n  .delta { font-size: 24px !important; }\n  .delta .value { font-size: 24px !important; }\n  .delta .arrow { font-size: 24px !important; }\n  .delta .label { font-size: 13px !important; }\n  .row { gap: 12px !important; margin-bottom: 12px !important; }\n  .alert .message { font-size: 13px !important; }\n  .data-table {\n    border-radius: 10px !important;\n    overflow: hidden !important;\n  }\n  .data-table th {\n    border-bottom-color: var(--grid) !important;\n    font-size: 12px !important;\n    font-weight: 600 !important;\n    padding: 8px 12px !important;\n  }\n  .data-table td {\n    font-size: 12px !important;\n    padding: 8px 12px !important;\n  }\n  .note-content, .text-content { font-size: 13px !important; line-height: 1.5 !important; }\n  .markdown-content { font-size: 14px !important; line-height: 1.6 !important; }\n  .markdown-content h1 { font-size: 28px !important; }\n  .markdown-content h2 { font-size: 22px !important; }\n  .markdown-content h3 { font-size: 18px !important; }\n  .markdown-content p, .markdown-content li { font-size: 14px !important; }\n  .markdown-content code { font-size: 13px !important; }\n  .card, .chart-card, .note, .alert, .text-card {\n    border-radius: 10px !important;\n    box-shadow: none !important;\n  }\n</style>\n</head><body class=\"theme-light\"><div class=\"dashboard dashboard-embed\"><section class=\"dashboard-section\"><div class=\"row\"><div class=\"grid-item\" style=\"--col-span: 16; grid-column: span 16;\"><h3 class=\"chart-title\">2024 Regular Season Team Scoring Leaders</h3><table id=\"mviz-dash-table-2\" class=\"data-table table-compact\" style=\"width: 100%; border-collapse: collapse; font-size: 10px;\"><thead><tr><th class=\"sortable\" data-col=\"0\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;\">Team<span class=\"mviz-sort-ind\"></span></th><th class=\"sortable\" data-col=\"1\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;\">Points<span class=\"mviz-sort-ind\"></span></th></tr></thead><tbody><tr><td data-sort=\"BOS\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>BOS</strong></td><td data-sort=\"10422\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">10.42k</td></tr><tr><td data-sort=\"DEN\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>DEN</strong></td><td data-sort=\"10051\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">10.05k</td></tr><tr><td data-sort=\"OKC\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>OKC</strong></td><td data-sort=\"9964\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">9,964</td></tr><tr><td data-sort=\"MIN\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>MIN</strong></td><td data-sort=\"9818\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">9,818</td></tr><tr><td data-sort=\"NYK\" style=\"text-align: left; padding: 3px 6px; font-size: 10px;  \"><strong>NYK</strong></td><td data-sort=\"9721\" style=\"text-align: right; padding: 3px 6px; font-size: 10px;  \">9,721</td></tr></tbody></table></div></div></section></div>\n  <script>(function(){if(window.mvizTableInit) return;function compareCells(a,b){var an=parseFloat(a),bn=parseFloat(b);if(!isNaN(an)&&!isNaN(bn)) return an-bn;return String(a).localeCompare(String(b));}function getSortKey(cell){var v=cell.getAttribute('data-sort');return v!=null?v:cell.textContent.trim();}window.mvizTableInit=function(tableId){var table=document.getElementById(tableId);if(!table) return;var thead=table.tHead;var tbody=table.tBodies[0];if(!thead||!tbody) return;var origRows=Array.prototype.slice.call(tbody.rows);var visibility={};origRows.forEach(function(r,i){visibility[i]=true;});function applyVisibility(){origRows.forEach(function(r,i){r.style.display=visibility[i]?'':'none';});}var sortableHeaders=thead.querySelectorAll('th.sortable');var activeTh=null;var activeState=0;sortableHeaders.forEach(function(th){th.style.cursor='pointer';th.style.userSelect='none';th.addEventListener('click',function(){var colIdx=parseInt(th.getAttribute('data-col'),10);if(isNaN(colIdx)) return;if(activeTh===th){activeState=activeState===1?-1:activeState===-1?0:1;}else{if(activeTh){activeTh.removeAttribute('data-sort-dir');var prevInd=activeTh.querySelector('.mviz-sort-ind');if(prevInd) prevInd.textContent='';}activeTh=th;activeState=1;}var ind=th.querySelector('.mviz-sort-ind');if(activeState===0){th.removeAttribute('data-sort-dir');if(ind) ind.textContent='';activeTh=null;origRows.forEach(function(r){tbody.appendChild(r);});applyVisibility();return;}th.setAttribute('data-sort-dir',activeState===1?'asc':'desc');if(ind) ind.textContent=activeState===1?'▲':'▼';var sorted=origRows.slice().sort(function(a,b){var av=getSortKey(a.cells[colIdx]);var bv=getSortKey(b.cells[colIdx]);var cmp=compareCells(av,bv);return activeState===1?cmp:-cmp;});sorted.forEach(function(r){tbody.appendChild(r);});applyVisibility();});});var container=table.parentElement;var globalInput=container&&container.querySelector('.mviz-filter-global[data-table=\"'+tableId+'\"]');if(globalInput){globalInput.addEventListener('input',function(){var q=globalInput.value.toLowerCase();origRows.forEach(function(r,i){visibility[i]=!q||r.textContent.toLowerCase().indexOf(q)!==-1;});applyVisibility();});}};})();if(window.mvizTableInit) window.mvizTableInit(\"mviz-dash-table-2\");</script>\n\n<script>\n(function() {\n  function reportHeight() {\n    var h = document.body ? document.body.scrollHeight : 0;\n    if (h > 0) parent.postMessage({ type: 'mviz-height', height: h }, '*');\n  }\n  if (document.readyState === 'complete') reportHeight();\n  else window.addEventListener('load', reportHeight);\n  new MutationObserver(reportHeight).observe(document.documentElement, { childList: true, subtree: true });\n  setTimeout(reportHeight, 300);\n  setTimeout(reportHeight, 1000);\n})();\n</script>\n</body></html>",
       "source": "```table size=[16,5]\n{\"title\":\"2024 Regular Season Team Scoring Leaders\",\"columns\":[{\"id\":\"team\",\"title\":\"Team\",\"bold\":true},{\"id\":\"points\",\"title\":\"Points\",\"fmt\":\"auto\",\"align\":\"right\"}],\"data\":[{\"team\":\"BOS\",\"points\":10422},{\"team\":\"DEN\",\"points\":10051},{\"team\":\"OKC\",\"points\":9964},{\"team\":\"MIN\",\"points\":9818},{\"team\":\"NYK\",\"points\":9721}],\"compact\":true}\n```",
-      "id": "62dd94c5-7f88-493f-b5f7-57c344918b60"
+      "id": "6dd46e57-b56a-4722-9630-eca95addb7dd"
     },
     {
       "type": "text",
@@ -1192,7 +1192,7 @@
     },
     {
       "type": "mviz_pending",
-      "id": "90397b3e-0f89-4592-9a8b-8bc67785b25a"
+      "id": "0d678c36-a5d0-4043-bd31-61a4be89cb68"
     },
     {
       "type": "text",
@@ -1202,7 +1202,7 @@
       "type": "mviz_html",
       "content": "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Dashboard</title>\n  <script src=\"https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js\"></script>\n  <style>*{box-sizing:border-box;margin:0;padding:0}:root{--bg:#FFFFFF;--fg:#1C1E26;--text:#1C1E26;--text-muted:#6B7280;--grid:#ECEDEF;--red:#2563EB;--link:#0777b3;--font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;--font-mono:'JetBrains Mono','Roboto Mono',ui-monospace,monospace}body.theme-dark{--bg:#231f20;--fg:#ffffff;--text:#ffffff;--text-muted:#888888;--grid:#3a3a3a;--red:#bc1200;--link:#0777b3}html,body{width:100%;min-height:100%;font-family:var(--font-family);color:var(--text);font-size:12px;transition:background-color 0.3s,color 0.3s}.dashboard{max-width:720px;margin:0 auto;padding:16px;position:relative;overflow-x:hidden}body.theme-dark .theme-toggle .icon-moon{display:none}body.theme-dark .theme-toggle .icon-sun{display:block}.dashboard-section{margin-bottom:16px}.chart-title{font-family:var(--font-family);font-weight:700;font-size:10px;font-weight:bold;color:var(--text);margin-bottom:4px}.row{display:grid;grid-template-columns:repeat(16,1fr);gap:8px;margin-bottom:8px}@media (max-width:720px){.row{grid-template-columns:repeat(8,1fr)}.row>*{grid-column:span min(var(--col-span,8),8)}}@media (max-width:480px){.row{grid-template-columns:1fr}.row>*{grid-column:span 1}.grid-item{overflow-x:auto;-webkit-overflow-scrolling:touch}}.grid-item{padding:4px;transition:background-color 0.3s}.dashboard.dashboard-embed{max-width:100%;padding:8px}@media (max-width:720px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}}@media (max-width:480px){.dashboard.dashboard-embed .row{grid-template-columns:repeat(16,1fr)}.dashboard.dashboard-embed .row>*{grid-column:span var(--col-span,8)}.dashboard.dashboard-embed .grid-item{overflow-x:visible}}</style>\n\n<style>\n  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');\n  /* Kill the browser default body margin so the frame hugs its host card. */\n  html, body {\n    margin: 0 !important;\n  }\n  .dashboard {\n    max-width: 100% !important;\n    padding: 20px !important;\n  }\n  .dashboard-section:last-child {\n    margin-bottom: 0 !important;\n    padding-bottom: 0 !important;\n  }\n  .row:last-child {\n    margin-bottom: 0 !important;\n  }\n  html, body { font-size: 14px !important; }\n  .section-title { font-size: 16px !important; font-weight: 600 !important; }\n  .chart-title { font-size: 16px !important; }\n  .big-value { font-size: 30px !important; font-weight: 700 !important; }\n  .label { font-size: 13px !important; }\n  .delta { font-size: 24px !important; }\n  .delta .value { font-size: 24px !important; }\n  .delta .arrow { font-size: 24px !important; }\n  .delta .label { font-size: 13px !important; }\n  .row { gap: 12px !important; margin-bottom: 12px !important; }\n  .alert .message { font-size: 13px !important; }\n  .data-table {\n    border-radius: 10px !important;\n    overflow: hidden !important;\n  }\n  .data-table th {\n    border-bottom-color: var(--grid) !important;\n    font-size: 12px !important;\n    font-weight: 600 !important;\n    padding: 8px 12px !important;\n  }\n  .data-table td {\n    font-size: 12px !important;\n    padding: 8px 12px !important;\n  }\n  .note-content, .text-content { font-size: 13px !important; line-height: 1.5 !important; }\n  .markdown-content { font-size: 14px !important; line-height: 1.6 !important; }\n  .markdown-content h1 { font-size: 28px !important; }\n  .markdown-content h2 { font-size: 22px !important; }\n  .markdown-content h3 { font-size: 18px !important; }\n  .markdown-content p, .markdown-content li { font-size: 14px !important; }\n  .markdown-content code { font-size: 13px !important; }\n  .card, .chart-card, .note, .alert, .text-card {\n    border-radius: 10px !important;\n    box-shadow: none !important;\n  }\n</style>\n</head><body class=\"theme-light\"><div class=\"dashboard dashboard-embed\"><section class=\"dashboard-section\"><div class=\"row\"><div class=\"grid-item\" style=\"--col-span: 8; grid-column: span 8;\"><h3 class=\"chart-title\">Top Teams by Points</h3><div id=\"chart_1\" style=\"width: 100%; height: 360px;\"></div></div></div></section></div>\n  <script>(function(){var chart=echarts.init(document.getElementById('chart_1'),null,{renderer:'svg'});chart.setOption({\"backgroundColor\":\"transparent\",\"animation\":false,\"tooltip\":{\"trigger\":\"axis\",\"axisPointer\":{\"type\":\"shadow\"},\"backgroundColor\":\"#ffffff\",\"borderColor\":\"#d4d4d4\",\"textStyle\":{\"color\":\"#231f20\"}},\"grid\":{\"left\":\"2%\",\"right\":\"2%\",\"top\":\"14%\",\"bottom\":\"8%\",\"containLabel\":true},\"xAxis\":{\"type\":\"category\",\"data\":[\"BOS\",\"DEN\",\"OKC\",\"MIN\",\"NYK\"],\"axisLine\":{\"show\":false},\"axisTick\":{\"show\":false},\"axisLabel\":{\"color\":\"#6a6a6a\",\"interval\":0,\"rotate\":45,\"overflow\":\"truncate\",\"ellipsis\":\"...\",\"width\":100}},\"yAxis\":{\"type\":\"value\",\"axisLine\":{\"show\":false},\"axisTick\":{\"show\":false},\"axisLabel\":{\"color\":\"#6a6a6a\",\"fontSize\":11,\"margin\":10,\"formatter\":function(value){return value.toLocaleString();}},\"splitLine\":{\"lineStyle\":{\"color\":\"#d4d4d4\",\"type\":[2,3],\"opacity\":0.6}}},\"series\":[{\"name\":\"points\",\"type\":\"bar\",\"data\":[10422,10051,9964,9818,9721],\"barMaxWidth\":32,\"itemStyle\":{\"color\":\"#9F7AEA\"},\"label\":{\"show\":true,\"position\":\"top\",\"color\":\"#6a6a6a\",\"fontSize\":10,\"offset\":[0,-2],\"formatter\":function(params){var value=params.value;if(Array.isArray(value)) value=value[1];return value.toLocaleString();}}}]});window.addEventListener('resize',function(){chart.resize();});})();</script>\n\n<script>\n(function() {\n  function reportHeight() {\n    var h = document.body ? document.body.scrollHeight : 0;\n    if (h > 0) parent.postMessage({ type: 'mviz-height', height: h }, '*');\n  }\n  if (document.readyState === 'complete') reportHeight();\n  else window.addEventListener('load', reportHeight);\n  new MutationObserver(reportHeight).observe(document.documentElement, { childList: true, subtree: true });\n  setTimeout(reportHeight, 300);\n  setTimeout(reportHeight, 1000);\n})();\n</script>\n</body></html>",
       "source": "```bar size=[8,12]\n{\"type\":\"bar\",\"title\":\"Top Teams by Points\",\"x\":\"team\",\"y\":\"points\",\"format\":\"num0\",\"data\":[{\"team\":\"BOS\",\"points\":10422},{\"team\":\"DEN\",\"points\":10051},{\"team\":\"OKC\",\"points\":9964},{\"team\":\"MIN\",\"points\":9818},{\"team\":\"NYK\",\"points\":9721}]}\n```",
-      "id": "90397b3e-0f89-4592-9a8b-8bc67785b25a"
+      "id": "0d678c36-a5d0-4043-bd31-61a4be89cb68"
     },
     {
       "type": "text",
@@ -1426,7 +1426,7 @@
         "name": "update_context_layer",
         "args": {
           "action": "update",
-          "id": "019f92b3-9da0-7542-922b-2405716cf7f0",
+          "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba",
           "title": "box_scores to schedule join key",
           "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
           "references": [
@@ -1448,7 +1448,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "update",
-                "id": "019f92b3-9da0-7542-922b-2405716cf7f0",
+                "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba",
                 "title": "box_scores to schedule join key",
                 "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
                 "references": [
@@ -1488,7 +1488,7 @@
         "name": "update_context_layer",
         "args": {
           "action": "delete",
-          "id": "019f92b3-9da0-7542-922b-2405716cf7f0"
+          "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba"
         }
       }
     },
@@ -1504,7 +1504,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "delete",
-                "id": "019f92b3-9da0-7542-922b-2405716cf7f0"
+                "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba"
               }
             }
           ]
@@ -1624,7 +1624,7 @@
               "database:nba_box_scores_v2.main.schedule"
             ]
           },
-          "resultText": "Created fragment \"box_scores to schedule join key\" (id 019f92b3-9da0-7542-922b-2405716cf7f0).",
+          "resultText": "Created fragment \"box_scores to schedule join key\" (id 019f92bf-d18b-726a-99d2-e4b39baac1ba).",
           "isError": false
         }
       ],
@@ -1731,7 +1731,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_save_1",
-              "content": "Created fragment \"box_scores to schedule join key\" (id 019f92b3-9da0-7542-922b-2405716cf7f0)."
+              "content": "Created fragment \"box_scores to schedule join key\" (id 019f92bf-d18b-726a-99d2-e4b39baac1ba)."
             }
           ]
         },
@@ -1814,7 +1814,7 @@
             "query": "full-game team scoring grain double count",
             "reference": "database:nba_box_scores_v2.main.box_scores"
           },
-          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92b3-9da0-7542-922b-2405716cf7f0\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
+          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92bf-d18b-726a-99d2-e4b39baac1ba\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
           "isError": false
         },
         {
@@ -1828,7 +1828,7 @@
               "database:nba_box_scores_v2.main.box_scores"
             ]
           },
-          "resultText": "Created fragment \"full-game team scoring grain\" (id 019f92b3-9e30-71f8-a674-2eaa2b79306f).",
+          "resultText": "Created fragment \"full-game team scoring grain\" (id 019f92bf-d21a-7482-890f-b9cde3f24b51).",
           "isError": false
         }
       ],
@@ -1853,7 +1853,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_lookup_grain",
-              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92b3-9da0-7542-922b-2405716cf7f0\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
+              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92bf-d18b-726a-99d2-e4b39baac1ba\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
             }
           ]
         },
@@ -1905,7 +1905,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_save_grain",
-              "content": "Created fragment \"full-game team scoring grain\" (id 019f92b3-9e30-71f8-a674-2eaa2b79306f)."
+              "content": "Created fragment \"full-game team scoring grain\" (id 019f92bf-d21a-7482-890f-b9cde3f24b51)."
             }
           ]
         },
@@ -1957,7 +1957,7 @@
             "query": "full-game team scoring grain",
             "reference": "database:nba_box_scores_v2.main.box_scores"
           },
-          "resultText": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f92b3-9e30-71f8-a674-2eaa2b79306f\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals.",
+          "resultText": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f92bf-d21a-7482-890f-b9cde3f24b51\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals.",
           "isError": false
         }
       ],
@@ -1982,7 +1982,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_lookup_2",
-              "content": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f92b3-9e30-71f8-a674-2eaa2b79306f\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals."
+              "content": "1 context fragment(s):\n\n### full-game team scoring grain\nid: 019f92bf-d21a-7482-890f-b9cde3f24b51\nreferences: database:nba_box_scores_v2.main.box_scores\n\nFor team scoring totals in nba_box_scores_v2.main.box_scores, filter period = FullGame and player_name IS NULL before summing points. This avoids double-counting player rows when the question asks for team-level totals."
             }
           ]
         },
@@ -2118,7 +2118,7 @@
           "args": {
             "query": "FullGame join"
           },
-          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92b3-9da0-7542-922b-2405716cf7f0\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
+          "resultText": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92bf-d18b-726a-99d2-e4b39baac1ba\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats.",
           "isError": false
         },
         {
@@ -2126,7 +2126,7 @@
           "name": "update_context_layer",
           "args": {
             "action": "update",
-            "id": "019f92b3-9da0-7542-922b-2405716cf7f0",
+            "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba",
             "title": "box_scores to schedule join key",
             "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
             "references": [
@@ -2142,9 +2142,9 @@
           "name": "update_context_layer",
           "args": {
             "action": "delete",
-            "id": "019f92b3-9da0-7542-922b-2405716cf7f0"
+            "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba"
           },
-          "resultText": "Deleted fragment 019f92b3-9da0-7542-922b-2405716cf7f0.",
+          "resultText": "Deleted fragment 019f92bf-d18b-726a-99d2-e4b39baac1ba.",
           "isError": false
         }
       ],
@@ -2168,7 +2168,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_lookup_3",
-              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92b3-9da0-7542-922b-2405716cf7f0\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
+              "content": "1 context fragment(s):\n\n### box_scores to schedule join key\nid: 019f92bf-d18b-726a-99d2-e4b39baac1ba\nreferences: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule\n\nJoin nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats."
             }
           ]
         },
@@ -2181,7 +2181,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "update",
-                "id": "019f92b3-9da0-7542-922b-2405716cf7f0",
+                "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba",
                 "title": "box_scores to schedule join key",
                 "content": "Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Filter box_scores.period = FullGame for full-game stats before aggregating.",
                 "references": [
@@ -2211,7 +2211,7 @@
               "name": "update_context_layer",
               "input": {
                 "action": "delete",
-                "id": "019f92b3-9da0-7542-922b-2405716cf7f0"
+                "id": "019f92bf-d18b-726a-99d2-e4b39baac1ba"
               }
             }
           ]
@@ -2222,7 +2222,7 @@
             {
               "type": "tool_result",
               "tool_use_id": "ctx_delete_1",
-              "content": "Deleted fragment 019f92b3-9da0-7542-922b-2405716cf7f0."
+              "content": "Deleted fragment 019f92bf-d18b-726a-99d2-e4b39baac1ba."
             }
           ]
         },

--- a/projects/data-chat-mini/reports/demo-validation/latest.md
+++ b/projects/data-chat-mini/reports/demo-validation/latest.md
@@ -1,9 +1,9 @@
 # Demo Validation Report
 
-- Run: 2026-07-24T04-42-10-506Z-mock
+- Run: 2026-07-24T05-57-52-667Z-mock
 - Mode: mock
 - Dataset: nba_box_scores_v2
-- Completed: 2026-07-24T04:42:10.660Z
+- Completed: 2026-07-24T05:57:52.822Z
 - Assertions: 23/23
 - Unresolved P1/P2: 0
 
@@ -55,10 +55,10 @@ SELECT team, points FROM team_rows ORDER BY points DESC LIMIT 5
 - PASS [P2] context query/update/delete lifecycle succeeds: context services: query_context_layer:1 context fragment(s):
 
 ### box_scores to schedule join key
-id: 019f926e-4ecf-78b0-a3af-bc8ded6190ee
+id: 019f92b3-9da0-7542-922b-2405716cf7f0
 references: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule
 
-Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment "box_scores to schedule join key". | update_context_layer:Deleted fragment 019f926e-4ecf-78b0-a3af-bc8ded6190ee.
+Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment "box_scores to schedule join key". | update_context_layer:Deleted fragment 019f92b3-9da0-7542-922b-2405716cf7f0.
 - PASS [P2] presenter reset clears local conversations and context: conversations: 0; fragments: 0
 
 ## Tool Calls

--- a/projects/data-chat-mini/reports/demo-validation/latest.md
+++ b/projects/data-chat-mini/reports/demo-validation/latest.md
@@ -1,9 +1,9 @@
 # Demo Validation Report
 
-- Run: 2026-07-24T06-23-37-533Z-mock
+- Run: 2026-07-24T06-36-17-283Z-mock
 - Mode: mock
 - Dataset: nba_box_scores_v2
-- Completed: 2026-07-24T06:23:37.696Z
+- Completed: 2026-07-24T06:36:17.439Z
 - Assertions: 23/23
 - Unresolved P1/P2: 0
 
@@ -55,10 +55,10 @@ SELECT team, points FROM team_rows ORDER BY points DESC LIMIT 5
 - PASS [P2] context query/update/delete lifecycle succeeds: context services: query_context_layer:1 context fragment(s):
 
 ### box_scores to schedule join key
-id: 019f92cb-3042-7605-9867-f216dc7a7fa1
+id: 019f92d6-c808-7d59-9163-296c17613ee1
 references: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule
 
-Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment "box_scores to schedule join key". | update_context_layer:Deleted fragment 019f92cb-3042-7605-9867-f216dc7a7fa1.
+Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment "box_scores to schedule join key". | update_context_layer:Deleted fragment 019f92d6-c808-7d59-9163-296c17613ee1.
 - PASS [P2] presenter reset clears local conversations and context: conversations: 0; fragments: 0
 
 ## Tool Calls

--- a/projects/data-chat-mini/reports/demo-validation/latest.md
+++ b/projects/data-chat-mini/reports/demo-validation/latest.md
@@ -1,9 +1,9 @@
 # Demo Validation Report
 
-- Run: 2026-07-24T06-11-12-391Z-mock
+- Run: 2026-07-24T06-23-37-533Z-mock
 - Mode: mock
 - Dataset: nba_box_scores_v2
-- Completed: 2026-07-24T06:11:12.545Z
+- Completed: 2026-07-24T06:23:37.696Z
 - Assertions: 23/23
 - Unresolved P1/P2: 0
 
@@ -55,10 +55,10 @@ SELECT team, points FROM team_rows ORDER BY points DESC LIMIT 5
 - PASS [P2] context query/update/delete lifecycle succeeds: context services: query_context_layer:1 context fragment(s):
 
 ### box_scores to schedule join key
-id: 019f92bf-d18b-726a-99d2-e4b39baac1ba
+id: 019f92cb-3042-7605-9867-f216dc7a7fa1
 references: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule
 
-Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment "box_scores to schedule join key". | update_context_layer:Deleted fragment 019f92bf-d18b-726a-99d2-e4b39baac1ba.
+Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment "box_scores to schedule join key". | update_context_layer:Deleted fragment 019f92cb-3042-7605-9867-f216dc7a7fa1.
 - PASS [P2] presenter reset clears local conversations and context: conversations: 0; fragments: 0
 
 ## Tool Calls

--- a/projects/data-chat-mini/reports/demo-validation/latest.md
+++ b/projects/data-chat-mini/reports/demo-validation/latest.md
@@ -1,9 +1,9 @@
 # Demo Validation Report
 
-- Run: 2026-07-24T05-57-52-667Z-mock
+- Run: 2026-07-24T06-11-12-391Z-mock
 - Mode: mock
 - Dataset: nba_box_scores_v2
-- Completed: 2026-07-24T05:57:52.822Z
+- Completed: 2026-07-24T06:11:12.545Z
 - Assertions: 23/23
 - Unresolved P1/P2: 0
 
@@ -55,10 +55,10 @@ SELECT team, points FROM team_rows ORDER BY points DESC LIMIT 5
 - PASS [P2] context query/update/delete lifecycle succeeds: context services: query_context_layer:1 context fragment(s):
 
 ### box_scores to schedule join key
-id: 019f92b3-9da0-7542-922b-2405716cf7f0
+id: 019f92bf-d18b-726a-99d2-e4b39baac1ba
 references: database:nba_box_scores_v2.main.box_scores, database:nba_box_scores_v2.main.schedule
 
-Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment "box_scores to schedule join key". | update_context_layer:Deleted fragment 019f92b3-9da0-7542-922b-2405716cf7f0.
+Join nba_box_scores_v2.main.box_scores to nba_box_scores_v2.main.schedule on game_id. Use box_scores.period = FullGame for full-game player/team stats. | update_context_layer:Updated fragment "box_scores to schedule join key". | update_context_layer:Deleted fragment 019f92bf-d18b-726a-99d2-e4b39baac1ba.
 - PASS [P2] presenter reset clears local conversations and context: conversations: 0; fragments: 0
 
 ## Tool Calls


### PR DESCRIPTION
Fixes the sidebar showing "No guides mention `<db>`" for guides that ARE about the active database but don't name it in their topic/title/description.

## Root cause

The database-scope filter is a normalized substring match over `list_guides` summaries — guide bodies and structured references aren't available at list time, so a guide like "Jacob's ecom company" (note: `ecom` ≠ `ecomm`) or one that only *references* the database never matches.

## The fix (zero additional MCP round-trips)

`list_tables(database)` returns `relatedGuides` — **reference-driven**: the server attests these guides are about the database via their structured catalog references, including the caller's private guides. Verified live with a controlled probe (a guide whose summary never names the database still surfaces via its `md:<db>` reference; `search_catalog`'s `relatedGuides` is text-match-only and was rejected). The sidebar already called `list_tables` through `/api/schema` on every load and discarded the field.

- `lib/mcp-parsers.ts` — `RelatedGuide` + `parseRelatedGuides` (defensive parse, drops uuid-less rows)
- `/api/schema?database=X` → `{ tables, relatedGuides }`
- Sidebar database scope renders the union: server-attested guides first, then text matches, deduped by uuid; header count deduped; the schema fetch re-keys on `contextReloadKey` so the guides ↻ button re-pulls both; empty state now explains the mechanism (attach a catalog reference or mention the db in topic/title/description)
- New `lib/mcp-parsers.test.ts` exercising a real production `list_tables` payload

## Verification

- 113/113 tests, typecheck, lint, build clean
- Live probe transcript: reference-only guide appears in `list_tables.relatedGuides`, absent from `search_catalog.relatedGuides`

🤖 Generated with [Claude Code](https://claude.com/claude-code)