### PR TITLE
docs: catch READMEs up to PRs #79/#81/#83/#94

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,19 @@ Each experiment lives in its own directory under [`projects/`](./projects/). Bro
 <!-- BEGIN PROJECT LIST -->
 | Project | What it is |
 |---|---|
+| [`agentic-malloy`](./projects/agentic-malloy/) | Experiment: is a Malloy semantic layer a better LLM substrate than markdown + SQL context on DABStep? Concluded — hypothesis not supported (91.2% vs the 99.8% baseline at ~2.5× prompt tokens); full findings in its `RESULTS.md` and a data-backed MotherDuck Dive. |
 | [`agentic-sql-claude-edition`](./projects/agentic-sql-claude-edition/) | Single-setup agentic-SQL system for the DABStep benchmark — a compact skill plus a `fetch_context` semantic layer that discloses domain knowledge progressively. Hits 419/419 on the cleaned test set. |
+| [`agentic-sql-context-mcp`](./projects/agentic-sql-context-mcp/) | Fork of `agentic-sql-claude-edition` with the hand-built local tools swapped for the MotherDuck context MCP — domain knowledge lives as MotherDuck guides fetched progressively, and data access runs over the same MCP server. 417/419 on the cleaned test set. |
 | [`agentic-sql-mini`](./projects/agentic-sql-mini/) | Minimal A/B harness for the catalog-context-for-agents experiment — can descriptive column names alone replace prose docs as an agent's information source? |
 | [`bird-bench`](./projects/bird-bench/) | Text-to-SQL evaluation framework using the BIRD Mini-Dev benchmark with MotherDuck as the execution backend. |
 | [`connections-eval-mini`](./projects/connections-eval-mini/) | Evaluate AI models on NYT Connections puzzles. Built for the Seattle Startup Summit evals workshop. |
 | [`controllog`](./projects/controllog/) | Controllable logging library for AI/agentic systems — events + balanced postings, JSONL transport, optional MotherDuck upload. Shared dep of `agentic-sql-claude-edition`, `agentic-sql-mini`, `bird-bench`, and `connections-eval-mini`. |
 | [`controllog-viz`](./projects/controllog-viz/) | Static HTML views for `controllog` datasets (JSONL or MotherDuck via one DuckDB layer) — a per-run review with a chain-of-thought conversation explorer and a cross-run dashboard with a run × question progression/regression matrix. |
-| [`data-chat-mini`](./projects/data-chat-mini/) | Minimal "chat with your data" Next.js app — read-only agentic SQL over the MotherDuck MCP, inline `mviz` charts, IndexedDB history + local context layer, and `controllog` telemetry. Runs a fleet on one read scaling token. |
+| [`data-chat-mini`](./projects/data-chat-mini/) | Minimal "chat with your data" Next.js app — read-only agentic SQL over the MotherDuck MCP, inline `mviz` charts, IndexedDB history, durable context in MotherDuck guides, and `controllog` telemetry. Runs a fleet on one read scaling token. |
 | [`metadata_generator`](./projects/metadata_generator/) | Generate rich metadata for MotherDuck databases — profile statistics, LLM-generated descriptions, and SQL `COMMENT` statements. Used as a dep by `bird-bench`. |
 | [`motherduck-dive-viewer`](./projects/motherduck-dive-viewer/) | Generic BI-style Next.js app — sign in with MotherDuck (OAuth 2.1 + PKCE), browse/search your Dives, and view them rendered inline via a server-side query proxy so no MotherDuck token ever reaches the browser. |
 | [`postgres-vs-motherduck`](./projects/postgres-vs-motherduck/) | Same query, same `pg` driver, two engines side by side — a Next.js page fires one heavy aggregate at managed Postgres and at MotherDuck at once and charts each as it answers, with server-measured latency. Includes a Python pipeline to load Postgres → MotherDuck. Deploys to Vercel. |
+| [`quackbot`](./projects/quackbot/) | Slack bot port of `data-chat-mini`'s chat-with-your-data agent — read-only MotherDuck SQL over MCP in Slack threads, `mviz` charts as PNGs, native Slack tables, MotherDuck guides as the context layer, Postgres-backed conversation state, and `controllog` telemetry. |
 | [`react-components`](./projects/react-components/) | Open-source React components extracted from MotherDuck's website and docs — embed a public Dive, embed a private Dive, and an in-browser MotherDuck SQL editor. |
 <!-- END PROJECT LIST -->
 

--- a/projects/agentic-sql-context-mcp/README.md
+++ b/projects/agentic-sql-context-mcp/README.md
@@ -9,21 +9,27 @@ tools swapped from local hand-built ones to the **MotherDuck context MCP**:
    itself.
 2. **A semantic layer via MotherDuck guides** — domain knowledge (fee matching,
    bucketing, terminology, SQL patterns, answer formatting) lives as guides on
-   the MotherDuck MCP server and is fetched progressively: `list_guides()` →
-   folder listing with descriptions → `get_guide(path)` for one item's full
-   body. The agent loads only what each question needs, and data access
-   (`list_tables`, `list_columns`, `search_catalog`, `query`) runs against the
-   same MCP server instead of an in-process DuckDB connection.
+   the MotherDuck MCP server, grouped under six `dabstep/<domain>` topics that
+   are pre-seeded in the skill, and is fetched progressively:
+   `list_guides(topic)` → the topic's guides with uuids and one-line
+   descriptions → `get_guide(uuid)` for one item's full body. The agent loads
+   only what each question needs, and data access (`list_tables`,
+   `list_columns`, `query`) runs against the same MCP server instead of an
+   in-process DuckDB connection.
 
 Target: **100% on the 26 template-representative questions** (one per DABStep
 template T01–T26; `train_ids` in `data/split.json`).
 
 ## Results
 
-The baseline this fork aims to match (from `agentic-sql-claude-edition`, the
+This fork: **417/419 (99.5%)** on the cleaned full test set, with
+`gemini-3-flash` at `--reasoning low`, for **~$8.57** per run
+(~$0.020/question).
+
+The baseline it aims to match (from `agentic-sql-claude-edition`, the
 hand-built local-tools version this project was copied from):
-**419/419 (100%)** on the cleaned full test set, with `gemini-3-flash` at
-`--reasoning low`, for **~$7.91** per run (~$0.019/question).
+**419/419 (100%)** on the same set and model, for **~$7.91** per run
+(~$0.019/question).
 
 - **Set:** all 450 DABStep questions minus the 26 template reps (= 424 held-out)
   minus **5 provably-wrong `hf_consensus` golds** set aside in `data/bad_golds.json`
@@ -53,9 +59,9 @@ answer flow and the log-driven improvement loop.
 
 ```
 system prompt + SKILL + question
-  → list_guides(partial_path="dabstep/")       # folder of guides + descriptions
-  → get_guide("dabstep/fees-matching-9dim.md") # full guide body, as needed
-  → list_tables / list_columns / search_catalog  # explore schema (MCP)
+  → list_guides(topic="dabstep/fees")   # a domain topic's guides: uuid + description
+  → get_guide(uuid)                     # full guide body, as needed
+  → list_tables / list_columns          # explore schema (MCP)
   → query (verify SQL, via MCP)
   → submit_answer                              # the SQL whose result IS the answer
 ```
@@ -71,9 +77,9 @@ system prompt + SKILL + question
   `medium` accuracy on this skill at roughly half the cost; `medium`/`high` are
   available for harder models/tasks.
 - Data + semantic layer: the **MotherDuck context MCP server** (`src/mcp_client.py`).
-  Data access (`list_tables`, `list_columns`, `search_catalog`, `query`) and the
-  semantic layer (`list_guides`, `get_guide`) are both MCP tools at agent
-  runtime — no in-process DuckDB connection, no local `semantic_lookup` store.
+  Data access (`list_tables`, `list_columns`, `query`) and the semantic layer
+  (`list_guides`, `get_guide`) are both MCP tools at agent runtime — no
+  in-process DuckDB connection, no local `semantic_lookup` store.
 - Logging: `controllog` double-entry events/postings; inspect with `controllog-viz`.
 - Scoring: the strict DABStep scorer (`src/score.py`, verbatim port).
 

--- a/projects/data-chat-mini/README.md
+++ b/projects/data-chat-mini/README.md
@@ -113,6 +113,11 @@ The guided rail covers:
   with `list_guides({topic})` → `get_guide({uuid})`, and persists durable
   learnings as small private guides under the `data-chat-mini/…` topic. The
   guide manager uses `/api/guides` for viewing, editing, history, and deletion.
+  The schema sidebar's database scope also surfaces **reference-attested
+  guides**: `list_tables(database)` returns `relatedGuides` computed from
+  structured catalog references, so a guide about a database appears there even
+  if its title/topic never names it (`/api/schema` passes the field through;
+  union + dedupe with text matches in `lib/guide-view.ts`).
   The old IndexedDB context-tool round trip remains only to support the
   recorded demo until it is re-recorded.
 - **mviz inline.** The model emits ` ```table ` / ` ```bar ` / ` ```line ` /

--- a/projects/quackbot/README.md
+++ b/projects/quackbot/README.md
@@ -152,9 +152,10 @@ carry injected instructions). The boundaries that matter:
   (`src/slack/confirm.ts` + `requiresConfirmation`) — so prompt-injected content
   can *propose* a write but can't commit one unattended. Deny, timeout (2 min),
   or a failed prompt-post all fail closed (no write). Behind that, the writes
-  stay confined: guide paths are guarded to the bot's own
-  `users/<bot>/quackbot/` folder (the guard rejects `..`, percent-encoded, and
-  Unicode traversal) and `save_dive` is create-only with a fresh id.
+  stay confined: guide writes are guarded to the bot's own `quackbot/` topic
+  namespace with `access` forced private (the guard rejects `.`/`..` segments
+  so a topic can never mimic path traversal) and `save_dive` is create-only
+  with a fresh id.
 - **Chart rendering is network-isolated.** Chart specs are attacker-influenced,
   so the headless-Chromium screenshot path denies all egress except the Google
   Fonts the self-contained embed needs, and the spec sanitizer strips raw-JS


### PR DESCRIPTION
## Summary
- **Top-level README**: add the three missing committed projects to the table — `agentic-sql-context-mcp` (#83), `quackbot` (#81), and `agentic-malloy` — and update `data-chat-mini`'s one-liner now that durable context lives in MotherDuck guides (#79).
- **agentic-sql-context-mcp**: README described the old path-based guide API; now matches the merged code (pre-seeded `dabstep/<domain>` topics, `list_guides(topic)` → `get_guide(uuid)`, no `search_catalog`) and records the fork's own headline result — **417/419 (99.5%) @ ~$8.57/run** — next to the 419/419 @ ~$7.91 baseline.
- **data-chat-mini**: document #94's reference-attested guides in the schema sidebar's database scope (`list_tables` `relatedGuides`, unioned/deduped with text matches).
- **quackbot**: fix one stale path-API sentence in the security section — the guide-write guard confines by the `quackbot/` topic namespace (rejecting `.`/`..` segments), not a `users/<bot>/` folder.

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)