### PR TITLE
quackbot: bump vulnerable deps (dependabot)

### DIFF
--- a/projects/quackbot/package-lock.json
+++ b/projects/quackbot/package-lock.json
@@ -876,12 +876,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2738,9 +2738,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/projects/quackbot/package.json
+++ b/projects/quackbot/package.json
@@ -28,5 +28,9 @@
     "@types/pg": "^8",
     "typescript": "^5",
     "vitest": "^4.1.4"
+  },
+  "overrides": {
+    "@hono/node-server": "^2.0.5",
+    "fast-uri": "^3.1.4"
   }
 }


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert #109 (`@hono/node-server`, medium, GHSA-frvp-7c67-39w9) by pinning the transitive dependency to `^2.0.5` via an `overrides` block (resolved to 2.0.11).
- Resolves Dependabot alert #110 (`fast-uri`, high, GHSA-v2hh-gcrm-f6hx) by pinning to `^3.1.4` via the same `overrides` block (resolved to 3.1.4).
- Both packages are transitive dependencies pulled in by `@modelcontextprotocol/sdk@1.29.0` (directly, and via `ajv`). `npm audit fix --force` would have downgraded the SDK to 1.24.3 (a breaking change), so `overrides` is used instead to keep the SDK version and apply a pure dependency bump — no application code changed.

## Test plan
- [x] `npm install` inside `projects/quackbot`
- [x] `npm audit` — before: 3 vulnerabilities (2 moderate, 1 high); after: **0 vulnerabilities**
- [x] `npm run typecheck` — passed, no errors
- [x] `npm run test` (vitest) — **233 tests passed** across 19 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)