### PR TITLE
agentic-malloy: bump vulnerable deps (dependabot)

### DIFF
--- a/projects/agentic-malloy/package-lock.json
+++ b/projects/agentic-malloy/package-lock.json
@@ -656,12 +656,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2174,9 +2174,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -2422,9 +2422,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3803,13 +3803,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/projects/agentic-malloy/package.json
+++ b/projects/agentic-malloy/package.json
@@ -27,5 +27,11 @@
     "tsx": "^4.19.0",
     "typescript": "^5",
     "vitest": "^4.1.4"
+  },
+  "overrides": {
+    "fast-uri": "^3.1.4",
+    "hono": "^4.12.27",
+    "@hono/node-server": "^2.0.5",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
## Summary
Fixes all open Dependabot alerts scoped to `projects/agentic-malloy/package-lock.json`. None of the affected packages are direct dependencies of `agentic-malloy` (they come in transitively via `@malloydata/malloy` and `@modelcontextprotocol/sdk`), and `npm audit fix --force` would have downgraded `@modelcontextprotocol/sdk` to 1.24.3 and bumped `@malloydata/malloy` to a breaking 0.0.425. Instead, added an `overrides` block to `projects/agentic-malloy/package.json` pinning the minimum patched versions and regenerated the lockfile, leaving both direct deps untouched at their current versions.

Resolved alerts:
- #45 uuid — GHSA-w5hq-g745-h8pq — now 11.1.1 (was 8.3.2, via `@malloydata/malloy`)
- #56 @hono/node-server — GHSA-frvp-7c67-39w9 — now 2.0.11 (was 1.19.14, via `@modelcontextprotocol/sdk`)
- #57 hono — GHSA-xgm2-5f3f-mvvc — now 4.12.32 (was 4.12.25, via `@modelcontextprotocol/sdk`)
- #58 hono — GHSA-w62v-xxxg-mg59 — now 4.12.32
- #59 hono — GHSA-hvrm-45r6-mjfj — now 4.12.32
- #60 fast-uri — GHSA-4c8g-83qw-93j6 — now 3.1.4 (was 3.1.2, via `ajv` <- `@modelcontextprotocol/sdk`)
- #61 fast-uri — GHSA-v2hh-gcrm-f6hx — now 3.1.4

Verified `uuid@11.1.1` still ships CJS output (`require("uuid")` resolves via conditional exports) matching how `@malloydata/malloy`'s dist consumes it, and both `hono@4.12.32` / `@hono/node-server@2.0.11` require Node >=16.9 / >=20 respectively, which is satisfied by this package's existing `engines.node >= 20`.

`git diff package-lock.json` shows only the four targeted packages changed version — no unrelated churn.

## Test plan
- [x] `npm install` — lockfile regenerated cleanly
- [x] `npm audit` — `found 0 vulnerabilities` (was 7: 6 moderate, 1 high)
- [x] `npm ls uuid hono @hono/node-server fast-uri` — confirms `uuid@11.1.1`, `hono@4.12.32`, `@hono/node-server@2.0.11`, `fast-uri@3.1.4`, all via `overridden`
- [x] `npm run typecheck` — passes (no output/errors)
- [x] `npm run test` (vitest) — `Test Files 19 passed (19)`, `Tests 222 passed (222)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)