### PR TITLE
react-components/example: bump vite to fix dependabot alerts

### DIFF
--- a/projects/react-components/example/package.json
+++ b/projects/react-components/example/package.json
@@ -22,8 +22,8 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/react-syntax-highlighter": "^15.5.13",
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^4.7.0",
     "typescript": "^5.6.3",
-    "vite": "^5.4.10"
+    "vite": "^6.4.3"
   }
 }

--- a/projects/react-components/example/vite.config.ts
+++ b/projects/react-components/example/vite.config.ts
@@ -1,5 +1,21 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import pkg from './package.json' with { type: 'json' };
+
+// The playground imports the sibling `packages/*` sources directly (via
+// relative paths, not an npm workspace), and those sources declare this
+// app's runtime dependencies as peerDependencies. Because `packages/` is a
+// *sibling* of `example/` rather than a descendant, Node/Vite's normal
+// upward node_modules search (starting from the importing file) never
+// reaches `example/node_modules`, so bare imports like `@auth0/auth0-react`
+// fail to resolve during `vite build`. Alias each runtime dependency to its
+// resolved location here so sources in `../packages/*/src` can find them too.
+const resolveFromExample = (name: string) =>
+  fileURLToPath(new URL(`./node_modules/${name}`, import.meta.url));
+const dependencyAliases = Object.fromEntries(
+  Object.keys(pkg.dependencies ?? {}).map((name) => [name, resolveFromExample(name)])
+);
 
 // Tiny dev-server middleware that mocks the dive-session endpoint so the
 // dive-embed-private component can render its loading/expand UI without a
@@ -21,6 +37,9 @@ const mockSessionPlugin = () => ({
 
 export default defineConfig({
   plugins: [react(), mockSessionPlugin()],
+  resolve: {
+    alias: dependencyAliases,
+  },
   optimizeDeps: {
     // wasm-client is CJS; let Vite pre-bundle so the SQL editor's runtime
     // require() call resolves correctly.


### PR DESCRIPTION
## Summary

Fixes 3 open Dependabot alerts scoped to `projects/react-components/example/package.json` by bumping `vite` (devDependency) from `^5.4.10` to `^6.4.3` — a major version bump.

- **#4** `vite` (medium) — [GHSA-4w7w-66w2-5vf9](https://github.com/advisories/GHSA-4w7w-66w2-5vf9) — path traversal in optimized deps `.map` handling — fixed in 6.4.2
- **#41** `vite` (high) — [GHSA-fx2h-pf6j-xcff](https://github.com/advisories/GHSA-fx2h-pf6j-xcff) — `server.fs.deny` bypass on Windows alternate paths — fixed in 6.4.3
- **#42** `vite` (medium) — [GHSA-v6wh-96g9-6wx3](https://github.com/advisories/GHSA-v6wh-96g9-6wx3) — `launch-editor` NTLMv2 hash disclosure on Windows — fixed in 6.4.3

Also bumped `@vitejs/plugin-react` `^4.3.3` -> `^4.7.0` (latest 4.x release), which is the newest release still explicitly declaring a `vite ^6.0.0` peer range — this avoids an additional, unrelated major jump to plugin-react 5.x/6.x (which requires vite 7/8).

### Unrelated fix needed to get `npm run build` passing

While verifying, `vite build` failed — and this reproduces identically on the *prior* vite 5.4.21 too, so it's pre-existing and not caused by this bump. The example imports the sibling `../packages/*/src` sources directly (relative paths, no npm workspace), and those sources' bare imports (e.g. `@auth0/auth0-react`) fall outside Node's upward `node_modules` search starting from `example/`, so Rollup can't resolve them during a production build. Added a small `resolve.alias` in `vite.config.ts`, derived from this package's own `"dependencies"`, so sibling sources resolve against `example/node_modules`. Scoped only to `vite.config.ts`; no `packages/*` files touched.

## Commands run (in `projects/react-components/example`)

- `npm install` → baseline: 2 vulnerabilities (1 moderate, 1 high) — the 3 GHSA IDs above (esbuild's advisory is a transitive effect of vite <=6.4.2).
- Bumped `vite` and `@vitejs/plugin-react` in `package.json`, `npm install` → **0 vulnerabilities**; `npm ls vite @vitejs/plugin-react` confirms `vite@6.4.3` / `@vitejs/plugin-react@4.7.0`.
- `npm audit` → `found 0 vulnerabilities`.
- `npm run build` → **fails** pre-fix (reproduced on both vite 5.4.21 and 6.4.3) due to the sibling-package resolution gap above; **succeeds** after the `vite.config.ts` alias fix: `969 modules transformed`, `✓ built in 862ms`.
- `npx vite --version` → `vite/6.4.3 darwin-arm64 node-v22.22.2` (Node 22.22.2, well above Vite 6's Node 18+ requirement).
- `npm run dev -- --port 5199` → started cleanly (`VITE v6.4.3 ready in 87 ms`), `curl localhost:5199/` → `200`.

## Test plan

- [x] `npm install && npm audit` shows 0 vulnerabilities (previously reported the 3 GHSA IDs above)
- [x] `npm run build` succeeds (production build)
- [x] `npm run dev` boots and serves `200` on its port
- [x] Only files under `projects/react-components/example/` changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)