### PR TITLE
quackbot: bump postcss to fix path traversal (dependabot)

### DIFF
--- a/projects/quackbot/package-lock.json
+++ b/projects/quackbot/package-lock.json
@@ -3833,9 +3833,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4238,9 +4238,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "dev": true,
       "funding": [
         {
@@ -4258,7 +4258,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/projects/quackbot/package.json
+++ b/projects/quackbot/package.json
@@ -31,6 +31,7 @@
   },
   "overrides": {
     "@hono/node-server": "^2.0.5",
-    "fast-uri": "^3.1.4"
+    "fast-uri": "^3.1.4",
+    "postcss": "^8.5.18"
   }
 }


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert #115 (high): GHSA-r28c-9q8g-f849 — PostCSS path traversal in previous sourceMappingURL auto-loading, which can lead to arbitrary `.map` file disclosure.
- `postcss` is a transitive dependency in `projects/quackbot` (pulled in via `vitest` -> `vite` -> `postcss`), pinned at vulnerable `8.5.16` (vulnerable range `<= 8.5.17`).
- Extended the existing `overrides` block in `projects/quackbot/package.json` to add `"postcss": "^8.5.18"` (kept the existing `@hono/node-server` and `fast-uri` entries intact). After `npm install`, postcss resolves to `8.5.22`.
- Pure dependency bump only — no changes to deploy config or app code. quackbot is a live production Slack bot on Fly.

## Verification
Run from `projects/quackbot`:
- `npm ls postcss` → `postcss@8.5.22 overridden` (was `8.5.16`)
- `npm audit` → `found 0 vulnerabilities`
- `npm audit --json | grep -i r28c-9q8g-f849` → no matches
- `npm run typecheck` → passes, no errors
- `npm run test` (vitest) → `Test Files 19 passed (19)`, `Tests 233 passed (233)`

## Test plan
- [x] `npm install` completes cleanly with the new override
- [x] `npm audit` shows 0 vulnerabilities, GHSA-r28c-9q8g-f849 no longer present
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (233/233)
- [x] Diff scoped to `projects/quackbot/package.json` and `projects/quackbot/package-lock.json` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)