### PR TITLE
agentic-sql-context-mcp: inline 9dim CTEs into fraud-ACI steering guide

### DIFF
--- a/projects/agentic-sql-context-mcp/context/items/sql-aci-fraud-steering.md
+++ b/projects/agentic-sql-context-mcp/context/items/sql-aci-fraud-steering.md
@@ -23,8 +23,39 @@ T08+T17. Including F flips Belles_cookbook_store tasks from the gold `E` to a wr
 `F` (F can have a lower raw total but isn't a valid target). (This differs from the
 "most-expensive ACI" pattern, which uses A–F.)
 
+The template below is **self-contained — copy it whole.** The `monthly_stats` and
+`mp` CTEs are the canonical ones from `fees-matching-9dim`; do NOT improvise your
+own bucket ranges (the capture_delay buckets are exactly `<3` / `3-5` / `>5` plus
+`immediate`/`manual` kept as-is — any other bucketing mismatches the fees table
+and silently steers to the wrong ACI).
+
 ```sql
-WITH frauds AS (   -- the merchant's fraudulent transactions in the window
+WITH monthly_stats AS (   -- volume & fraud buckets per merchant per calendar month
+  SELECT merchant, year,
+    MONTH(MAKE_DATE(year, 1, 1) + INTERVAL (day_of_year - 1) DAY) AS month,
+    CASE WHEN SUM(eur_amount) < 100000 THEN '<100k'
+         WHEN SUM(eur_amount) < 1000000 THEN '100k-1m'
+         WHEN SUM(eur_amount) < 5000000 THEN '1m-5m'
+         ELSE '>5m' END AS volume_range,
+    CASE WHEN SUM(CASE WHEN has_fraudulent_dispute THEN eur_amount ELSE 0 END)
+              / NULLIF(SUM(eur_amount), 0) * 100 < 7.2 THEN '<7.2%'
+         WHEN SUM(CASE WHEN has_fraudulent_dispute THEN eur_amount ELSE 0 END)
+              / NULLIF(SUM(eur_amount), 0) * 100 < 7.7 THEN '7.2%-7.7%'
+         WHEN SUM(CASE WHEN has_fraudulent_dispute THEN eur_amount ELSE 0 END)
+              / NULLIF(SUM(eur_amount), 0) * 100 < 8.3 THEN '7.7%-8.3%'
+         ELSE '>8.3%' END AS fraud_level_range
+  FROM payments
+  GROUP BY merchant, year, month
+),
+mp AS (   -- merchant profile, with capture_delay bucketed (buckets are FIXED: <3 / 3-5 / >5)
+  SELECT m.merchant, m.account_type, m.merchant_category_code,
+    CASE WHEN TRY_CAST(m.capture_delay AS INTEGER) < 3 THEN '<3'
+         WHEN TRY_CAST(m.capture_delay AS INTEGER) BETWEEN 3 AND 5 THEN '3-5'
+         WHEN TRY_CAST(m.capture_delay AS INTEGER) > 5 THEN '>5'
+         ELSE m.capture_delay END AS capture_delay_range  -- keep 'immediate'/'manual' AS-IS
+  FROM merchants m
+),
+frauds AS (   -- the merchant's fraudulent transactions in the window
   SELECT * FROM payments
   WHERE merchant = 'Golfclub_Baron_Friso' AND year = 2023
     AND MONTH(MAKE_DATE(year,1,1)+INTERVAL (day_of_year-1) DAY) = 1
@@ -54,9 +85,10 @@ costs AS (
 )
 SELECT aci FROM costs ORDER BY total_fee ASC, aci LIMIT 1;
 ```
-(Define `mp` and `monthly_stats` as in `fees-matching-9dim`.)
 
 Rules:
+- Use the `monthly_stats`/`mp` CTEs above verbatim — the bucket boundaries come
+  from the manual (see `fees-matching-9dim`), not from the data.
 - The candidate ACI replaces the transaction's real ACI in the fee match.
 - ONE overall ACI across all card schemes — do NOT break down per scheme.
 - "Lowest fees" → `ORDER BY total_fee ASC`.


### PR DESCRIPTION
Kills the residual ~1/23 fraud-ACI flake noted in #107: the steering guide's SQL template cross-referenced `fees-matching-9dim` for the `mp`/`monthly_stats` CTE definitions, and when the agent skipped that second fetch it invented its own capture_delay buckets (mismatching the fees table → steered E instead of D, e.g. task 2755). The template is now self-contained with both CTEs inlined and an explicit "do not improvise bucket ranges" warning.

Guides republished to MotherDuck (`asm guides-load`: 27 updated, 0 failed) — the live guide already serves the new body.

Validation:
- fraud-ACI family (all 23 test-split tasks): 23/23
- task 2755 (the observed flake): 5/5
- templates split gate: 26/26 @ $0.55

🤖 Generated with [Claude Code](https://claude.com/claude-code)