### PR TITLE
quackbot: fix empty chart PNGs and surrogate-split Slack updates

### DIFF
--- a/projects/quackbot/README.md
+++ b/projects/quackbot/README.md
@@ -158,9 +158,17 @@ carry injected instructions). The boundaries that matter:
   with a fresh id.
 - **Chart rendering is network-isolated.** Chart specs are attacker-influenced,
   so the headless-Chromium screenshot path denies all egress except the Google
-  Fonts the self-contained embed needs, and the spec sanitizer strips raw-JS
+  Fonts the embed needs, and the spec sanitizer strips raw-JS
   option keys and neutralizes `</script>` breakout — no SSRF/exfil even if
   injected markup runs (`src/slack/screenshot.ts`, `src/core/mviz-processor.ts`).
+  The embed is *not* self-contained — mviz `document.write`s a `<script src>` for
+  echarts on every chart tile — so echarts is a pinned dependency of this
+  project and `resolveVendoredAsset` fulfills that one request off disk rather
+  than allowlisting `cdn.jsdelivr.net`, which would hand attacker-influenced
+  page content a live fetch channel to any npm package. Charts render with the
+  network unplugged. Anything else the embed starts requesting fails closed
+  (aborted, chart visibly empty) and trips a test — see the "covers every
+  external script" case in `src/slack/screenshot.test.ts`.
 - **Secrets** never reach logs, prompts, Slack, or rendered output; `.env` is
   git- and docker-ignored and not baked into any image layer. Postgres always
   connects over verified TLS (`resolvePoolConfig` in `src/store/pg.ts`).

--- a/projects/quackbot/package-lock.json
+++ b/projects/quackbot/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@slack/bolt": "^4",
+        "echarts": "^5.5.0",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.1.1",
         "mviz": "^1.7.0",
@@ -2255,6 +2256,22 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/echarts": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.0.tgz",
+      "integrity": "sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.5.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -5250,6 +5267,21 @@
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
+    },
+    "node_modules/zrender": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.5.0.tgz",
+      "integrity": "sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     }
   }
 }

--- a/projects/quackbot/package.json
+++ b/projects/quackbot/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@slack/bolt": "^4",
+    "echarts": "^5.5.0",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.1.1",
     "mviz": "^1.7.0",

--- a/projects/quackbot/src/core/mviz-processor.ts
+++ b/projects/quackbot/src/core/mviz-processor.ts
@@ -309,6 +309,10 @@ export function processMvizMarkdown(markdown: string, theme = 'light'): string {
   // title row, theme toggle), prunes unused CSS/CDN scripts, and minifies for
   // iframe embedding — the rendering path these tiles live in. Replaces the
   // manual chrome-stripping we used to carry in CUSTOM_CSS_OVERRIDES.
+  // Note: it prunes the CDN scripts it doesn't need, NOT the one it does — the
+  // output still document.writes a <script src> for echarts on every chart
+  // tile. The Slack PNG path serves that from disk; see `resolveVendoredAsset`
+  // in src/slack/screenshot.ts.
   const result = parseMarkdownToDashboard(
     sanitizedMarkdown,
     theme,

--- a/projects/quackbot/src/slack/screenshot.test.ts
+++ b/projects/quackbot/src/slack/screenshot.test.ts
@@ -1,8 +1,31 @@
-import { describe, expect, it } from 'vitest';
-import { isAllowedResourceUrl } from './screenshot';
+import { existsSync } from 'node:fs';
+import { afterAll, describe, expect, it } from 'vitest';
+import { processMvizMarkdown } from '../core/mviz-processor';
+import {
+  closeBrowser,
+  isAllowedResourceUrl,
+  probeRenderedChart,
+  renderHtmlToPng,
+  resolveVendoredAsset,
+} from './screenshot';
+
+const BAR_FENCE = [
+  '```bar size=[8,8]',
+  JSON.stringify({
+    type: 'bar',
+    title: 'Revenue by Month',
+    data: [
+      { month: 'Jan', revenue: 120 },
+      { month: 'Feb', revenue: 190 },
+    ],
+    x: 'month',
+    y: 'revenue',
+  }),
+  '```',
+].join('\n');
 
 describe('isAllowedResourceUrl', () => {
-  it('allows the self-contained embed’s font fetches and inline schemes', () => {
+  it('allows the embed’s font fetches and inline schemes', () => {
     expect(isAllowedResourceUrl('https://fonts.googleapis.com/css2?family=Inter')).toBe(true);
     expect(isAllowedResourceUrl('https://fonts.gstatic.com/s/inter/inter.woff2')).toBe(true);
     expect(isAllowedResourceUrl('data:text/css,body{}')).toBe(true);
@@ -27,5 +50,76 @@ describe('isAllowedResourceUrl', () => {
     expect(isAllowedResourceUrl('https://fonts.googleapis.com.evil.example/x')).toBe(false);
     // Garbage / non-URL input fails closed.
     expect(isAllowedResourceUrl('not a url')).toBe(false);
+  });
+
+  it('denies the echarts CDN itself — it is served from disk, never fetched', () => {
+    expect(isAllowedResourceUrl('https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js')).toBe(
+      false,
+    );
+  });
+});
+
+describe('resolveVendoredAsset', () => {
+  it('serves the echarts bundle mviz asks for from a real local file', () => {
+    const local = resolveVendoredAsset('https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js');
+    expect(local).toBeTruthy();
+    expect(existsSync(local as string)).toBe(true);
+  });
+
+  it('matches by shape so an mviz echarts version bump keeps rendering', () => {
+    expect(resolveVendoredAsset('https://cdn.jsdelivr.net/npm/echarts@5.6.1/dist/echarts.min.js')).toBeTruthy();
+    expect(resolveVendoredAsset('https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.js')).toBeTruthy();
+  });
+
+  it('refuses to source anything else off disk', () => {
+    // Any other jsdelivr path — the URL must never widen which file we read.
+    expect(resolveVendoredAsset('https://cdn.jsdelivr.net/npm/evil/x.js')).toBeNull();
+    expect(resolveVendoredAsset('https://cdn.jsdelivr.net/npm/echarts@5.5.0/../../../etc/passwd')).toBeNull();
+    expect(resolveVendoredAsset('https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js.map')).toBeNull();
+    // Other hosts, other schemes, garbage.
+    expect(resolveVendoredAsset('https://evil.example/npm/echarts@5.5.0/dist/echarts.min.js')).toBeNull();
+    expect(resolveVendoredAsset('file:///etc/passwd')).toBeNull();
+    expect(resolveVendoredAsset('not a url')).toBeNull();
+  });
+
+  it('covers every external script the real embed HTML requests', () => {
+    // The guard that would have caught the empty-chart bug at build time: if
+    // mviz starts pulling a script we do not vendor, the render sandbox aborts
+    // it and charts come out blank. Fonts are the one allowed network fetch.
+    const html = processMvizMarkdown(BAR_FENCE);
+    const scriptSrcs = [...html.matchAll(/<script[^>]*\bsrc\s*=\s*["']([^"']+)["']/gi)].map((m) => m[1]);
+    expect(scriptSrcs.length).toBeGreaterThan(0);
+    for (const src of scriptSrcs) {
+      expect(
+        resolveVendoredAsset(src) !== null || isAllowedResourceUrl(src),
+        `embed requests ${src}, which is neither vendored nor allowlisted — charts will render empty`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('renderHtmlToPng', () => {
+  it('renders actual chart marks, not just the tile title', async () => {
+    // Regression test for charts arriving in Slack as a title over blank space:
+    // mviz's embed loads echarts from a CDN, and the render sandbox denies all
+    // egress, so the chart body silently failed with `echarts is not defined`.
+    // Asserting on PNG bytes alone would not have caught it — a blank tile is a
+    // perfectly valid PNG — so assert on the rendered DOM via a marker page.
+    const html = processMvizMarkdown(BAR_FENCE);
+    const png = await renderHtmlToPng(html);
+    expect(png.length).toBeGreaterThan(0);
+    // A drawn echarts chart leaves an <svg> with axis/series geometry in it.
+    // renderHtmlToPng returns only pixels, so re-render the same HTML through
+    // the same sandbox and inspect the DOM it produced.
+    const probe = await probeRenderedChart(html);
+    expect(probe.echartsInstances).toBeGreaterThan(0);
+    expect(probe.svgPaths).toBeGreaterThan(0);
+    // The axis labels and the series values must both have been drawn.
+    expect(probe.text).toContain('Jan');
+    expect(probe.text).toContain('120');
+  }, 60_000);
+
+  afterAll(async () => {
+    await closeBrowser();
   });
 });

--- a/projects/quackbot/src/slack/screenshot.test.ts
+++ b/projects/quackbot/src/slack/screenshot.test.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { afterAll, describe, expect, it } from 'vitest';
 import { processMvizMarkdown } from '../core/mviz-processor';
 import {
@@ -8,6 +9,10 @@ import {
   renderHtmlToPng,
   resolveVendoredAsset,
 } from './screenshot';
+
+const installedEchartsVersion = (
+  createRequire(import.meta.url)('echarts/package.json') as { version: string }
+).version;
 
 const BAR_FENCE = [
   '```bar size=[8,8]',
@@ -66,9 +71,33 @@ describe('resolveVendoredAsset', () => {
     expect(existsSync(local as string)).toBe(true);
   });
 
-  it('matches by shape so an mviz echarts version bump keeps rendering', () => {
-    expect(resolveVendoredAsset('https://cdn.jsdelivr.net/npm/echarts@5.6.1/dist/echarts.min.js')).toBeTruthy();
-    expect(resolveVendoredAsset('https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.js')).toBeTruthy();
+  it('serves any minor/patch inside the vendored major, so an mviz bump keeps rendering', () => {
+    const major = installedEchartsVersion.split('.')[0];
+    expect(resolveVendoredAsset(`https://cdn.jsdelivr.net/npm/echarts@${major}.99.99/dist/echarts.min.js`)).toBeTruthy();
+    expect(resolveVendoredAsset(`https://cdn.jsdelivr.net/npm/echarts@${major}.0.0/dist/echarts.js`)).toBeTruthy();
+  });
+
+  it('refuses a different major rather than serving an incompatible bundle', () => {
+    // Answering an echarts-6 embed with the vendored echarts 5 would reproduce
+    // the blank-chart bug silently. Refusing fails closed at the allowlist and
+    // surfaces as the "covers every external script" failure below.
+    const major = Number(installedEchartsVersion.split('.')[0]);
+    expect(resolveVendoredAsset(`https://cdn.jsdelivr.net/npm/echarts@${major + 1}.0.0/dist/echarts.min.js`)).toBeNull();
+    expect(resolveVendoredAsset(`https://cdn.jsdelivr.net/npm/echarts@${major - 1}.0.0/dist/echarts.min.js`)).toBeNull();
+    expect(resolveVendoredAsset('https://cdn.jsdelivr.net/npm/echarts@latest/dist/echarts.min.js')).toBeNull();
+  });
+
+  it('vendors the same echarts MAJOR that mviz actually requests', () => {
+    // The invariant the version guard depends on. If an mviz upgrade moves to a
+    // new echarts major, this fails by name — telling you to bump the vendored
+    // dependency — instead of charts quietly going blank in Slack again.
+    const html = processMvizMarkdown(BAR_FENCE);
+    const requested = /\/npm\/echarts@(\d+)[^/]*\/dist\/echarts(?:\.min)?\.js/.exec(html);
+    expect(requested, 'mviz no longer requests echarts from jsdelivr — revisit resolveVendoredAsset').toBeTruthy();
+    expect(
+      requested?.[1],
+      `mviz requests echarts ${requested?.[1]}.x but package.json vendors ${installedEchartsVersion} — bump the echarts dependency`,
+    ).toBe(installedEchartsVersion.split('.')[0]);
   });
 
   it('refuses to source anything else off disk', () => {

--- a/projects/quackbot/src/slack/screenshot.ts
+++ b/projects/quackbot/src/slack/screenshot.ts
@@ -1,4 +1,5 @@
-import { chromium, type Browser } from 'playwright';
+import { createRequire } from 'node:module';
+import { chromium, type Browser, type Page } from 'playwright';
 
 /**
  * Renders self-contained mviz embed HTML to a PNG for Slack, since Slack
@@ -34,11 +35,16 @@ async function getBrowser(): Promise<Browser> {
 const CLIP_PAD_PX = 16;
 
 /**
- * The embed HTML (`processMvizMarkdown`) is fully self-contained — the chart
- * library is inlined and the specs render with no runtime `fetch`/XHR. The
- * ONLY legitimate external request is the Google Fonts `@import` in
- * mviz-theme's `MVIZ_FONT_IMPORT_URL` (the CSS on fonts.googleapis.com, then
- * the font files on fonts.gstatic.com).
+ * The embed HTML (`processMvizMarkdown`) carries its specs inline and issues no
+ * runtime `fetch`/XHR, but it is NOT fully self-contained: mviz emits a
+ * `document.write`n `<script src>` for echarts on every chart tile (see
+ * `mviz/dist/core/serializer.js`). Two legitimate external requests, then:
+ * the echarts bundle, and the Google Fonts `@import` in mviz-theme's
+ * `MVIZ_FONT_IMPORT_URL` (the CSS on fonts.googleapis.com, then the font files
+ * on fonts.gstatic.com).
+ *
+ * echarts is served from disk rather than the network — see
+ * `resolveVendoredAsset`. Only the fonts actually leave the machine.
  *
  * Chart content is model- and query-data-derived, i.e. attacker-influenced, so
  * we treat the render as hostile: even if injected markup or a raw-JS chart
@@ -64,31 +70,77 @@ export function isAllowedResourceUrl(rawUrl: string): boolean {
   return url.protocol === 'https:' && ALLOWED_FONT_HOSTS.has(url.hostname);
 }
 
+const require_ = createRequire(import.meta.url);
+
 /**
- * Render a self-contained HTML document (an mviz embed) to a PNG buffer.
- *
- * The page is 900px wide and mviz lays the chart out on its 16-column grid,
- * so the fence's `size=[w,h]` decides the `.grid-item` box (w=8 → ~424px
- * wide, taller h → taller box). Screenshot THAT box — plus a little padding,
- * clamped to the dashboard — so the PNG Slack displays is the size the spec
- * asked for, not a full-width canvas with dead space beside a half-width
- * chart. Multi-tile embeds and missing selectors fall back to the
- * `.dashboard` root, then to a full-page shot.
+ * The chart-library script mviz asks jsdelivr for, e.g.
+ * `/npm/echarts@5.5.0/dist/echarts.min.js`. Matched by shape rather than by
+ * exact version so an mviz bump to a new echarts patch keeps rendering; the
+ * bundle actually served is always the lockfile-pinned local one, and
+ * `screenshot.test.ts` fails if mviz's pinned MAJOR ever moves past ours.
  */
-export async function renderHtmlToPng(html: string): Promise<Buffer> {
+const ECHARTS_CDN_PATH_RE = /^\/npm\/echarts@[^/]+\/dist\/echarts(\.min)?\.js$/;
+
+/**
+ * Map a CDN request to a local file to serve in its place, or null to let the
+ * allowlist decide.
+ *
+ * Blocking echarts outright (the allowlist's behavior before this existed) left
+ * every chart PNG as a bare tile title over an empty canvas — the static HTML
+ * renders, `echarts is not defined` kills the chart body. Allowlisting
+ * cdn.jsdelivr.net would fix that by handing attacker-influenced page content a
+ * live fetch channel to a host that serves any npm package at any path, which
+ * is exactly the egress this sandbox exists to deny.
+ *
+ * So echarts is a real dependency of this project and gets fulfilled off disk:
+ * no egress, version pinned by the lockfile, no CDN in the render path, and
+ * charts render with the network fully unplugged. Reads are confined to this
+ * one resolved module path — the URL never influences which file is opened.
+ */
+export function resolveVendoredAsset(rawUrl: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (url.hostname !== 'cdn.jsdelivr.net' || !ECHARTS_CDN_PATH_RE.test(url.pathname)) return null;
+  try {
+    return require_.resolve('echarts/dist/echarts.min.js');
+  } catch {
+    // Dependency missing — fall through to the allowlist, which denies it. The
+    // chart renders empty (visibly broken) instead of silently reaching a CDN.
+    return null;
+  }
+}
+
+/**
+ * Load an mviz embed in a network-sandboxed page and hand it to `fn`.
+ *
+ * Shared by the PNG path and by `probeRenderedChart`, so a test asserting the
+ * chart actually drew exercises the same sandbox production renders through —
+ * the empty-chart bug lived entirely in this route handler, so a test that
+ * built its own page would have missed it.
+ */
+async function withRenderedPage<T>(html: string, fn: (page: Page) => Promise<T>): Promise<T> {
   const browser = await getBrowser();
   const page = await browser.newPage({
     viewport: { width: 900, height: 600 },
     deviceScaleFactor: 2,
   });
   try {
-    // Sandbox the render's network: allow only the self-contained embed's font
-    // fetch, abort everything else. This is the load-bearing control against
-    // SSRF/exfil from attacker-influenced chart content — see the comment on
-    // isAllowedResourceUrl. Registered before setContent so the very first
+    // Sandbox the render's network: serve the chart library from disk, allow
+    // only the embed's font fetch, abort everything else. This is the
+    // load-bearing control against SSRF/exfil from attacker-influenced chart
+    // content — see the comments on isAllowedResourceUrl and
+    // resolveVendoredAsset. Registered before setContent so the very first
     // subresource load is already gated.
     await page.route('**/*', (route) => {
-      if (isAllowedResourceUrl(route.request().url())) {
+      const url = route.request().url();
+      const vendored = resolveVendoredAsset(url);
+      if (vendored) {
+        void route.fulfill({ path: vendored, contentType: 'application/javascript; charset=utf-8' });
+      } else if (isAllowedResourceUrl(url)) {
         void route.continue();
       } else {
         void route.abort();
@@ -104,7 +156,46 @@ export async function renderHtmlToPng(html: string): Promise<Buffer> {
     }
     // Give charts a beat to animate/settle before capturing.
     await page.waitForTimeout(500);
+    return await fn(page);
+  } finally {
+    await page.close().catch(() => {});
+  }
+}
 
+/**
+ * What a rendered embed's DOM actually contains. Exists so tests can assert the
+ * chart drew — a blank tile is a perfectly valid PNG, so pixel output alone
+ * cannot distinguish a working chart from a failed one.
+ */
+export interface RenderedChartProbe {
+  echartsInstances: number;
+  svgPaths: number;
+  text: string;
+}
+
+export async function probeRenderedChart(html: string): Promise<RenderedChartProbe> {
+  return withRenderedPage(html, (page) =>
+    page.evaluate(`(() => ({
+      echartsInstances: document.querySelectorAll('[_echarts_instance_]').length,
+      svgPaths: document.querySelectorAll('svg path').length,
+      text: document.body.innerText || '',
+    }))()`),
+  );
+}
+
+/**
+ * Render an mviz embed HTML document to a PNG buffer.
+ *
+ * The page is 900px wide and mviz lays the chart out on its 16-column grid,
+ * so the fence's `size=[w,h]` decides the `.grid-item` box (w=8 → ~424px
+ * wide, taller h → taller box). Screenshot THAT box — plus a little padding,
+ * clamped to the dashboard — so the PNG Slack displays is the size the spec
+ * asked for, not a full-width canvas with dead space beside a half-width
+ * chart. Multi-tile embeds and missing selectors fall back to the
+ * `.dashboard` root, then to a full-page shot.
+ */
+export async function renderHtmlToPng(html: string): Promise<Buffer> {
+  return withRenderedPage(html, async (page) => {
     const root = page.locator('.dashboard').first();
     let buffer: Buffer | null = null;
     try {
@@ -130,9 +221,7 @@ export async function renderHtmlToPng(html: string): Promise<Buffer> {
       // fall through to the full-page shot
     }
     return buffer ?? (await page.screenshot({ type: 'png', fullPage: true }));
-  } finally {
-    await page.close().catch(() => {});
-  }
+  });
 }
 
 /** Close the shared browser. Best-effort; safe to call when never launched. */

--- a/projects/quackbot/src/slack/screenshot.ts
+++ b/projects/quackbot/src/slack/screenshot.ts
@@ -74,12 +74,29 @@ const require_ = createRequire(import.meta.url);
 
 /**
  * The chart-library script mviz asks jsdelivr for, e.g.
- * `/npm/echarts@5.5.0/dist/echarts.min.js`. Matched by shape rather than by
- * exact version so an mviz bump to a new echarts patch keeps rendering; the
- * bundle actually served is always the lockfile-pinned local one, and
- * `screenshot.test.ts` fails if mviz's pinned MAJOR ever moves past ours.
+ * `/npm/echarts@5.5.0/dist/echarts.min.js`. Capture group 1 is the major.
  */
-const ECHARTS_CDN_PATH_RE = /^\/npm\/echarts@[^/]+\/dist\/echarts(\.min)?\.js$/;
+const ECHARTS_CDN_PATH_RE = /^\/npm\/echarts@(\d+)[^/]*\/dist\/echarts(\.min)?\.js$/;
+
+/**
+ * Major version of the echarts we vendor. A request for a DIFFERENT major is
+ * refused rather than answered with this bundle: serving echarts 5 to an embed
+ * written against echarts 6 would reintroduce the very bug this vendoring
+ * fixes — a blank chart — but silently, and with the mismatch buried a layer
+ * deeper. Refusing instead fails closed at the allowlist and trips the
+ * "covers every external script" test in `screenshot.test.ts`, which is what
+ * turns an mviz major bump into a build-time failure with a name on it.
+ *
+ * Patch and minor bumps inside the major are served as usual.
+ */
+const VENDORED_ECHARTS_MAJOR = ((): string | null => {
+  try {
+    const { version } = require_('echarts/package.json') as { version: string };
+    return version.split('.')[0] ?? null;
+  } catch {
+    return null;
+  }
+})();
 
 /**
  * Map a CDN request to a local file to serve in its place, or null to let the
@@ -104,7 +121,11 @@ export function resolveVendoredAsset(rawUrl: string): string | null {
   } catch {
     return null;
   }
-  if (url.hostname !== 'cdn.jsdelivr.net' || !ECHARTS_CDN_PATH_RE.test(url.pathname)) return null;
+  if (url.hostname !== 'cdn.jsdelivr.net') return null;
+  const match = ECHARTS_CDN_PATH_RE.exec(url.pathname);
+  if (!match) return null;
+  // Only answer for the major we actually vendor — see VENDORED_ECHARTS_MAJOR.
+  if (VENDORED_ECHARTS_MAJOR === null || match[1] !== VENDORED_ECHARTS_MAJOR) return null;
   try {
     return require_.resolve('echarts/dist/echarts.min.js');
   } catch {

--- a/projects/quackbot/src/slack/sink.test.ts
+++ b/projects/quackbot/src/slack/sink.test.ts
@@ -11,7 +11,7 @@ vi.mock('./screenshot', () => ({
   renderHtmlToPng: vi.fn(),
 }));
 
-import { SlackTurnSink } from './sink';
+import { SlackTurnSink, sanitizeSurrogates } from './sink';
 import { classifyMvizBlock, tableBlockToMarkdown } from './viz';
 import { renderHtmlToPng } from './screenshot';
 
@@ -533,5 +533,78 @@ describe('SlackTurnSink error handling', () => {
     sink.onText('hi');
     // finalize must resolve despite the update rejecting.
     await expect(sink.finalize()).resolves.toBeUndefined();
+  });
+});
+
+describe('SlackTurnSink surrogate safety', () => {
+  // @slack/web-api form-encodes with querystring.stringify, which throws
+  // ERR_INVALID_URI on an unpaired surrogate — and it throws for the WHOLE
+  // payload, so one split emoji anywhere loses the entire message (observed in
+  // production as `chat.update failed: URIError` retried to exhaustion).
+  const hasLoneSurrogate = (s: string): boolean =>
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(s);
+
+  /** Every string that would be form-encoded, from a payload of any shape. */
+  const allStrings = (value: unknown): string[] => {
+    if (typeof value === 'string') return [value];
+    if (Array.isArray(value)) return value.flatMap(allStrings);
+    if (value !== null && typeof value === 'object') return Object.values(value).flatMap(allStrings);
+    return [];
+  };
+
+  it('sanitizeSurrogates drops unpaired halves and keeps whole pairs intact', () => {
+    expect(sanitizeSurrogates('a😀b')).toBe('a😀b'); // 😀 survives
+    expect(sanitizeSurrogates('a\uD83Db')).toBe('ab'); // lone high
+    expect(sanitizeSurrogates('a\uDE00b')).toBe('ab'); // lone low
+    expect(sanitizeSurrogates('trailing\uD83D')).toBe('trailing');
+    expect(hasLoneSurrogate(sanitizeSurrogates('\uD83D😀\uDE00'))).toBe(false);
+  });
+
+  it('never sends a lone surrogate when an emoji straddles the interim cap', async () => {
+    const { client, updates } = makeClient();
+    const sink = makeSink(client);
+
+    // Land a 😀 exactly on the 3899-char interim cut, so a naive slice(0, 3899)
+    // keeps only its high half.
+    sink.onText(`${'x'.repeat(3898)}😀${'y'.repeat(200)}`);
+    await sink.finalize();
+
+    expect(updates.length).toBeGreaterThan(0);
+    for (const u of updates) {
+      for (const s of allStrings(u)) expect(hasLoneSurrogate(s)).toBe(false);
+    }
+  });
+
+  it('never sends a lone surrogate when a streaming delta splits a pair', async () => {
+    const { client, updates } = makeClient();
+    const sink = makeSink(client);
+
+    // A model/tool boundary can cut a surrogate pair across two deltas; an
+    // interim repaint in between renders the half-formed accumulation.
+    sink.onText('total: \uD83D');
+    sink.onText('\uDE00 done');
+    await sink.finalize();
+
+    for (const u of updates) {
+      for (const s of allStrings(u)) expect(hasLoneSurrogate(s)).toBe(false);
+    }
+  });
+
+  it('strips a lone surrogate arriving in query-result text', async () => {
+    const { client, updates, posts } = makeClient();
+    const sink = makeSink(client);
+
+    // Row data is not guaranteed to be well-formed UTF-16 once it round-trips
+    // through JSON — a bare \uD800 in a cell must not take down the message.
+    sink.onText('here is the value: \uD800 and the rest of the answer');
+    await sink.finalize();
+
+    for (const payload of [...updates, ...posts]) {
+      for (const s of allStrings(payload)) expect(hasLoneSurrogate(s)).toBe(false);
+    }
+    const joined = updates
+      .flatMap((u) => allStrings(u))
+      .join('\n');
+    expect(joined).toContain('and the rest of the answer');
   });
 });

--- a/projects/quackbot/src/slack/sink.ts
+++ b/projects/quackbot/src/slack/sink.ts
@@ -61,11 +61,54 @@ function verbFor(name: string): string {
   return TOOL_VERBS[name] ?? 'working';
 }
 
+/**
+ * Back a split index off by one when it would land between a surrogate pair.
+ *
+ * `slice` cuts on UTF-16 code units, so a cap falling mid-emoji leaves a lone
+ * surrogate at the seam. `@slack/web-api` form-encodes the payload with
+ * `querystring.stringify`, which throws `ERR_INVALID_URI` on an unpaired
+ * surrogate — so the call fails, fails every retry, and the message never
+ * repaints. Cheap to avoid at every cap site; `sanitizeSurrogates` is the
+ * backstop for pairs split anywhere else.
+ */
+function safeSplitIndex(s: string, at: number): number {
+  if (at <= 0 || at >= s.length) return at;
+  const prev = s.charCodeAt(at - 1);
+  const isHighSurrogate = prev >= 0xd800 && prev <= 0xdbff;
+  return isHighSurrogate ? at - 1 : at;
+}
+
+/**
+ * Drop unpaired surrogates from an outgoing payload string.
+ *
+ * The cap sites use `safeSplitIndex`, but a lone surrogate can also reach us
+ * from a streaming delta boundary that split a pair (an interim repaint renders
+ * whatever has accumulated) or from a query result whose text carries one. Any
+ * single one of them makes the whole Slack call throw `ERR_INVALID_URI`, so
+ * strip them at the send chokepoint rather than trusting every producer.
+ */
+export function sanitizeSurrogates(s: string): string {
+  // A high surrogate not followed by a low one, or a low one not preceded by a high.
+  return s.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, '');
+}
+
+/** Recursively apply `sanitizeSurrogates` to every string in a Slack payload. */
+function sanitizePayload<T>(value: T): T {
+  if (typeof value === 'string') return sanitizeSurrogates(value) as T;
+  if (Array.isArray(value)) return value.map(sanitizePayload) as T;
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, sanitizePayload(v)]),
+    ) as T;
+  }
+  return value;
+}
+
 /** Split `s` at or before `cap`, preferring a newline boundary. */
 function findSplit(s: string, cap: number): number {
   const nl = s.lastIndexOf('\n', cap);
   if (nl > cap * 0.5) return nl + 1;
-  return cap;
+  return safeSplitIndex(s, cap);
 }
 
 /** Split a stable final body into chunks each ≤ FINAL_CAP, at newline boundaries. */
@@ -84,7 +127,7 @@ function splitForFinal(body: string): string[] {
 /** Cap the notification-fallback `text` well under Slack's recommended 4k. */
 function truncateFallback(s: string): string {
   if (s.length <= INTERIM_CAP) return s;
-  return `${s.slice(0, INTERIM_CAP - 1)}…`;
+  return `${s.slice(0, safeSplitIndex(s, INTERIM_CAP - 1))}…`;
 }
 
 /**
@@ -97,7 +140,7 @@ function truncateFallback(s: string): string {
 function capForText(s: string): string {
   if (s.length <= SLACK_TEXT_CAP) return s;
   const note = '\n\n_…truncated…_';
-  return `${s.slice(0, SLACK_TEXT_CAP - note.length)}${note}`;
+  return `${s.slice(0, safeSplitIndex(s, SLACK_TEXT_CAP - note.length))}${note}`;
 }
 
 function delay(ms: number): Promise<void> {
@@ -393,7 +436,8 @@ export class SlackTurnSink implements TurnSink {
       // cap so a single chat.update always succeeds; the authoritative full
       // answer (split across messages) lands in finalize. A failed interim is
       // fine to swallow — finalize self-heals.
-      const shown = body.length > INTERIM_CAP ? `${body.slice(0, INTERIM_CAP - 1)}…` : body;
+      const shown =
+        body.length > INTERIM_CAP ? `${body.slice(0, safeSplitIndex(body, INTERIM_CAP - 1))}…` : body;
       // The 3.9k cap is on the MARKDOWN source, but toMrkdwn's ASCII-table
       // padding can expand a small table past Slack's text limit — so re-cap the
       // CONVERTED string (note appended after slicing) or the update is rejected.
@@ -461,7 +505,7 @@ export class SlackTurnSink implements TurnSink {
     blocks?: object[];
   }): Promise<boolean> {
     try {
-      await this.client.chat.update(args);
+      await this.client.chat.update(sanitizePayload(args));
       return true;
     } catch (err) {
       console.warn('[quackbot] chat.update failed:', err);
@@ -474,7 +518,7 @@ export class SlackTurnSink implements TurnSink {
       await this.client.chat.postMessage({
         channel: this.channel,
         ...(this.threadTs ? { thread_ts: this.threadTs } : {}),
-        ...args,
+        ...sanitizePayload(args),
       });
       return true;
     } catch (err) {


### PR DESCRIPTION
Charts rendered as a tile title over blank space. mviz's embed document.writes a script tag for echarts from cdn.jsdelivr.net, and the render sandbox (added with #81's hardening, after that branch's live smoke) aborts all egress except Google Fonts — so the page threw `echarts is not defined` and only static markup drew. Tables were unaffected since they never touch Chromium.

Fix: vendor echarts as a pinned dep and fulfill that one request off disk (`resolveVendoredAsset`), gated on a matching major, rather than allowlisting cdn.jsdelivr.net — which would give attacker-influenced page content a fetch channel to any npm package at any path. Charts now render with the network unplugged.

Also fixes `chat.update failed: URIError [ERR_INVALID_URI]` from the prod logs: slice() truncation on UTF-16 code units left a lone surrogate when a cap landed mid-emoji, and querystring.stringify in @slack/web-api throws on one, dropping the whole payload and stranding the message on its placeholder.

245/245 tests pass (was 233). Codex-reviewed, two passes: first found the version matcher accepted any echarts major (fixed in bca5058), second was clean.