### PR TITLE
postgres_cdc: MotherDuck Postgres-CDC replicator (submodule + CI-on-labs + Flight)

### DIFF
--- a/.github/workflows/postgres_cdc-build.yml
+++ b/.github/workflows/postgres_cdc-build.yml
@@ -1,0 +1,106 @@
+name: postgres_cdc build
+
+# Builds the MotherDuck Postgres-CDC replicator (`etl-replicator`, ducklake
+# feature only) from the `projects/postgres_cdc/etl` submodule (the
+# Alex-Monahan/etl fork @ branch motherduck-minimal) and publishes a standalone
+# Linux x86_64 binary as a LABS GitHub Release. A MotherDuck Flight
+# (`projects/postgres_cdc/flight/flight_postgres_cdc.py`) pulls the latest green
+# build from this release via its `resolve_binary()` resolver.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - postgres_cdc
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    # Build on an older glibc (Ubuntu 22.04 = glibc 2.35) so the binary runs on
+    # the Flights Debian base image. ubuntu-latest ships a newer glibc that
+    # fails with "GLIBC_2.3x not found" on the Flight.
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout (with submodule)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        # ducklake-only build: no protobuf needed.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            libssl-dev \
+            clang \
+            lld \
+            make \
+            cmake
+
+      - name: Install Rust toolchain
+        # Honors the submodule's rust-toolchain.toml (channel 1.95.0).
+        working-directory: projects/postgres_cdc/etl
+        run: rustup show
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: projects/postgres_cdc/etl
+
+      - name: Build etl-replicator (ducklake only)
+        working-directory: projects/postgres_cdc/etl
+        run: |
+          cargo build --release -p etl-replicator \
+            --no-default-features --features ducklake
+          strip target/release/etl-replicator
+          cp target/release/etl-replicator "$GITHUB_WORKSPACE/etl-replicator-linux-amd64"
+
+      - name: Package binary and build manifest
+        env:
+          # Recorded into latest.json so the MotherDuck Flight resolver can
+          # verify it is pulling exactly this successful LABS build.
+          BUILD_SHA: ${{ github.sha }}
+          BUILD_RUN_ID: ${{ github.run_id }}
+          BUILD_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          mkdir -p dist
+          cp etl-replicator-linux-amd64 dist/
+          cd dist
+          gzip -9 etl-replicator-linux-amd64
+          # SHA256SUMS is the sha256 of the .gz asset that consumers download.
+          GZ_SHA=$(sha256sum etl-replicator-linux-amd64.gz | awk '{print $1}')
+          sha256sum etl-replicator-linux-amd64.gz > SHA256SUMS
+          # latest.json makes "the latest successful build" explicit + traceable.
+          BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          jq -n \
+            --arg sha "$BUILD_SHA" \
+            --argjson run_id "$BUILD_RUN_ID" \
+            --arg run_url "$BUILD_RUN_URL" \
+            --arg built_at "$BUILT_AT" \
+            --arg asset "etl-replicator-linux-amd64.gz" \
+            --arg sha256 "$GZ_SHA" \
+            '{sha:$sha, run_id:$run_id, run_url:$run_url, built_at:$built_at, asset:$asset, sha256:$sha256}' \
+            > latest.json
+          echo "--- latest.json ---"; cat latest.json
+          echo "--- SHA256SUMS ---"; cat SHA256SUMS
+          ls -la
+
+      - name: Publish release
+        # Runs only on success (default job flow), so whatever lands in the
+        # release is by definition the latest successful build. Recreate the
+        # release so the tag always tracks this build; latest.json records the
+        # exact sha / run for traceable, verifiable pulls.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="postgres_cdc-replicator"
+          gh release delete "$TAG" --yes --cleanup-tag || true
+          gh release create "$TAG" \
+            --title "MotherDuck Postgres-CDC replicator (linux/amd64)" \
+            --notes "etl-replicator built with the ducklake feature for native MotherDuck Postgres CDC replication, from the projects/postgres_cdc/etl submodule. Commit ${GITHUB_SHA}." \
+            dist/etl-replicator-linux-amd64.gz \
+            dist/SHA256SUMS \
+            dist/latest.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "projects/postgres_cdc/etl"]
+	path = projects/postgres_cdc/etl
+	url = https://github.com/Alex-Monahan/etl
+	branch = motherduck-minimal

--- a/projects/postgres_cdc/README.md
+++ b/projects/postgres_cdc/README.md
@@ -1,0 +1,85 @@
+# postgres_cdc
+
+Packages the **MotherDuck Postgres-CDC replicator** end to end: source code as a
+git submodule, a CI build that runs **on labs**, and a MotherDuck **Flight** that
+pulls the resulting binary from the labs release.
+
+## Layout
+
+```
+projects/postgres_cdc/
+├── etl/                                  # git submodule -> Alex-Monahan/etl @ motherduck-minimal
+├── flight/
+│   ├── flight_postgres_cdc.py            # MotherDuck Flight (pull-model resolver)
+│   └── flight_postgres_cdc_requirements.txt
+└── README.md
+.github/workflows/postgres_cdc-build.yml  # CI build (must live at repo root per GH Actions)
+```
+
+### 1. Submodule → the fork
+
+`projects/postgres_cdc/etl` is a git submodule pointing at the
+[`Alex-Monahan/etl`](https://github.com/Alex-Monahan/etl) fork of Supabase ETL,
+tracking branch **`motherduck-minimal`** and pinned to a specific commit. This is
+the MotherDuck-minimal replicator source (a ducklake-only `etl-replicator`).
+
+Update the pin with:
+
+```bash
+git submodule update --remote projects/postgres_cdc/etl
+git add projects/postgres_cdc/etl && git commit -m "bump etl submodule"
+```
+
+### 2. CI on labs builds the submodule + publishes the release
+
+[`.github/workflows/postgres_cdc-build.yml`](../../.github/workflows/postgres_cdc-build.yml)
+triggers on push to the `postgres_cdc` branch (and `workflow_dispatch`). It:
+
+- checks out with `submodules: recursive`,
+- builds on `ubuntu-22.04` (glibc 2.35, for Flight compatibility),
+- honors the submodule's pinned Rust toolchain (`rustup show` → 1.95.0),
+- builds `cargo build --release -p etl-replicator --no-default-features --features ducklake`
+  inside the submodule, strips + gzips the binary,
+- computes `SHA256SUMS` (of the `.gz`) and a `latest.json` manifest
+  (`sha`, `run_id`, `run_url`, `built_at`, `asset`, `sha256`), and
+- on success, **recreates** the labs GitHub Release tag
+  [`postgres_cdc-replicator`](https://github.com/motherduckdb/labs/releases/tag/postgres_cdc-replicator)
+  so the tag always tracks the latest green build, publishing
+  `etl-replicator-linux-amd64.gz` + `SHA256SUMS` + `latest.json`.
+
+The build is ducklake-only: no protobuf, no sccache/failpoints/LTO.
+
+### 3. The Flight pulls the latest green labs build
+
+[`flight/flight_postgres_cdc.py`](flight/flight_postgres_cdc.py) uses a
+**pull-model** `resolve_binary()`: instead of a hardcoded URL, it asks the
+GitHub API for the newest **successful** run of the build workflow on labs, then
+downloads the release asset and verifies it two ways before ever spawning the
+replicator:
+
+1. `latest.json.sha` **must equal** the head SHA of the latest green run
+   (rejects a stale-release race), and
+2. the downloaded `.gz` **must** match `latest.json.sha256` (and cross-checks
+   `SHA256SUMS`).
+
+It is configured for labs via these keys (Flight `config`, all overridable):
+
+| key | value |
+| --- | --- |
+| `BUILD_REPO` | `motherduckdb/labs` |
+| `BUILD_WORKFLOW` | `postgres_cdc-build.yml` |
+| `BUILD_BRANCH` | `postgres_cdc` |
+| `RELEASE_TAG` | `postgres_cdc-replicator` |
+
+It then replicates a small PlanetScale `tpch` table (`region`, 5 rows) into a
+native MotherDuck database (`postgres_cdc_labs`) via the in-place DuckLake
+destination (`catalog_url: md:<database>`), and proves backfill landed by
+comparing the destination row count to the source count. Non-destructive: it
+never modifies the source table.
+
+#### Rollback with `PIN_SHA`
+
+Set the `PIN_SHA` config/env key to a specific commit SHA to bypass the "latest
+green" API lookup and pin the resolver to that build (it still verifies the
+checksum against `latest.json`). Leave it unset to always track the newest green
+labs build.

--- a/projects/postgres_cdc/flight/flight_postgres_cdc.py
+++ b/projects/postgres_cdc/flight/flight_postgres_cdc.py
@@ -1,0 +1,315 @@
+"""MotherDuck Postgres-CDC replication proof (Flight).
+
+Resolves the `etl-replicator` from the LATEST SUCCESSFUL CI build of the
+`postgres_cdc-build.yml` workflow ON LABS (motherduckdb/labs), verified against
+the commit SHA + a sha256 checksum via the rolling `postgres_cdc-replicator`
+release + its `latest.json`, then replicates a small PlanetScale table
+(`tpch.region`) into a NATIVE MotherDuck database using the in-place
+DuckLake destination config with a `md:<database>` catalog URL:
+
+  {"destination":{"ducklake":{
+      "catalog_url":"md:<database>",
+      "metadata_catalog_url":"postgres://…?sslmode=require",
+      "metadata_schema":"…",
+      "maintenance_mode":"disabled"}},
+   "pipeline":{…}}
+
+Proves backfill lands (row count in MotherDuck == source count). Non-destructive:
+does not modify the source table. Never touches the `lineitem` table.
+"""
+import gzip, hashlib, json, os, shutil, subprocess, time, urllib.request, urllib.error
+import certifi, duckdb, psycopg
+
+
+def env(n, d=None):
+    return os.environ.get(n, d)
+
+
+H = env("PGHOST", "us-east-2.pg.psdb.cloud")
+PORT = int(env("PGPORT", "5432"))
+DB = env("PGDATABASE", "postgres")
+U = env("PGUSER", "pscale_api_s6z748j4md6b.sbodytoesjz2")
+MD_DB = env("MD_DB", "postgres_cdc_labs")
+SRC_SCHEMA = env("SRC_SCHEMA", "tpch")
+SRC_TABLE = env("SRC_TABLE", "region")
+PID = int(env("PIPELINE_ID", "911"))
+PUB = env("PUBLICATION_NAME", "postgres_cdc_labs_pub")
+META_SCHEMA = env("METADATA_SCHEMA", "postgres_cdc_labs_meta")
+BIN = "/tmp/etl-replicator-postgres-cdc"
+CFG = "/tmp/etl_postgres_cdc_cfg"
+# --- Resolver: pull the LATEST SUCCESSFUL CI build of the replicator ---
+# Instead of a hardcoded release URL, resolve the binary from the newest green
+# run of the build workflow, verified against the commit SHA + a sha256 checksum.
+BUILD_REPO = env("BUILD_REPO", "motherduckdb/labs")
+BUILD_WORKFLOW = env("BUILD_WORKFLOW", "postgres_cdc-build.yml")
+BUILD_BRANCH = env("BUILD_BRANCH", "postgres_cdc")
+RELEASE_TAG = env("RELEASE_TAG", "postgres_cdc-replicator")
+PIN_SHA = env("PIN_SHA")  # optional: pin to a specific commit sha (skips the API)
+
+
+def pw():
+    return os.environ["planetscale_cdc_password"]
+
+
+def pg():
+    return psycopg.connect(
+        host=H, port=PORT, dbname=DB, user=U, password=pw(),
+        sslmode="require", autocommit=True,
+    )
+
+
+def md():
+    return duckdb.connect("md:")
+
+
+def meta_url():
+    return f"postgres://{U}:{pw()}@{H}:{PORT}/{DB}?sslmode=require"
+
+
+def _http(url, accept=None, binary=False):
+    req = urllib.request.Request(url)
+    if accept:
+        req.add_header("Accept", accept)
+    tok = env("GITHUB_TOKEN")  # optional: only raises API rate limits
+    if tok:
+        req.add_header("Authorization", f"Bearer {tok}")
+    with urllib.request.urlopen(req, timeout=60) as r:
+        data = r.read()
+    return data if binary else data.decode("utf-8")
+
+
+def _latest_green_run():
+    """Return (head_sha, run_id, run_url) for the newest successful workflow run."""
+    api = (
+        f"https://api.github.com/repos/{BUILD_REPO}/actions/workflows/"
+        f"{BUILD_WORKFLOW}/runs?branch={BUILD_BRANCH}&status=success&per_page=1"
+    )
+    payload = json.loads(_http(api, accept="application/vnd.github+json"))
+    runs = payload.get("workflow_runs") or []
+    if not runs:
+        raise RuntimeError(
+            f"no successful runs of {BUILD_WORKFLOW} on branch {BUILD_BRANCH} in {BUILD_REPO}"
+        )
+    r = runs[0]
+    return r["head_sha"], r["id"], r.get("html_url")
+
+
+def resolve_binary():
+    """Resolve + verify the replicator binary from the latest successful CI build.
+
+    Returns a metadata dict (sha/run_id/run_url/built_at) for traceability.
+    Aborts (raises) on any resolution or verification failure so we never spawn
+    the replicator with a stale or corrupt binary.
+    """
+    if PIN_SHA:
+        target_sha, run_id, run_url = PIN_SHA, None, None
+        print(f"[resolve] PIN_SHA set -> targeting sha {target_sha}", flush=True)
+    else:
+        target_sha, run_id, run_url = _latest_green_run()
+        print(
+            f"[resolve] latest green run: sha={target_sha} run_id={run_id} url={run_url}",
+            flush=True,
+        )
+
+    # Fetch the release manifest (public, no auth needed).
+    base = f"https://github.com/{BUILD_REPO}/releases/download/{RELEASE_TAG}"
+    manifest = json.loads(_http(f"{base}/latest.json"))
+    print(f"[resolve] latest.json: {json.dumps(manifest)}", flush=True)
+
+    # Verify the release matches the target commit (reject stale-release race).
+    if manifest.get("sha") != target_sha:
+        raise RuntimeError(
+            "release/target SHA mismatch: latest.json.sha="
+            f"{manifest.get('sha')} != target={target_sha}. "
+            "Release is stale vs the newest green build; refusing to run."
+        )
+
+    asset = manifest.get("asset", "etl-replicator-linux-amd64.gz")
+    want_sha256 = manifest["sha256"]
+    # run_id/run_url come from latest.json when pinning (API was skipped).
+    if run_id is None:
+        run_id, run_url = manifest.get("run_id"), manifest.get("run_url")
+
+    # Cache by sha: skip re-download if the same sha is already local + valid.
+    sha_marker = BIN + ".sha"
+    if os.path.exists(BIN) and os.path.exists(sha_marker):
+        if open(sha_marker).read().strip() == target_sha:
+            print(f"[resolve] cache hit for sha {target_sha}; skipping download", flush=True)
+            _log_resolved(target_sha, run_id, run_url, manifest.get("built_at"))
+            return {"sha": target_sha, "run_id": run_id, "run_url": run_url,
+                    "built_at": manifest.get("built_at"), "cached": True}
+
+    # Download the .gz asset and verify its sha256 against the manifest.
+    gz = BIN + ".gz"
+    gz_bytes = _http(f"{base}/{asset}", binary=True)
+    got_sha256 = hashlib.sha256(gz_bytes).hexdigest()
+    if got_sha256 != want_sha256:
+        raise RuntimeError(
+            f"checksum mismatch for {asset}: got {got_sha256} != latest.json {want_sha256}"
+        )
+    print(f"[resolve] sha256 verified: {got_sha256}", flush=True)
+
+    # Cross-check against SHA256SUMS too (best-effort; must agree if present).
+    try:
+        sums = _http(f"{base}/SHA256SUMS")
+        for line in sums.splitlines():
+            parts = line.split()
+            if len(parts) == 2 and parts[1].lstrip("*").endswith(asset):
+                if parts[0] != want_sha256:
+                    raise RuntimeError(
+                        f"SHA256SUMS disagrees with latest.json for {asset}: "
+                        f"{parts[0]} != {want_sha256}"
+                    )
+                print("[resolve] SHA256SUMS cross-check OK", flush=True)
+    except urllib.error.HTTPError:
+        pass
+
+    with open(gz, "wb") as f:
+        f.write(gz_bytes)
+    with gzip.open(gz, "rb") as i, open(BIN, "wb") as o:
+        shutil.copyfileobj(i, o)
+    os.chmod(BIN, 0o755)
+    open(sha_marker, "w").write(target_sha)
+    print(f"[binary] {os.path.getsize(BIN)} bytes (sha {target_sha})", flush=True)
+    _log_resolved(target_sha, run_id, run_url, manifest.get("built_at"))
+    return {"sha": target_sha, "run_id": run_id, "run_url": run_url,
+            "built_at": manifest.get("built_at"), "cached": False}
+
+
+def _log_resolved(sha, run_id, run_url, built_at):
+    print(
+        "[RESOLVED] " + json.dumps(
+            {"sha": sha, "run_id": run_id, "run_url": run_url, "built_at": built_at}
+        ),
+        flush=True,
+    )
+
+
+def source_count():
+    with pg() as c:
+        cur = c.cursor()
+        cur.execute(f'select count(*) from "{SRC_SCHEMA}"."{SRC_TABLE}"')
+        return cur.fetchone()[0]
+
+
+def prepare_source():
+    # Create a publication for exactly the one small table, and clear any stale
+    # replication slots from a previous run of this pipeline id. The source
+    # table itself is never modified.
+    with pg() as c:
+        cur = c.cursor()
+        cur.execute(
+            "select pg_terminate_backend(active_pid) from pg_replication_slots "
+            "where active_pid is not null and (slot_name like %s or slot_name like %s)",
+            (f"supabase_etl_apply_{PID}", f"supabase_etl_table_sync_{PID}_%"),
+        )
+        time.sleep(1)
+        cur.execute(
+            "select pg_drop_replication_slot(slot_name) from pg_replication_slots "
+            "where slot_name like %s or slot_name like %s",
+            (f"supabase_etl_apply_{PID}", f"supabase_etl_table_sync_{PID}_%"),
+        )
+        cur.execute("drop schema if exists etl cascade")
+        cur.execute(f"drop publication if exists {PUB}")
+        cur.execute(f'create publication {PUB} for table "{SRC_SCHEMA}"."{SRC_TABLE}"')
+    print(f"[source] publication {PUB} -> {SRC_SCHEMA}.{SRC_TABLE}", flush=True)
+
+
+def prepare_dest():
+    con = md()
+    con.execute(f'CREATE DATABASE IF NOT EXISTS "{MD_DB}"')
+    con.execute(f'DROP SCHEMA IF EXISTS "{MD_DB}"."{SRC_SCHEMA}" CASCADE')
+    for mk in ("__etl_applied_table_batches", "__etl_streaming_progress"):
+        try:
+            con.execute(f'DROP TABLE IF EXISTS "{MD_DB}"."main"."{mk}"')
+        except Exception:
+            pass
+    # Also clear the replay-epoch bookkeeping schema in the metadata catalog.
+    with pg() as c:
+        c.cursor().execute(f'drop schema if exists "{META_SCHEMA}" cascade')
+    print(f"[dest] reset MotherDuck database {MD_DB}", flush=True)
+
+
+def write_cfg():
+    os.makedirs(CFG, exist_ok=True)
+    base = {
+        "destination": {
+            "ducklake": {
+                "catalog_url": f"md:{MD_DB}",
+                "metadata_catalog_url": meta_url(),
+                "metadata_schema": META_SCHEMA,
+                "maintenance_mode": "disabled",
+            }
+        },
+        "pipeline": {
+            "id": PID,
+            "publication_name": PUB,
+            "memory_backpressure": None,
+            "pg_connection": {
+                "host": H, "port": PORT, "name": DB, "username": U, "password": pw(),
+                "tls": {"enabled": True, "trusted_root_certs": open(certifi.where()).read()},
+            },
+        },
+    }
+    json.dump(base, open(CFG + "/base.json", "w"))
+    open(CFG + "/prod.json", "w").write("{}")
+    print("[config] wrote base.json/prod.json (ducklake variant, md: catalog)", flush=True)
+
+
+def spawn():
+    e = dict(os.environ)
+    e["motherduck_token"] = os.environ["MOTHERDUCK_TOKEN"]
+    e["APP_CONFIG_DIR"] = CFG
+    e["APP_ENVIRONMENT"] = "prod"
+    e["RUST_LOG"] = "info,etl=info,etl_destinations=info"
+    return subprocess.Popen([BIN], env=e)
+
+
+def dest_count():
+    try:
+        return md().execute(
+            f'select count(*) from "{MD_DB}"."{SRC_SCHEMA}"."{SRC_TABLE}"'
+        ).fetchone()[0]
+    except Exception:
+        return 0
+
+
+def main():
+    binary = resolve_binary()  # aborts before spawn on any verify failure
+    src_n = source_count()
+    print(f"[source] {SRC_SCHEMA}.{SRC_TABLE} has {src_n} rows", flush=True)
+    prepare_source()
+    prepare_dest()
+    write_cfg()
+    p = spawn()
+    result = {"source_rows": src_n, "table": f"{SRC_SCHEMA}.{SRC_TABLE}",
+              "md_db": MD_DB, "binary": binary}
+    try:
+        deadline = time.time() + 300
+        landed = 0
+        while time.time() < deadline:
+            landed = dest_count()
+            if landed >= src_n and src_n > 0:
+                break
+            time.sleep(2)
+        result["dest_rows"] = landed
+        result["backfill_ok"] = bool(src_n > 0 and landed == src_n)
+        if result["backfill_ok"]:
+            sample = md().execute(
+                f'select * from "{MD_DB}"."{SRC_SCHEMA}"."{SRC_TABLE}" order by 1 limit 3'
+            ).fetchall()
+            result["sample"] = [list(map(str, r)) for r in sample]
+    finally:
+        if p.poll() is None:
+            p.terminate()
+            try:
+                p.wait(timeout=25)
+            except Exception:
+                p.kill()
+    result["pass"] = result.get("backfill_ok", False)
+    print("[RESULT] " + json.dumps(result), flush=True)
+    print(f"\nOVERALL: {'PASS' if result['pass'] else 'FAIL'}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/postgres_cdc/flight/flight_postgres_cdc_requirements.txt
+++ b/projects/postgres_cdc/flight/flight_postgres_cdc_requirements.txt
@@ -1,0 +1,3 @@
+duckdb==1.5.4
+psycopg[binary]==3.2.3
+certifi==2024.12.14


### PR DESCRIPTION
## What

Adds a new `projects/postgres_cdc/` project that packages the **MotherDuck Postgres-CDC replicator** end to end:

- **Submodule** `projects/postgres_cdc/etl` → [`Alex-Monahan/etl`](https://github.com/Alex-Monahan/etl) @ branch `motherduck-minimal` (pinned to `c5f2b1e`), the ducklake-only `etl-replicator` source (a fork of Supabase ETL).
- **CI build on labs** `.github/workflows/postgres_cdc-build.yml` — triggers on push to `postgres_cdc` + `workflow_dispatch`. Builds on `ubuntu-22.04` (glibc 2.35 for Flight compatibility), checks out the submodule recursively, honors its pinned Rust toolchain (1.95.0), builds `etl-replicator --no-default-features --features ducklake` (no protobuf, ducklake-only), strips + gzips, computes `SHA256SUMS` + `latest.json`, and on success recreates the labs release tag `postgres_cdc-replicator`.
- **Flight** `projects/postgres_cdc/flight/flight_postgres_cdc.py` — pull-model `resolve_binary()` pointed at labs (`BUILD_REPO=motherduckdb/labs`, `BUILD_WORKFLOW=postgres_cdc-build.yml`, `BUILD_BRANCH=postgres_cdc`, `RELEASE_TAG=postgres_cdc-replicator`). Verifies release `sha` == latest green run head SHA + sha256 checksum before spawning, then replicates PlanetScale `tpch.region` (5 rows) into a native MotherDuck database. Supports `PIN_SHA` rollback.
- **README** explaining the layout: submodule → fork, CI-on-labs build + release, Flight pull model.

## How it fits together

submodule (fork source) → CI on labs builds it + publishes the release → Flight pulls the latest green labs build via `resolve_binary()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcfmAoK9wnTUmPiGBHyAAJ