### PR TITLE
agentic-sql-context-mcp: --luna-max shortcut, retry transient MCP failures

### DIFF
--- a/projects/agentic-sql-context-mcp/src/run.py
+++ b/projects/agentic-sql-context-mcp/src/run.py
@@ -48,6 +48,7 @@ MODEL_ALIASES = {
     "haiku": "anthropic/claude-haiku-4.5",
     "gemini": "google/gemini-3-flash-preview",
     "gpt": "openai/gpt-5.5",
+    "luna": "openai/gpt-5.6-luna",
 }
 
 
@@ -250,10 +251,13 @@ def _correctness_mark(c: str) -> str:
 @click.option("--task-ids", "task_ids", type=str, default=None,
               help="Comma-separated task_ids to run as one batch (overrides --split).")
 @click.option("--max-turns", type=int, default=40)
-@click.option("--reasoning", type=click.Choice(["low", "medium", "high", "off"]), default="low",
+@click.option("--reasoning", type=click.Choice(["low", "medium", "high", "max", "off"]), default="low",
               help="Thinking budget. Default 'low' — the cost/accuracy sweet spot for this skill.")
 @click.option("--watch", is_flag=True, default=False, help="Stream tool calls live.")
 @click.option("--concurrency", type=int, default=15, help="Questions to run in parallel.")
+@click.option("--luna-max", "luna_max", is_flag=True, default=False,
+              help="Shortcut: openai/gpt-5.6-luna at reasoning=max (418/419 test @ $1.86, "
+                   "~1/5 the gemini cost). Overrides --model and --reasoning.")
 @click.option("--no-guides", "no_guides", is_flag=True, default=False,
               help="Ablation baseline: list_guides/get_guide always answer 'No guides "
                    "exist.' — measures the agent without the semantic layer.")
@@ -269,10 +273,13 @@ def evaluate(
     reasoning: str,
     watch: bool,
     concurrency: int,
+    luna_max: bool,
     no_guides: bool,
     out: Path | None,
 ) -> None:
     """Run the agent across the eval set and write per-question JSONL."""
+    if luna_max:
+        model, reasoning = "luna", "max"
     model = MODEL_ALIASES.get(model, model)
     database = database or _md_database()
 
@@ -311,6 +318,24 @@ def evaluate(
         max_turns=max_turns, reasoning=reasoning, watch=watch,
         concurrency=concurrency, no_guides=no_guides, out=out,
     ))
+
+
+def _describe_exception(e: BaseException) -> str:
+    """Render an exception for the jsonl `error` field. An ExceptionGroup's
+    str() hides the sub-exceptions (the MCP SDK surfaces transport failures
+    through an anyio TaskGroup) — flatten them so the actual cause is recorded."""
+    desc = f"{type(e).__name__}: {e}"
+    if isinstance(e, BaseExceptionGroup):
+        leaves: list[BaseException] = []
+        stack: list[BaseException] = [e]
+        while stack:
+            cur = stack.pop()
+            if isinstance(cur, BaseExceptionGroup):
+                stack.extend(cur.exceptions)
+            else:
+                leaves.append(cur)
+        desc += " [" + "; ".join(f"{type(s).__name__}: {s}" for s in leaves) + "]"
+    return desc
 
 
 def _tid_prefix(task_id: str | None) -> str:
@@ -483,23 +508,35 @@ async def _evaluate_loop(
 
             # One MCP session per task: all data + schema + guide access goes
             # server-side against md:<db> through this read-only session.
+            # MCP transport flakes come in bursts under concurrency (observed
+            # 18/419 on one run, all fine on retry) — one retry keeps a
+            # transient outage from being scored as incorrect answers.
             t0 = time.time()
-            try:
-                async with create_mcp_session(
-                    session_hint=tid, database=database, no_guides=no_guides,
-                ) as mcp:
-                    run = await run_agent(
-                        mcp=mcp, database=database,
-                        question=q["question"], guidelines=q.get("guidelines"),
-                        model=model, provider=provider, skill_text=skill_text,
-                        max_turns=max_turns,
-                        on_tool_call=(lambda call, _tid=tid: _render_tool_call(call, _tid)) if watch else None,
-                        on_thinking=(lambda text, _tid=tid: _render_thinking(text, _tid)) if watch else None,
-                    )
-                err = None
-            except Exception as e:
-                run = None
-                err = f"{type(e).__name__}: {e}"
+            run, err = None, None
+            for attempt in range(2):
+                try:
+                    async with create_mcp_session(
+                        session_hint=tid, database=database, no_guides=no_guides,
+                    ) as mcp:
+                        run = await run_agent(
+                            mcp=mcp, database=database,
+                            question=q["question"], guidelines=q.get("guidelines"),
+                            model=model, provider=provider, skill_text=skill_text,
+                            max_turns=max_turns,
+                            on_tool_call=(lambda call, _tid=tid: _render_tool_call(call, _tid)) if watch else None,
+                            on_thinking=(lambda text, _tid=tid: _render_thinking(text, _tid)) if watch else None,
+                        )
+                    err = None
+                    break
+                except Exception as e:
+                    run = None
+                    err = _describe_exception(e)
+                    if attempt == 0:
+                        console.print(
+                            f"  {_tid_prefix(tid)}[yellow]run failed, retrying:[/yellow] "
+                            f"[dim]{err[:160]}[/dim]"
+                        )
+                        await asyncio.sleep(3)
 
             elapsed = time.time() - t0
 


### PR DESCRIPTION
## Summary
- Benchmarked `openai/gpt-5.6-luna` at `reasoning=max` on the DABStep splits: **test 418/419 = 99.8% @ $1.86** (vs gemini-3-flash 418/419 @ $9.02 — same accuracy at ~1/5 the cost), templates 25/26 @ $0.12, 0 hit_limit, avg 22.5 turns.
- New `--luna-max` flag opts into that config; the **default stays gemini-3-flash @ reasoning=low**. A `luna` model alias and a `max` value for `--reasoning` are also available individually.

## Ops fixes
On the first test pass, 18/419 tasks were scored *incorrect* without making a single LLM call — MCP transport failures arriving in two tight bursts under concurrency 15, surfaced as bare `ExceptionGroup: unhandled errors in a TaskGroup`. All 18 passed on re-run.
- **Retry once on run failure** (3s pause) so a transient transport flake isn't scored as a wrong answer.
- **Flatten `BaseExceptionGroup` sub-exceptions** into the jsonl `error` field — `str()` on an ExceptionGroup hides the actual cause.

## Genuine misses (unchanged, for the record)
- test task 69 ("highest volume at which fees do not become cheaper", gold `>5m`): submitted `Not Applicable` after 27 calls.
- templates task 1711 (9-dim fee matching): right guides and day filter, but joined the final result via an amount-equality `EXISTS` semi-join across all merchants/days → 4.4× overcount.

## Test plan
- [x] `_describe_exception` unit-checked on nested ExceptionGroups and plain exceptions
- [x] Smoke run through the retry-refactored path (1/1 correct)
- [x] `--luna-max` smoke run resolves to luna @ max (1/1 correct); `--help` shows unchanged defaults
- [x] Full runs: templates 25/26, test 400/419 first pass + 18/18 on re-run (results jsonl are gitignored, kept locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)