### PR TITLE
agentic-sql-context-mcp: --reasoning off sends effort=none per OpenRouter docs

### DIFF
--- a/projects/agentic-sql-context-mcp/src/run.py
+++ b/projects/agentic-sql-context-mcp/src/run.py
@@ -456,7 +456,9 @@ async def _evaluate_loop(
     width = len(str(len(questions)))
     sem = asyncio.Semaphore(concurrency)
     write_lock = asyncio.Lock()
-    provider = OpenRouterProvider(reasoning_effort=None if reasoning == "off" else reasoning)
+    # OpenRouter's documented "disable reasoning" is effort="none"; omitting the
+    # reasoning param would instead fall back to the model's endpoint default.
+    provider = OpenRouterProvider(reasoning_effort="none" if reasoning == "off" else reasoning)
     skill_text = SKILL_PATH.read_text() if SKILL_PATH.exists() else None
     md_token = os.environ.get("MOTHERDUCK_TOKEN")
     if not md_token:


### PR DESCRIPTION
Follow-up to #116 (this commit was pushed to that branch just after it merged, so it never made it in).

Previously `--reasoning off` omitted the `reasoning` param, which falls back to the model's endpoint default — for a reasoning model that is not off. Per the [OpenRouter reasoning-tokens docs](https://openrouter.ai/docs/use-cases/reasoning-tokens), `effort: "none"` is the documented way to disable reasoning entirely (`minimal` shrinks the budget and `exclude` only hides the trace; neither disables it).

Smoke-tested with gpt-5.6-luna: accepts `effort=none`, 1/1 correct @ $0.0024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)