### PR TITLE
agentic-sql-context-mcp: Agentic Company benchmark profile

### DIFF
--- a/projects/agentic-sql-context-mcp/.env.example
+++ b/projects/agentic-sql-context-mcp/.env.example
@@ -16,3 +16,9 @@ MD_DATABASE=agentic_sql_claude
 # service-account token can write; "organization" needs an admin token.
 DABSTEP_GUIDES_PREFIX=dabstep
 DABSTEP_GUIDES_ACCESS=user
+
+# Agentic Company benchmark (optional). By default the harness resolves the
+# adjacent checkout at ../../../the-agentic-company and uses the shared
+# database alias agentic_company_snapshot.
+# AGENTIC_COMPANY_REPO=/absolute/path/to/the-agentic-company
+AGENTIC_COMPANY_MD_DATABASE=agentic_company_snapshot

--- a/projects/agentic-sql-context-mcp/README.md
+++ b/projects/agentic-sql-context-mcp/README.md
@@ -124,7 +124,7 @@ The same evaluation loop can run the 40-question Agentic Company DABstep set. It
 canonical `questions.jsonl` and `manual.md` from the adjacent `the-agentic-company` repository;
 it does not copy them into this project. By default that repository is resolved as
 `../../../the-agentic-company` from this project (set `AGENTIC_COMPANY_REPO` to override it).
-The v0.3.0 manifest contract and exact question/manual hashes are validated before model spend.
+The v0.3.1 manifest contract and exact question/manual hashes are validated before model spend.
 
 Only `manual.md` is published as model context. The architecture documents and private semantic
 contracts are never published or added to a prompt. The guide is personal (`access=user`): the
@@ -155,6 +155,10 @@ table discovery and rejects explicit schema references, metadata enumeration, an
 lookup as benchmark-integrity defenses. For a warehouse-enforced security boundary, publish a
 sanitized share that omits those schemas entirely.
 
+Before model spend, the profile also scans all 68 public relations and compares a deterministic
+row-count/content fingerprint with the canonical local database. This detects data changes behind
+the stable share URL instead of treating the snapshot cutoff as proof of database identity.
+
 ## Iterating toward 100%
 
 Each miss points at one of four artifacts to fix, then re-run:
@@ -173,6 +177,8 @@ skill/SKILL.md          the skill (procedure + navigation)
 context/items/*.md      the semantic-layer source (one file = one item; published as guides)
 src/mcp_client.py       MCP session + tool-call plumbing (query/schema/guides)
 src/agent.py            tools + prompt + OpenRouter provider
+src/agentic_company_profile.py  Agentic artifact contract, preflight, and profile policy
+src/agentic_company_score.py    strict criteria-driven Agentic Company scorer
 src/load.py             build the MotherDuck database
 src/run.py              CLI: load / guides-load / evaluate / summary
 src/score.py            DABStep scorer (verbatim)

--- a/projects/agentic-sql-context-mcp/README.md
+++ b/projects/agentic-sql-context-mcp/README.md
@@ -118,6 +118,43 @@ uvx --from "git+https://github.com/motherduckdb/labs#subdirectory=projects/contr
     controllog-viz dashboard --source results --open -o dashboard.html
 ```
 
+### Agentic Company benchmark profile
+
+The same evaluation loop can run the 40-question Agentic Company DABstep set. It reads the
+canonical `questions.jsonl` and `manual.md` from the adjacent `the-agentic-company` repository;
+it does not copy them into this project. By default that repository is resolved as
+`../../../the-agentic-company` from this project (set `AGENTIC_COMPANY_REPO` to override it).
+The v0.3.0 manifest contract and exact question/manual hashes are validated before model spend.
+
+Only `manual.md` is published as model context. The architecture documents and private semantic
+contracts are never published or added to a prompt. The guide is personal (`access=user`): the
+fixed topic acts as the registry, so each MotherDuck principal creates or updates exactly one
+manual without committing a principal-specific UUID. Do not run the first publish concurrently
+from two processes; a duplicate is detected and must be cleaned up before evaluation.
+
+```bash
+# Preview, then publish exactly one guide at agentic-company/manual.
+uv run asm guides-load --benchmark agentic-company --dry-run
+uv run asm guides-load --benchmark agentic-company
+
+# The profile attaches the configured read-only MotherDuck share as
+# agentic_company_snapshot at the start of each MCP session.
+uv run asm evaluate --benchmark agentic-company --task-id AC-002 --watch
+uv run asm evaluate --benchmark agentic-company --split all
+```
+
+The Agentic profile keeps concurrency, retries, OpenRouter routing, tool traces, controllog events,
+JSONL results, and summaries on the existing harness. Its additions are profile-specific: a
+multi-schema prompt/skill, the single manual guide, trusted share attachment, filtering/blocking of
+the private `ground_truth` and `sim` schemas, and strict scoring from each task's
+`answer_criteria`. DABstep remains the default profile and retains its existing scorer and split
+behavior.
+
+The supplied share still physically contains `ground_truth` and `sim`. The client hides them from
+table discovery and rejects explicit schema references, metadata enumeration, and dynamic table
+lookup as benchmark-integrity defenses. For a warehouse-enforced security boundary, publish a
+sanitized share that omits those schemas entirely.
+
 ## Iterating toward 100%
 
 Each miss points at one of four artifacts to fix, then re-run:

--- a/projects/agentic-sql-context-mcp/skill/AGENTIC_COMPANY.md
+++ b/projects/agentic-sql-context-mcp/skill/AGENTIC_COMPANY.md
@@ -1,0 +1,30 @@
+# Agentic Company analysis skill
+
+## Required workflow
+
+1. Read the single guide under `agentic-company/manual` before exploring data. Treat it as shared
+   operating context, not as a query recipe.
+2. Translate the question into a population, event-time/cohort rule, cutoff, measure, grain,
+   ranking, tie-break, and output shape. Keep these choices consistent across every CTE.
+3. Use `list_tables` and `list_columns` to locate authoritative public records. Never use the
+   private `ground_truth` or `sim` schemas.
+4. Aggregate each fact to its native business key before joining facts of different grains. Check
+   row counts and intermediate totals when a join could fan out or a lifecycle has revisions.
+5. Run exploratory SQL until the result is supported by the manual and records. Apply the stated
+   cutoff to what was knowable, preserve signs, use deterministic tie-breaks, and round only the
+   final reported value.
+6. Call `submit_answer` exactly once with read-only SQL whose result has precisely the shape in the
+   question guidelines. Return only requested answer columns and ordering—no commentary columns.
+
+## Analysis discipline
+
+- Distinguish placement, shipment, receipt, posting, payment, start, publication, and snapshot
+  dates. Filter on the date for the event the question actually names.
+- For "latest" or "as of" language, select the latest eligible revision at the business grain;
+  do not sum revisions.
+- For ratios, aggregate the numerator and denominator first unless an average of entity rates is
+  explicitly requested. Exclude zero-denominator entities.
+- When a question fixes an earlier cohort but asks for outcomes through the snapshot cutoff, keep
+  the cohort date rule separate from the outcome cutoff.
+- If ambiguity remains, prefer the record closest to the measured business event and verify the
+  choice against adjacent tables rather than guessing from column names.

--- a/projects/agentic-sql-context-mcp/src/agent.py
+++ b/projects/agentic-sql-context-mcp/src/agent.py
@@ -25,10 +25,10 @@ Provider/usage/caching machinery is ported from agentic-sql-mini unchanged.
 
 from __future__ import annotations
 
+import asyncio
 import contextvars
 import json
 import os
-import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -267,6 +267,42 @@ Guideline sanity-check: a guideline can be mislabeled. If it shows a `{{card_sch
 """
 
 
+_AGENTIC_COMPANY_SYSTEM_PROMPT = """You are an expert data analyst. You answer factoid questions by querying a multi-schema company database with SQL via tools.
+
+**Database:** {database} (MotherDuck, DuckDB SQL).
+Use `schema.table` names, or `{database}.schema.table` when fully qualifying. Public business schemas include `catalog`, `comms`, `cx`, `dtc`, `finance`, `hr`, `marketing`, `ops`, `wholesale`, and `workflow`. The private `ground_truth` and `sim` schemas are outside the analyst information boundary and must never be queried.
+
+The shared operating context is exactly one guide under the topic `agentic-company/manual`. It explains evidence authority, lifecycle semantics, time/grain discipline, and reporting conventions. At the start of every task, call `list_guides(topic="agentic-company/manual")`, then read the returned guide with `get_guide(uuid)`. There are no benchmark architecture documents or task-specific SQL recipes in context; synthesize the manual with the database schema and records.
+
+You have six tools:
+- `list_guides` — list the single manual guide and discover its opaque `uuid`.
+- `get_guide` — read that guide's full markdown by the discovered `uuid`.
+- `list_tables` — list public tables/views.
+- `list_columns` — describe one table's columns.
+- `query` — run a read-only SELECT (returns up to ~50 rows).
+- `submit_answer` — submit the SQL whose result IS the final answer. Call exactly once after verifying the query; every run MUST end with it. An unsubmitted run scores zero.
+
+Follow the skill below exactly.
+
+============================== SKILL ==============================
+{skill}
+===================================================================
+"""
+
+
+AGENTIC_COMPANY_USER_PROMPT_TEMPLATE = """Question: {question}
+
+Guidelines: {guidelines}
+
+Use the shared analyst manual and the public database records to derive the answer. The validator is strict about output shape, ordering, rounding, and sign; make the submitted SQL return exactly the value or components requested by the guidelines, with no explanation.
+"""
+
+
+def build_agentic_company_system_prompt(database: str, skill_text: str) -> str:
+    """Build the isolated Agentic Company prompt (no DABstep/payment context)."""
+    return _AGENTIC_COMPANY_SYSTEM_PROMPT.format(database=database, skill=skill_text)
+
+
 @dataclass
 class RunState:
     """Mutable state captured during one agent run."""
@@ -277,7 +313,7 @@ class RunState:
     final_rows: list[tuple] | ExecutionError | None = None
     submitted: bool = False
     tool_calls: list[dict] = field(default_factory=list)
-    lock: threading.Lock = field(default_factory=threading.Lock)
+    submission_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     on_tool_call: Callable[[dict], None] | None = None
     max_turns: int = 40
 
@@ -434,8 +470,15 @@ def _format_query_display(result: MCPResult, row_cap: int = _QUERY_DISPLAY_ROW_C
     return "\n".join(lines)
 
 
-def _make_tools(state: RunState) -> list:
-    @function_tool
+def _make_tools(state: RunState, guide_topic: str | None = None) -> list:
+    guide_description = None
+    if guide_topic:
+        guide_description = (
+            "List the guides for the configured dataset topic. Call with "
+            f'topic="{guide_topic}" to discover the guide uuid, then call get_guide.'
+        )
+
+    @function_tool(description_override=guide_description)
     async def list_guides(topic: str | None = None) -> str:
         """Browse the guide catalog by topic (this dataset's knowledge).
 
@@ -527,49 +570,53 @@ def _make_tools(state: RunState) -> list:
     @function_tool
     async def submit_answer(sql: str) -> str:
         """Submit the SQL whose result IS the answer. Call once with working SQL."""
-        with state.lock:
+        # The SDK may invoke sibling tool calls concurrently. Serialize the
+        # entire check/execute/latch transaction so two successful submissions
+        # cannot race and make the final answer depend on response timing. A
+        # failed execution releases the lock without latching, so retry remains
+        # possible.
+        async with state.submission_lock:
             if state.submitted:
                 return "ERROR: answer already submitted"
-        start_time, start_perf = _tool_timing_start()
-        # Execute FIRST (via the read-only MCP query tool). Only latch the
-        # submission on success — a SQL error here must NOT end the run, or a
-        # single typo would lock the agent out of resubmitting a corrected query.
-        try:
-            result = await state.mcp.call_tool("query", {"sql": sql})
-        except Exception as e:
-            state.record(_with_tool_timing({"tool": "submit_answer", "sql": sql, "error": str(e)}, start_time, start_perf))
-            return (
-                f"Your submitted SQL failed to execute: {e}\n"
-                "The answer was NOT recorded. Fix the SQL and call submit_answer "
-                "again with a corrected query." + _budget_suffix(state)
-            )
-        if result.is_error:
-            state.record(_with_tool_timing({"tool": "submit_answer", "sql": sql, "error": result.text}, start_time, start_perf))
-            return (
-                f"Your submitted SQL failed to execute: {result.text}\n"
-                "The answer was NOT recorded. Fix the SQL and call submit_answer "
-                "again with a corrected query." + _budget_suffix(state)
-            )
-        # result.rows is positional (list of arrays); score.py wants list[tuple].
-        # A None here means the server returned no structuredContent.rows at all
-        # (unparseable), which we CANNOT distinguish from an answer — treat it as
-        # a submission failure so a genuine empty result (rows == []) is the only
-        # thing that latches as "". Don't end the run; let the model resubmit.
-        if result.rows is None:
-            state.record(_with_tool_timing({"tool": "submit_answer", "sql": sql, "error": "no rows in result payload"}, start_time, start_perf))
-            return (
-                "Your submitted SQL ran but returned no parseable result rows "
-                "(no structuredContent.rows). The answer was NOT recorded. Make "
-                "sure the query SELECTs the answer value(s) and call submit_answer "
-                "again." + _budget_suffix(state)
-            )
-        rows = [tuple(r) for r in result.rows]
-        with state.lock:
+            start_time, start_perf = _tool_timing_start()
+            # Execute FIRST (via the read-only MCP query tool). Only latch the
+            # submission on success — a SQL error here must NOT end the run, or a
+            # single typo would lock the agent out of resubmitting a corrected query.
+            try:
+                result = await state.mcp.call_tool("query", {"sql": sql})
+            except Exception as e:
+                state.record(_with_tool_timing({"tool": "submit_answer", "sql": sql, "error": str(e)}, start_time, start_perf))
+                return (
+                    f"Your submitted SQL failed to execute: {e}\n"
+                    "The answer was NOT recorded. Fix the SQL and call submit_answer "
+                    "again with a corrected query." + _budget_suffix(state)
+                )
+            if result.is_error:
+                state.record(_with_tool_timing({"tool": "submit_answer", "sql": sql, "error": result.text}, start_time, start_perf))
+                return (
+                    f"Your submitted SQL failed to execute: {result.text}\n"
+                    "The answer was NOT recorded. Fix the SQL and call submit_answer "
+                    "again with a corrected query." + _budget_suffix(state)
+                )
+            # result.rows is positional (list of arrays); score.py wants list[tuple].
+            # A None here means the server returned no structuredContent.rows at all
+            # (unparseable), which we CANNOT distinguish from an answer — treat it as
+            # a submission failure so a genuine empty result (rows == []) is the only
+            # thing that latches as "". Don't end the run; let the model resubmit.
+            if result.rows is None:
+                state.record(_with_tool_timing({"tool": "submit_answer", "sql": sql, "error": "no rows in result payload"}, start_time, start_perf))
+                return (
+                    "Your submitted SQL ran but returned no parseable result rows "
+                    "(no structuredContent.rows). The answer was NOT recorded. Make "
+                    "sure the query SELECTs the answer value(s) and call submit_answer "
+                    "again." + _budget_suffix(state)
+                )
+            rows = [tuple(r) for r in result.rows]
             state.submitted = True
             state.final_sql = sql
             state.final_rows = rows
-        state.record(_with_tool_timing({"tool": "submit_answer", "sql": sql, "rows": len(rows)}, start_time, start_perf))
-        return f"Submitted. {len(rows)} rows."
+            state.record(_with_tool_timing({"tool": "submit_answer", "sql": sql, "rows": len(rows)}, start_time, start_perf))
+            return f"Submitted. {len(rows)} rows."
 
     return [list_guides, get_guide, list_tables, list_columns, query, submit_answer]
 
@@ -597,6 +644,8 @@ async def run_agent(
     model: str,
     provider: OpenRouterProvider,
     skill_text: str | None = None,
+    prompt_profile: str = "dabstep",
+    guide_topic: str | None = None,
     max_turns: int = 40,
     temperature: float = 0.0,
     on_tool_call: Callable[[dict], None] | None = None,
@@ -610,16 +659,27 @@ async def run_agent(
         on_tool_call=on_tool_call,
         max_turns=max_turns,
     )
-    tools = _make_tools(state)
+    tools = _make_tools(state, guide_topic=guide_topic)
+
+    if prompt_profile == "dabstep":
+        instructions = build_system_prompt(database, skill_text)
+        user_prompt_template = USER_PROMPT_TEMPLATE
+    elif prompt_profile == "agentic-company":
+        if skill_text is None:
+            raise ValueError("Agentic Company profile requires its dedicated skill text.")
+        instructions = build_agentic_company_system_prompt(database, skill_text)
+        user_prompt_template = AGENTIC_COMPANY_USER_PROMPT_TEMPLATE
+    else:
+        raise ValueError(f"Unknown prompt profile: {prompt_profile!r}")
 
     agent = Agent(
         name="asc-sql",
-        instructions=build_system_prompt(database, skill_text),
+        instructions=instructions,
         tools=tools,
         model_settings=ModelSettings(temperature=temperature, max_tokens=16384),
     )
 
-    user_msg = USER_PROMPT_TEMPLATE.format(
+    user_msg = user_prompt_template.format(
         question=question,
         guidelines=guidelines or "(none)",
     )
@@ -678,8 +738,11 @@ async def run_agent(
         _usage_var.reset(usage_token)
         _thinking_var.reset(thinking_token)
 
-    if not state.submitted and not hit_limit:
-        hit_limit = True
+    hit_limit = _resolve_hit_limit(
+        prompt_profile=prompt_profile,
+        submitted=state.submitted,
+        hit_limit=hit_limit,
+    )
 
     # Capture the full conversation (Responses-API items: reasoning / function_call /
     # function_call_output / message) so controllog-viz can render the trace.
@@ -702,3 +765,10 @@ async def run_agent(
         completion_tokens=usage.completion_tokens,
         cached_tokens=usage.cached_tokens,
     )
+
+
+def _resolve_hit_limit(*, prompt_profile: str, submitted: bool, hit_limit: bool) -> bool:
+    """Preserve DABstep semantics while accepting Agentic final-turn submissions."""
+    if submitted:
+        return False if prompt_profile == "agentic-company" else hit_limit
+    return True

--- a/projects/agentic-sql-context-mcp/src/agentic_company_profile.py
+++ b/projects/agentic-sql-context-mcp/src/agentic_company_profile.py
@@ -1,0 +1,567 @@
+"""Agentic Company benchmark policy and artifact contract.
+
+The shared runner owns orchestration. This module owns everything specific to
+the Agentic Company profile: canonical artifact selection and validation,
+scoring, guide/share preflight, and result metadata.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+from src import guides_load
+from src.agentic_company_score import score as score_agentic_company
+from src.mcp_client import create_mcp_session
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_CRITERIA_TYPES = frozenset(
+    {"number", "string", "label:number", "label:label:number", "list[string]"}
+)
+_REQUIRED_FIELDS = (
+    "task_id",
+    "question",
+    "guidelines",
+    "answer",
+    "answer_criteria",
+    "level",
+    "topic_id",
+    "topic",
+    "snapshot_cutoff",
+    "source_tables",
+)
+
+
+@dataclass(frozen=True)
+class AgenticCompanyArtifacts:
+    """Validated canonical inputs carried through one evaluation run."""
+
+    version: str
+    snapshot_cutoff: str
+    questions_path: Path
+    questions_sha256: str
+    manual_path: Path
+    manual_sha256: str
+    database_sha256: str
+    share: str
+
+    def provenance(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "snapshot_cutoff": self.snapshot_cutoff,
+            "questions_path": str(self.questions_path.resolve()),
+            "questions_sha256": self.questions_sha256,
+            "manual_path": str(self.manual_path.resolve()),
+            "manual_sha256": self.manual_sha256,
+            "database_sha256": self.database_sha256,
+            "share": self.share,
+        }
+
+
+@dataclass(frozen=True)
+class AgenticCompanyProfile:
+    """Complete configuration and behavior for the Agentic Company profile."""
+
+    name: str = "agentic-company"
+    default_split: str = "all"
+    default_database: str = "agentic_company_snapshot"
+    database_env: str = "AGENTIC_COMPANY_MD_DATABASE"
+    guide_topic: str = "agentic-company/manual"
+    project_id: str = "agentic-company-dabstep"
+    manifest_version: str = "0.3.1"
+    snapshot_cutoff: str = "2026-07-31"
+    task_count: int = 40
+    topic_count: int = 10
+    database_bytes: int = 705_441_792
+    database_sha256: str = "0a3c0bd92591093ad936d4eeb3cecf60958916dbbfd75ea4210b88619f0d9aa2"
+    questions_sha256: str = "e459ae964e08318e2abd0b1ccb035d6d74c62e17f86efe1a996088c27da2ada4"
+    manual_sha256: str = "7d76d5025880bb47e7ed3c16946e1701d4558d779339b6fcf0f277c516bb7544"
+    share: str = "md:_share/agentic_company_snapshot_share/6b172abb-d377-4f0f-9a8a-d0ac199e074d"
+    excluded_schemas: tuple[str, ...] = ("ground_truth", "sim")
+    public_schemas: tuple[str, ...] = (
+        "catalog",
+        "comms",
+        "cx",
+        "dtc",
+        "finance",
+        "hr",
+        "marketing",
+        "ops",
+        "wholesale",
+        "workflow",
+    )
+    public_relation_count: int = 68
+    public_snapshot_fingerprint: str = (
+        "70360cfc468d329485b436935a6f3d4177156de893625aa72854c99ca424a531"
+    )
+
+    @property
+    def skill_path(self) -> Path:
+        return REPO_ROOT / "skill" / "AGENTIC_COMPANY.md"
+
+    def database_name(self, explicit: str | None) -> str:
+        return explicit or os.environ.get(self.database_env) or self.default_database
+
+    def task_key(self, value: Any) -> str:
+        return str(value).casefold()
+
+    def benchmark_dir(self) -> Path:
+        configured = os.environ.get("AGENTIC_COMPANY_REPO")
+        root = (
+            Path(configured).expanduser()
+            if configured
+            else REPO_ROOT.parents[2] / "the-agentic-company"
+        )
+        return root / "benchmarks" / "dabstep_agentic_company"
+
+    def resolve_paths(
+        self,
+        questions_jsonl: Path | None = None,
+        manual: Path | None = None,
+    ) -> tuple[Path, Path, Path]:
+        benchmark_dir = self.benchmark_dir()
+        return (
+            questions_jsonl or benchmark_dir / "questions.jsonl",
+            manual or benchmark_dir / "manual.md",
+            benchmark_dir / "manifest.json",
+        )
+
+    @staticmethod
+    def sha256(path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def load_questions(self, path: Path, *, split: str = "all") -> list[dict]:
+        if split != self.default_split:
+            raise ValueError(f"Agentic Company supports only split={self.default_split!r}.")
+        if not path.is_file():
+            raise FileNotFoundError(f"Agentic Company questions not found: {path}")
+
+        questions: list[dict] = []
+        seen: set[str] = set()
+        for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+            if not line.strip():
+                continue
+            location = f"{path}:{line_number}"
+            try:
+                question = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{location}: invalid JSON: {exc}") from exc
+            if not isinstance(question, dict):
+                raise TypeError(f"{location}: question record must be an object")
+            missing = [field for field in _REQUIRED_FIELDS if field not in question]
+            if missing:
+                raise ValueError(f"{location}: missing fields {missing}")
+            task_id = question["task_id"]
+            if not isinstance(task_id, str) or not task_id:
+                raise ValueError(f"{location}: task_id must be a string")
+            if task_id in seen:
+                raise ValueError(f"{location}: duplicate task_id {task_id!r}")
+            self.validate_criteria(question["answer_criteria"], location)
+            if not all(
+                isinstance(question[field], str)
+                for field in (
+                    "question",
+                    "guidelines",
+                    "answer",
+                    "level",
+                    "topic_id",
+                    "topic",
+                    "snapshot_cutoff",
+                )
+            ):
+                raise ValueError(
+                    f"{location}: question, guidelines, answer, level, topic_id, topic, "
+                    "and snapshot_cutoff must be strings"
+                )
+            if question["level"] not in {"easy", "hard"}:
+                raise ValueError(f"{location}: level must be 'easy' or 'hard'")
+            seen.add(task_id)
+            question["question_index"] = len(questions)
+            questions.append(question)
+        return questions
+
+    @staticmethod
+    def _validate_numeric_criteria(criteria: dict, location: str) -> None:
+        decimals = criteria.get("decimals")
+        if isinstance(decimals, bool) or not isinstance(decimals, int) or decimals < 0:
+            raise ValueError(f"{location}: decimals must be a non-negative integer")
+        tolerance = criteria.get("tolerance")
+        try:
+            parsed_tolerance = Decimal(str(tolerance))
+        except (InvalidOperation, ValueError, TypeError) as exc:
+            raise ValueError(f"{location}: tolerance must be a finite non-negative number") from exc
+        if not parsed_tolerance.is_finite() or parsed_tolerance < 0:
+            raise ValueError(f"{location}: tolerance must be a finite non-negative number")
+
+    def validate_criteria(self, criteria: object, location: str) -> None:
+        if not isinstance(criteria, dict):
+            raise TypeError(f"{location}: answer_criteria must be an object")
+        answer_type = criteria.get("type")
+        if answer_type not in _CRITERIA_TYPES:
+            raise ValueError(f"{location}: unsupported answer criteria type {answer_type!r}")
+        if answer_type in {"number", "label:number", "label:label:number"}:
+            self._validate_numeric_criteria(criteria, location)
+        if answer_type in {"label:number", "label:label:number", "list[string]"}:
+            delimiter = criteria.get("delimiter")
+            if not isinstance(delimiter, str) or not delimiter:
+                raise ValueError(f"{location}: delimiter must be a non-empty string")
+        if answer_type == "list[string]":
+            if not isinstance(criteria.get("order_sensitive"), bool):
+                raise ValueError(f"{location}: order_sensitive must be a boolean")
+            if not isinstance(criteria.get("empty_answer", ""), str):
+                raise ValueError(f"{location}: empty_answer must be a string")
+            element_type = criteria.get("element_type", "string")
+            if element_type not in {"string", "label:number"}:
+                raise ValueError(f"{location}: unsupported list element_type {element_type!r}")
+            if element_type == "label:number":
+                self._validate_numeric_criteria(criteria, location)
+
+    def validate_manifest(self, questions: list[dict], manifest: dict) -> None:
+        if manifest.get("version") != self.manifest_version:
+            raise ValueError(
+                "Agentic Company manifest version does not match this harness: "
+                f"expected {self.manifest_version!r}, received {manifest.get('version')!r}."
+            )
+        cutoff = manifest.get("snapshot_cutoff")
+        if cutoff != self.snapshot_cutoff:
+            raise ValueError(
+                "Agentic Company manifest snapshot_cutoff does not match this harness: "
+                f"expected {self.snapshot_cutoff!r}, received {cutoff!r}."
+            )
+        if manifest.get("excluded_schemas") != list(self.excluded_schemas):
+            raise ValueError(
+                "Agentic Company manifest excluded_schemas does not match the enforced "
+                f"boundary: expected {list(self.excluded_schemas)!r}, "
+                f"received {manifest.get('excluded_schemas')!r}."
+            )
+        if manifest.get("context_files") != ["benchmarks/dabstep_agentic_company/manual.md"]:
+            raise ValueError("Agentic Company manifest must expose only the analyst manual.")
+
+        source_database = manifest.get("source_database")
+        if not isinstance(source_database, dict):
+            raise TypeError("Agentic Company manifest source_database must be an object.")
+        if source_database.get("path") != "data/company_for_analysis.duckdb":
+            raise ValueError("Agentic Company manifest source_database.path is not canonical.")
+        if source_database.get("bytes") != self.database_bytes:
+            raise ValueError(
+                "Agentic Company manifest database byte size does not match the pinned snapshot."
+            )
+        if source_database.get("sha256") != self.database_sha256:
+            raise ValueError(
+                "Agentic Company manifest database SHA does not match the pinned snapshot."
+            )
+
+        expected_count = manifest.get("task_count")
+        if isinstance(expected_count, bool) or not isinstance(expected_count, int):
+            raise TypeError("Agentic Company manifest task_count must be an integer.")
+        if expected_count != self.task_count:
+            raise ValueError(f"Agentic Company manifest task_count must be {self.task_count}.")
+        if len(questions) != expected_count:
+            raise ValueError(
+                "Agentic Company questions.jsonl does not match manifest task_count: "
+                f"expected {expected_count}, loaded {len(questions)}."
+            )
+
+        expected_distribution = manifest.get("difficulty_distribution")
+        pinned_distribution = {"easy": 10, "hard": 30}
+        if expected_distribution != pinned_distribution:
+            raise ValueError(
+                "Agentic Company manifest difficulty_distribution does not match the "
+                f"pinned benchmark: {pinned_distribution}."
+            )
+        actual_distribution: dict[str, int] = {}
+        for question in questions:
+            level = str(question.get("level") or "")
+            actual_distribution[level] = actual_distribution.get(level, 0) + 1
+        if actual_distribution != expected_distribution:
+            raise ValueError(
+                "Agentic Company question difficulty distribution does not match manifest: "
+                f"expected {expected_distribution}, loaded {actual_distribution}."
+            )
+
+        expected_topics = manifest.get("topic_count")
+        actual_topics = len({str(question.get("topic_id")) for question in questions})
+        if isinstance(expected_topics, bool) or not isinstance(expected_topics, int):
+            raise TypeError("Agentic Company manifest topic_count must be an integer.")
+        if expected_topics != self.topic_count:
+            raise ValueError(f"Agentic Company manifest topic_count must be {self.topic_count}.")
+        if actual_topics != expected_topics:
+            raise ValueError(
+                "Agentic Company question topic count does not match manifest: "
+                f"expected {expected_topics}, loaded {actual_topics}."
+            )
+        self._validate_topics(questions, manifest, cutoff)
+
+    def _validate_topics(self, questions: list[dict], manifest: dict, cutoff: str) -> None:
+        topics = manifest.get("topics")
+        if not isinstance(topics, list) or len(topics) != self.topic_count:
+            raise ValueError("Agentic Company manifest topics must list every topic exactly once.")
+        expected_by_id: dict[str, dict] = {}
+        for topic in topics:
+            if not isinstance(topic, dict) or not isinstance(topic.get("topic_id"), str):
+                raise TypeError(
+                    "Every Agentic Company manifest topic must be an object with topic_id."
+                )
+            topic_id = topic["topic_id"]
+            if topic_id in expected_by_id:
+                raise ValueError(f"Duplicate Agentic Company manifest topic_id {topic_id!r}.")
+            expected_by_id[topic_id] = topic
+        canonical_topic_ids = {f"T{index:02d}" for index in range(1, 11)}
+        if set(expected_by_id) != canonical_topic_ids:
+            raise ValueError("Agentic Company manifest must contain topic IDs T01 through T10.")
+
+        actual_by_id: dict[str, dict[str, object]] = {}
+        public_schemas = set(self.public_schemas)
+        for question in questions:
+            task_id = question["task_id"]
+            topic_id = question["topic_id"]
+            topic_name = question["topic"]
+            if question["snapshot_cutoff"] != cutoff:
+                raise ValueError(f"{task_id}: snapshot_cutoff does not match manifest.")
+            source_tables = question["source_tables"]
+            if (
+                not isinstance(source_tables, list)
+                or not source_tables
+                or not all(isinstance(table, str) and table for table in source_tables)
+            ):
+                raise TypeError(f"{task_id}: source_tables must be non-empty strings.")
+            if any(table.split(".", 1)[0] not in public_schemas for table in source_tables):
+                raise ValueError(f"{task_id}: source_tables includes a non-public schema.")
+            actual = actual_by_id.setdefault(
+                topic_id,
+                {"topic": topic_name, "task_count": 0, "easy_count": 0, "hard_count": 0},
+            )
+            if actual["topic"] != topic_name:
+                raise ValueError(f"{topic_id}: question topic labels are inconsistent.")
+            actual["task_count"] = int(actual["task_count"]) + 1
+            level_key = f"{question['level']}_count"
+            actual[level_key] = int(actual[level_key]) + 1
+
+        if set(actual_by_id) != set(expected_by_id):
+            raise ValueError("Agentic Company manifest topic IDs do not match questions.jsonl.")
+        for topic_id, expected in expected_by_id.items():
+            actual = actual_by_id[topic_id]
+            for field in ("topic", "task_count", "easy_count", "hard_count"):
+                if expected.get(field) != actual[field]:
+                    raise ValueError(
+                        f"Agentic Company topic {topic_id} {field} does not match manifest: "
+                        f"expected {expected.get(field)!r}, loaded {actual[field]!r}."
+                    )
+
+    def load_bundle(
+        self,
+        questions_path: Path,
+        manual_path: Path,
+        manifest_path: Path,
+    ) -> tuple[list[dict], AgenticCompanyArtifacts]:
+        for label, path in (
+            ("questions", questions_path),
+            ("manual", manual_path),
+            ("manifest", manifest_path),
+        ):
+            if not path.is_file():
+                raise FileNotFoundError(f"Agentic Company {label} not found: {path}")
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Agentic Company manifest is not valid JSON: {manifest_path}: {exc}"
+            ) from exc
+        if not isinstance(manifest, dict):
+            raise TypeError(f"Agentic Company manifest must be a JSON object: {manifest_path}")
+
+        questions = self.load_questions(questions_path)
+        self.validate_manifest(questions, manifest)
+        questions_sha256 = self.sha256(questions_path)
+        manual_sha256 = self.sha256(manual_path)
+        if questions_sha256 != self.questions_sha256:
+            raise ValueError(
+                "Agentic Company questions.jsonl does not match the pinned "
+                f"v{self.manifest_version} artifact."
+            )
+        if manual_sha256 != self.manual_sha256:
+            raise ValueError(
+                "Agentic Company manual.md does not match the pinned "
+                f"v{self.manifest_version} artifact."
+            )
+        return questions, AgenticCompanyArtifacts(
+            version=manifest["version"],
+            snapshot_cutoff=manifest["snapshot_cutoff"],
+            questions_path=questions_path,
+            questions_sha256=questions_sha256,
+            manual_path=manual_path,
+            manual_sha256=manual_sha256,
+            database_sha256=manifest["source_database"]["sha256"],
+            share=self.share,
+        )
+
+    def score(
+        self,
+        *,
+        execution_result: Any,
+        question: dict,
+        predicted_sql: str | None,
+        hit_limit: bool = False,
+    ):
+        return score_agentic_company(
+            execution_result=execution_result,
+            gold_answer=question.get("answer", ""),
+            criteria=question.get("answer_criteria") or {},
+            predicted_sql=predicted_sql,
+            hit_limit=hit_limit,
+        )
+
+    def result_metadata(
+        self,
+        question: dict,
+        artifacts: AgenticCompanyArtifacts,
+    ) -> dict[str, Any]:
+        return {
+            "benchmark": self.name,
+            "question_index": question.get("question_index"),
+            "topic_id": question.get("topic_id"),
+            "topic": question.get("topic"),
+            "answer_criteria": question.get("answer_criteria"),
+            "snapshot_cutoff": question.get("snapshot_cutoff"),
+            "source_tables": question.get("source_tables"),
+            "questions_sha256": artifacts.questions_sha256,
+            "manual_sha256": artifacts.manual_sha256,
+            "database_sha256": artifacts.database_sha256,
+            "public_snapshot_fingerprint": self.public_snapshot_fingerprint,
+        }
+
+    @staticmethod
+    def snapshot_fingerprint(rows: list[list] | list[tuple]) -> str:
+        normalized: list[tuple[str, int, str]] = []
+        for row in rows:
+            if len(row) != 3:
+                raise ValueError("Snapshot fingerprint rows must have exactly three columns.")
+            relation, raw_count, raw_hash = row
+            relation = str(relation)
+            try:
+                row_count = int(raw_count)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"Invalid row count for {relation!r}.") from exc
+            row_hash = str(raw_hash)
+            if row_count < 0 or not row_hash.isdigit():
+                raise ValueError(f"Invalid content fingerprint for {relation!r}.")
+            normalized.append((relation, row_count, row_hash))
+        payload = "\n".join(
+            f"{relation}\t{row_count}\t{row_hash}"
+            for relation, row_count, row_hash in sorted(normalized)
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    async def _verify_public_snapshot(self, mcp) -> None:
+        listing = await mcp.call_tool("list_tables", {})
+        if listing.is_error or listing.rows is None:
+            raise RuntimeError(
+                f"Agentic Company share preflight could not list public relations: {listing.text}"
+            )
+        public_schemas = set(self.public_schemas)
+        relations: list[tuple[str, str]] = []
+        for item in listing.rows:
+            if not isinstance(item, dict):
+                raise TypeError("Agentic Company table listing contained a malformed row.")
+            schema = str(item.get("schema") or "")
+            table = str(item.get("name") or "")
+            if schema not in public_schemas or not _IDENTIFIER.fullmatch(table):
+                raise RuntimeError(
+                    f"Agentic Company table listing exposed unexpected relation {schema}.{table}."
+                )
+            relations.append((schema, table))
+        relations = sorted(set(relations))
+        if len(relations) != self.public_relation_count:
+            raise RuntimeError(
+                "Agentic Company public relation count does not match the pinned snapshot: "
+                f"expected {self.public_relation_count}, received {len(relations)}."
+            )
+
+        pieces = []
+        for schema, table in relations:
+            relation = f"{schema}.{table}"
+            pieces.append(
+                f"SELECT '{relation}' AS relation, count(*)::BIGINT AS row_count, "
+                "coalesce(bit_xor(md5_number(to_json(t))), 0)::VARCHAR AS content_hash "
+                f'FROM "{schema}"."{table}" AS t'
+            )
+        fingerprint_result = await mcp.call_tool(
+            "query",
+            {"sql": " UNION ALL ".join(pieces) + " ORDER BY relation"},
+        )
+        if fingerprint_result.is_error or fingerprint_result.rows is None:
+            raise RuntimeError(
+                "Agentic Company public snapshot fingerprint query failed: "
+                f"{fingerprint_result.text}"
+            )
+        fingerprint = self.snapshot_fingerprint(fingerprint_result.rows)
+        if fingerprint != self.public_snapshot_fingerprint:
+            raise RuntimeError(
+                "Agentic Company share content does not match the pinned public snapshot: "
+                f"expected {self.public_snapshot_fingerprint}, received {fingerprint}."
+            )
+
+    async def preflight(
+        self,
+        *,
+        database: str,
+        artifacts: AgenticCompanyArtifacts,
+        verify_guide: bool,
+    ) -> None:
+        """Fail before model spend unless the share and selected guide are exact."""
+        async with create_mcp_session(
+            session_hint="agentic-company-preflight",
+            database=database,
+            attach_share=self.share,
+            excluded_schemas=self.excluded_schemas,
+            guide_topic=self.guide_topic,
+        ) as mcp:
+            cutoff = await mcp.call_tool(
+                "query",
+                {"sql": "SELECT max(sim_date)::VARCHAR FROM finance.pnl_daily"},
+            )
+            if cutoff.is_error or cutoff.rows != [[artifacts.snapshot_cutoff]]:
+                raise RuntimeError(
+                    "Agentic Company share preflight failed: expected finance.pnl_daily "
+                    f"through {artifacts.snapshot_cutoff}, received {cutoff.text}"
+                )
+            await self._verify_public_snapshot(mcp)
+            if not verify_guide:
+                return
+
+            listing = await mcp.call_tool("list_guides", {"topic": self.guide_topic})
+            guide_uuid = guides_load.select_agentic_manual(
+                guides_load._guide_listing_payload(listing)
+            )
+            if guide_uuid is None:
+                raise RuntimeError(
+                    "Expected exactly one guide under agentic-company/manual; run "
+                    "`asm guides-load --benchmark agentic-company` before evaluation."
+                )
+            guide = await mcp.call_tool("get_guide", {"uuid": guide_uuid})
+            try:
+                remote_text = json.loads(guide.text).get("text", "")
+                local_text = artifacts.manual_path.read_text().rstrip()
+            except (OSError, AttributeError, json.JSONDecodeError) as exc:
+                raise RuntimeError("Could not verify the Agentic Company manual guide.") from exc
+            marker = f"\n\n{guides_load.AGENTIC_COMPANY_MANUAL_DESCRIPTION}\n\n"
+            remote_body = remote_text.split(marker, 1)[1] if marker in remote_text else None
+            if guide.is_error or remote_body != local_text:
+                raise RuntimeError(
+                    "The published Agentic Company manual does not match the selected manual.md. "
+                    "Run `asm guides-load --benchmark agentic-company` to update it."
+                )
+
+
+AGENTIC_COMPANY_PROFILE = AgenticCompanyProfile()

--- a/projects/agentic-sql-context-mcp/src/agentic_company_score.py
+++ b/projects/agentic-sql-context-mcp/src/agentic_company_score.py
@@ -1,0 +1,275 @@
+"""Criteria-driven scorer for the Agentic Company benchmark.
+
+The DABstep scorer intentionally has permissive compatibility behavior (for
+example, sign-insensitive numeric deltas and order-insensitive comma lists).
+Those rules conflict with the explicit ``answer_criteria`` shipped by the
+Agentic Company questions, so this module is a separate profile-specific seam.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from decimal import Decimal, InvalidOperation
+from difflib import SequenceMatcher
+from typing import Any
+
+from src.score import Correctness, ExecutionError, ExecutionResult, ScoreResult
+
+_NA_VARIANTS = frozenset({"not applicable", "n/a", "na", "none", "null", "-"})
+_SUPPORTED_TYPES = frozenset(
+    {"number", "string", "label:number", "label:label:number", "list[string]"}
+)
+
+
+def _decimal(value: Any) -> Decimal | None:
+    try:
+        number = Decimal(str(value).strip())
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+    return number if number.is_finite() else None
+
+
+def _format_number(value: Any, decimals: int | None) -> str:
+    number = _decimal(value)
+    if number is None:
+        return str(value)
+    if decimals is None:
+        return format(number, "f")
+    if decimals == 0 and number != number.to_integral_value():
+        # Integer criteria describe counts/units, not permission to round a
+        # fractional wrong aggregate into the correct whole number.
+        return format(number, "f")
+    return f"{number:.{decimals}f}"
+
+
+def _format_compound(values: list[Any], decimals: int | None, delimiter: str) -> str:
+    if not values:
+        return ""
+    labels = [str(value) for value in values[:-1]]
+    return delimiter.join([*labels, _format_number(values[-1], decimals)])
+
+
+def format_answer(
+    result: list[tuple] | list[list] | None,
+    criteria: dict[str, Any],
+) -> str:
+    """Format SQL rows according to an Agentic Company answer contract."""
+    answer_type = str(criteria.get("type") or "")
+    if answer_type not in _SUPPORTED_TYPES:
+        raise ValueError(f"Unsupported Agentic Company answer type: {answer_type!r}")
+    if not result:
+        if answer_type == "list[string]":
+            return str(criteria.get("empty_answer", ""))
+        return "Not Applicable"
+
+    delimiter = str(criteria.get("delimiter") or ":")
+    decimals = criteria.get("decimals")
+    decimals = int(decimals) if decimals is not None else None
+
+    if answer_type == "number":
+        if len(result) != 1 or len(result[0]) != 1:
+            return _flatten_unexpected(result)
+        return _format_number(result[0][0], decimals)
+
+    if answer_type == "string":
+        if len(result) != 1 or len(result[0]) != 1:
+            return _flatten_unexpected(result)
+        return str(result[0][0])
+
+    if answer_type in {"label:number", "label:label:number"}:
+        component_count = 2 if answer_type == "label:number" else 3
+        if len(result) != 1:
+            return _flatten_unexpected(result)
+        row = list(result[0])
+        if len(row) == component_count:
+            return _format_compound(row, decimals, delimiter)
+        if len(row) == 1:
+            parts = str(row[0]).split(delimiter)
+            if len(parts) == component_count:
+                return _format_compound(parts, decimals, delimiter)
+        return _flatten_unexpected(result)
+
+    # list[string]: preserve row order. Multi-column rows become colon-delimited
+    # compound elements, which supports AC-014 without requiring SQL-side string
+    # concatenation.
+    if len(result) == 1 and len(result[0]) == 1:
+        return str(result[0][0])
+    elements = [
+        str(row[0]) if len(row) == 1 else ":".join(str(value) for value in row)
+        for row in result
+    ]
+    return f"{delimiter} ".join(elements)
+
+
+def _flatten_unexpected(result: list[tuple] | list[list]) -> str:
+    return ",".join(str(value) for row in result for value in row)
+
+
+def _normalize_label(value: str) -> str:
+    value = unicodedata.normalize("NFKC", value).casefold().strip()
+    value = value.replace("_", " ")
+    value = re.sub(r"[^\w]+", " ", value, flags=re.UNICODE)
+    return " ".join(value.split())
+
+
+def _labels_match(predicted: str, gold: str, *, fuzzy: bool = False) -> bool:
+    pred_norm = _normalize_label(predicted)
+    gold_norm = _normalize_label(gold)
+    if pred_norm == gold_norm:
+        return True
+    return bool(
+        fuzzy
+        and pred_norm
+        and gold_norm
+        and SequenceMatcher(None, pred_norm, gold_norm).ratio() > 0.95
+    )
+
+
+def _numbers_match(predicted: str, gold: str, tolerance: Any) -> bool:
+    pred_number = _decimal(predicted)
+    gold_number = _decimal(gold)
+    tol_number = _decimal(tolerance)
+    if pred_number is None or gold_number is None or tol_number is None or tol_number < 0:
+        return False
+    return abs(pred_number - gold_number) <= tol_number
+
+
+def _compound_match(
+    predicted: str,
+    gold: str,
+    *,
+    label_count: int,
+    delimiter: str,
+    tolerance: Any,
+) -> bool:
+    pred_parts = [part.strip() for part in predicted.split(delimiter)]
+    gold_parts = [part.strip() for part in gold.split(delimiter)]
+    expected_count = label_count + 1
+    if len(pred_parts) != expected_count or len(gold_parts) != expected_count:
+        return False
+    if not all(
+        _labels_match(pred_parts[index], gold_parts[index]) for index in range(label_count)
+    ):
+        return False
+    return _numbers_match(pred_parts[-1], gold_parts[-1], tolerance)
+
+
+def _list_element_match(predicted: str, gold: str) -> bool:
+    # Compound list elements (currently AC-014) compare their label exactly
+    # after normalization and their numeric tail sign-sensitively.
+    pred_head, pred_sep, pred_tail = predicted.strip().rpartition(":")
+    gold_head, gold_sep, gold_tail = gold.strip().rpartition(":")
+    if pred_sep and gold_sep and _decimal(gold_tail) is not None:
+        decimal_places = len(gold_tail.rsplit(".", 1)[1]) if "." in gold_tail else 0
+        rounding_tolerance = Decimal(1).scaleb(-decimal_places) / 2
+        return _labels_match(pred_head, gold_head) and _numbers_match(
+            pred_tail,
+            gold_tail,
+            rounding_tolerance,
+        )
+    return _labels_match(predicted, gold, fuzzy=True)
+
+
+def answers_match(predicted: str, gold: str, criteria: dict[str, Any]) -> bool:
+    """Compare two answer strings using the declared criteria."""
+    pred = predicted.strip().strip("\"").strip("'")
+    expected = gold.strip().strip("\"").strip("'")
+    pred_na = pred.casefold() in _NA_VARIANTS
+    gold_na = expected.casefold() in _NA_VARIANTS
+    if pred_na or gold_na:
+        return pred_na and gold_na
+
+    answer_type = str(criteria.get("type") or "")
+    delimiter = str(criteria.get("delimiter") or ":")
+    tolerance = criteria.get("tolerance", 0)
+
+    if answer_type == "number":
+        return _numbers_match(pred, expected, tolerance)
+    if answer_type == "string":
+        return _labels_match(pred, expected, fuzzy=True)
+    if answer_type == "label:number":
+        return _compound_match(
+            pred,
+            expected,
+            label_count=1,
+            delimiter=delimiter,
+            tolerance=tolerance,
+        )
+    if answer_type == "label:label:number":
+        return _compound_match(
+            pred,
+            expected,
+            label_count=2,
+            delimiter=delimiter,
+            tolerance=tolerance,
+        )
+    if answer_type == "list[string]":
+        if pred == "" or expected == "":
+            return pred == expected
+        pred_items = [item.strip() for item in pred.split(delimiter)]
+        gold_items = [item.strip() for item in expected.split(delimiter)]
+        if len(pred_items) != len(gold_items):
+            return False
+        if criteria.get("order_sensitive", False):
+            return all(
+                _list_element_match(pred_item, gold_item)
+                for pred_item, gold_item in zip(pred_items, gold_items, strict=True)
+            )
+        unmatched = list(gold_items)
+        for pred_item in pred_items:
+            match_index = next(
+                (
+                    index
+                    for index, gold_item in enumerate(unmatched)
+                    if _list_element_match(pred_item, gold_item)
+                ),
+                None,
+            )
+            if match_index is None:
+                return False
+            unmatched.pop(match_index)
+        return not unmatched
+    raise ValueError(f"Unsupported Agentic Company answer type: {answer_type!r}")
+
+
+def score(
+    execution_result: ExecutionResult,
+    gold_answer: str,
+    criteria: dict[str, Any],
+    predicted_sql: str | None,
+    hit_limit: bool = False,
+) -> ScoreResult:
+    """Score one Agentic Company run without DABstep's permissive fallbacks."""
+    if hit_limit and isinstance(execution_result, ExecutionError):
+        return ScoreResult(
+            False,
+            Correctness.HIT_LIMIT,
+            0.0,
+            "none",
+            "hit_limit",
+            gold_answer,
+            None,
+        )
+    if isinstance(execution_result, ExecutionError):
+        return ScoreResult(
+            False,
+            Correctness.ERROR,
+            0.0,
+            "none",
+            "sql_execution_error" if predicted_sql else "no_sql_produced",
+            gold_answer,
+            None,
+        )
+
+    predicted_answer = format_answer(execution_result, criteria)
+    is_correct = answers_match(predicted_answer, gold_answer, criteria)
+    return ScoreResult(
+        is_correct,
+        Correctness.CORRECT if is_correct else Correctness.INCORRECT,
+        1.0 if is_correct else 0.0,
+        "agentic_criteria" if is_correct else "none",
+        None,
+        gold_answer,
+        predicted_answer,
+    )

--- a/projects/agentic-sql-context-mcp/src/agentic_company_score.py
+++ b/projects/agentic-sql-context-mcp/src/agentic_company_score.py
@@ -95,10 +95,15 @@ def format_answer(
     # concatenation.
     if len(result) == 1 and len(result[0]) == 1:
         return str(result[0][0])
-    elements = [
-        str(row[0]) if len(row) == 1 else ":".join(str(value) for value in row)
-        for row in result
-    ]
+    element_type = criteria.get("element_type", "string")
+    elements = []
+    for row in result:
+        if len(row) == 1:
+            elements.append(str(row[0]))
+        elif element_type == "label:number" and len(row) == 2:
+            elements.append(_format_compound(list(row), decimals, ":"))
+        else:
+            elements.append(":".join(str(value) for value in row))
     return f"{delimiter} ".join(elements)
 
 
@@ -148,33 +153,30 @@ def _compound_match(
     expected_count = label_count + 1
     if len(pred_parts) != expected_count or len(gold_parts) != expected_count:
         return False
-    if not all(
-        _labels_match(pred_parts[index], gold_parts[index]) for index in range(label_count)
-    ):
+    if not all(_labels_match(pred_parts[index], gold_parts[index]) for index in range(label_count)):
         return False
     return _numbers_match(pred_parts[-1], gold_parts[-1], tolerance)
 
 
-def _list_element_match(predicted: str, gold: str) -> bool:
-    # Compound list elements (currently AC-014) compare their label exactly
-    # after normalization and their numeric tail sign-sensitively.
+def _list_element_match(predicted: str, gold: str, criteria: dict[str, Any]) -> bool:
+    if criteria.get("element_type", "string") != "label:number":
+        return _labels_match(predicted, gold, fuzzy=True)
+
     pred_head, pred_sep, pred_tail = predicted.strip().rpartition(":")
     gold_head, gold_sep, gold_tail = gold.strip().rpartition(":")
-    if pred_sep and gold_sep and _decimal(gold_tail) is not None:
-        decimal_places = len(gold_tail.rsplit(".", 1)[1]) if "." in gold_tail else 0
-        rounding_tolerance = Decimal(1).scaleb(-decimal_places) / 2
+    if pred_sep and gold_sep:
         return _labels_match(pred_head, gold_head) and _numbers_match(
             pred_tail,
             gold_tail,
-            rounding_tolerance,
+            criteria.get("tolerance", 0),
         )
-    return _labels_match(predicted, gold, fuzzy=True)
+    return False
 
 
 def answers_match(predicted: str, gold: str, criteria: dict[str, Any]) -> bool:
     """Compare two answer strings using the declared criteria."""
-    pred = predicted.strip().strip("\"").strip("'")
-    expected = gold.strip().strip("\"").strip("'")
+    pred = predicted.strip().strip('"').strip("'")
+    expected = gold.strip().strip('"').strip("'")
     pred_na = pred.casefold() in _NA_VARIANTS
     gold_na = expected.casefold() in _NA_VARIANTS
     if pred_na or gold_na:
@@ -213,7 +215,7 @@ def answers_match(predicted: str, gold: str, criteria: dict[str, Any]) -> bool:
             return False
         if criteria.get("order_sensitive", False):
             return all(
-                _list_element_match(pred_item, gold_item)
+                _list_element_match(pred_item, gold_item, criteria)
                 for pred_item, gold_item in zip(pred_items, gold_items, strict=True)
             )
         unmatched = list(gold_items)
@@ -222,7 +224,7 @@ def answers_match(predicted: str, gold: str, criteria: dict[str, Any]) -> bool:
                 (
                     index
                     for index, gold_item in enumerate(unmatched)
-                    if _list_element_match(pred_item, gold_item)
+                    if _list_element_match(pred_item, gold_item, criteria)
                 ),
                 None,
             )

--- a/projects/agentic-sql-context-mcp/src/guides_load.py
+++ b/projects/agentic-sql-context-mcp/src/guides_load.py
@@ -56,6 +56,11 @@ re-run resumes as updates. The lock also records the `generated_for_prefix`;
 running with a different `--prefix` is refused rather than silently moving the
 existing guides to new topics.
 
+The Agentic Company profile publishes one in-memory item containing only its
+external ``manual.md``. Its fixed user-scoped topic is the idempotency registry:
+each MotherDuck principal discovers and updates their own guide without a local
+identity-specific UUID lock. Its architecture documents are never loaded here.
+
 Self-contained: stdlib + `src.context_store` + `src.mcp_client` only. run.py is
 responsible for load_dotenv before calling in; this module does not touch the
 environment beyond reading the config vars above.
@@ -64,11 +69,12 @@ environment beyond reading the config vars above.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 from pathlib import Path
 
-from src.context_store import ContextStore
+from src.context_store import ContextItem, ContextStore
 from src.mcp_client import create_mcp_session
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -76,6 +82,12 @@ LOCKFILE_PATH = REPO_ROOT / "guides.lock.json"
 
 DEFAULT_PREFIX = "dabstep"
 DEFAULT_ACCESS = "user"
+AGENTIC_COMPANY_PREFIX = "agentic-company"
+AGENTIC_COMPANY_MANUAL_ID = "analyst-field-manual"
+AGENTIC_COMPANY_MANUAL_DESCRIPTION = (
+    "Operating context, evidence authority, lifecycle semantics, and reporting "
+    "conventions for the Agentic Company benchmark."
+)
 
 
 def _topic(prefix: str, item) -> str:
@@ -158,12 +170,17 @@ def _looks_like_not_found(text: str | None) -> bool:
     return any(marker in low for marker in _NOT_FOUND_MARKERS)
 
 
-async def publish_all(
-    prefix: str | None = None,
-    access: str | None = None,
-    dry_run: bool = False,
+async def _publish_items(
+    items: list[ContextItem],
+    *,
+    prefix: str,
+    access: str,
+    dry_run: bool,
+    lockfile_path: Path,
+    lock_metadata: dict[str, dict] | None = None,
+    recreate_missing: bool = True,
 ) -> list[dict]:
-    """Publish every local context item as a MotherDuck guide (idempotent).
+    """Publish a set of context items with an isolated idempotency lock.
 
     Opens a single MCP session and, for each ContextItem, consults the committed
     lockfile: a known uuid is refreshed (update_guide body + update_guide_metadata),
@@ -189,20 +206,16 @@ async def publish_all(
         RuntimeError: if the committed lock was generated for a different topic
             prefix (reusing those uuids would silently move existing guides).
     """
-    prefix = (prefix or os.environ.get("DABSTEP_GUIDES_PREFIX", DEFAULT_PREFIX)).rstrip("/")
-    access = access or os.environ.get("DABSTEP_GUIDES_ACCESS", DEFAULT_ACCESS)
-
-    store = ContextStore()
-    items = [store._by_id[i] for i in sorted(store._by_id)]
-
-    lock, recorded_prefix = _load_lock()
+    lockfile_existed = lockfile_path.exists()
+    lock, recorded_prefix = _load_lock(lockfile_path)
+    lock_metadata = lock_metadata or {}
 
     # A lock's uuids belong to the topics of the prefix it was generated for.
     # Reusing them under a different prefix would MOVE existing guides (update
     # metadata → new topic) rather than create fresh ones. Refuse loudly.
     if lock and recorded_prefix is not None and recorded_prefix != prefix:
         raise RuntimeError(
-            f"guides.lock.json was generated for prefix '{recorded_prefix}', but "
+            f"{lockfile_path.name} was generated for prefix '{recorded_prefix}', but "
             f"'{prefix}' was requested. Reusing these uuids would move the existing "
             f"guides. Use --prefix {recorded_prefix}, or remove the lockfile to "
             f"publish a fresh set under '{prefix}'."
@@ -258,9 +271,10 @@ async def publish_all(
                     "topic": topic,
                     "title": item.id,
                     "access": access,
+                    **lock_metadata.get(item.id, {}),
                 }
                 # Persist immediately: never lose a just-minted uuid to a crash.
-                _write_lock(lock, prefix)
+                _write_lock(lock, prefix, lockfile_path)
 
             for item in items:
                 topic = _topic(prefix, item)
@@ -287,11 +301,18 @@ async def publish_all(
                             allow_write=True,
                         )
                         if body.is_error and _looks_like_not_found(body.text):
-                            # The locked guide was deleted server-side — recreate.
-                            record["warning"] = (
-                                f"locked uuid {known_uuid} not found server-side; recreated"
-                            )
-                            await _create(item, topic, record)
+                            if recreate_missing:
+                                # DABstep's historical recovery behavior.
+                                record["warning"] = (
+                                    f"locked uuid {known_uuid} not found server-side; recreated"
+                                )
+                                await _create(item, topic, record)
+                            else:
+                                record["action"] = "failed"
+                                record["error"] = (
+                                    f"locked uuid {known_uuid} is not visible to this token; "
+                                    "refusing to create a duplicate guide"
+                                )
                         elif body.is_error:
                             record["action"] = "failed"
                             record["error"] = body.text
@@ -326,6 +347,7 @@ async def publish_all(
                                 "topic": topic,
                                 "title": item.id,
                                 "access": locked_access,
+                                **lock_metadata.get(item.id, {}),
                             }
                     else:
                         await _create(item, topic, record)
@@ -335,9 +357,193 @@ async def publish_all(
                 results.append(record)
     finally:
         # Persist whatever succeeded, even on partial failure.
-        _write_lock(lock, prefix)
+        # Do not turn a transient first-create failure into a permanent empty
+        # lockfile. Successful creates are already persisted immediately.
+        if lock or lockfile_existed:
+            _write_lock(lock, prefix, lockfile_path)
 
     return results
+
+
+async def publish_all(
+    prefix: str | None = None,
+    access: str | None = None,
+    dry_run: bool = False,
+) -> list[dict]:
+    """Publish every local DABstep context item as a MotherDuck guide."""
+    prefix = (prefix or os.environ.get("DABSTEP_GUIDES_PREFIX", DEFAULT_PREFIX)).rstrip("/")
+    access = access or os.environ.get("DABSTEP_GUIDES_ACCESS", DEFAULT_ACCESS)
+    store = ContextStore()
+    items = [store._by_id[item_id] for item_id in sorted(store._by_id)]
+    return await _publish_items(
+        items,
+        prefix=prefix,
+        access=access,
+        dry_run=dry_run,
+        lockfile_path=LOCKFILE_PATH,
+    )
+
+
+async def publish_manual(
+    manual_path: Path,
+    prefix: str | None = None,
+    access: str | None = None,
+    dry_run: bool = False,
+) -> list[dict]:
+    """Publish exactly the Agentic Company manual as one guide."""
+    if not manual_path.is_file():
+        raise FileNotFoundError(f"Agentic Company manual not found: {manual_path}")
+    body = manual_path.read_text()
+    if not body.strip():
+        raise ValueError(f"Agentic Company manual is empty: {manual_path}")
+    if prefix not in (None, AGENTIC_COMPANY_PREFIX):
+        raise ValueError(
+            "Agentic Company guide prefix is fixed at 'agentic-company' so publication "
+            "cannot drift from the evaluation prompt."
+        )
+    item = ContextItem(
+        id=AGENTIC_COMPANY_MANUAL_ID,
+        domain="manual",
+        summary=AGENTIC_COMPANY_MANUAL_DESCRIPTION,
+        body=body,
+    )
+    if access not in (None, "user"):
+        raise ValueError(
+            "Agentic Company manual access is fixed at 'user'; each MotherDuck "
+            "principal owns one personal guide at the canonical topic."
+        )
+    source_sha256 = hashlib.sha256(body.encode()).hexdigest()
+    record = {
+        "id": item.id,
+        "topic": _topic(AGENTIC_COMPANY_PREFIX, item),
+        "uuid": None,
+        "action": "planned" if dry_run else None,
+        "error": None,
+        "warning": None,
+        "source_sha256": source_sha256,
+    }
+    if dry_run:
+        return [record]
+
+    async with create_mcp_session(session_hint="guides-load-agentic-company") as session:
+        listing = await session.call_tool("list_guides", {"topic": record["topic"]})
+        guide_uuid = select_agentic_manual(_guide_listing_payload(listing))
+        if guide_uuid is None:
+            create_args = {
+                "title": item.id,
+                "content": item.body,
+                "description": item.summary,
+                "topic": record["topic"],
+                "access": "user",
+                "external_id": item.id,
+            }
+            create_error: BaseException | None = None
+            try:
+                created = await session.call_tool("create_guide", create_args, allow_write=True)
+                if created.is_error:
+                    create_error = RuntimeError(created.text)
+                else:
+                    guide_uuid = _parse_created_uuid(created.text)
+            except Exception as exc:  # noqa: BLE001 — issued create may have reached server.
+                create_error = exc
+
+            # A missing UUID or ambiguous transport result is resolved by one
+            # re-list, never by issuing a second create in this invocation.
+            if guide_uuid is None:
+                relisted = await session.call_tool("list_guides", {"topic": record["topic"]})
+                guide_uuid = select_agentic_manual(_guide_listing_payload(relisted))
+            if guide_uuid is None:
+                detail = f": {create_error}" if create_error else ""
+                raise RuntimeError(f"create_guide did not produce a discoverable guide{detail}")
+            record["action"] = "created"
+        else:
+            updated = await session.call_tool(
+                "update_guide",
+                {"uuid": guide_uuid, "content": item.body, "external_id": item.id},
+                allow_write=True,
+            )
+            if updated.is_error:
+                raise RuntimeError(f"Could not update Agentic Company manual: {updated.text}")
+            metadata = await session.call_tool(
+                "update_guide_metadata",
+                {
+                    "uuid": guide_uuid,
+                    "title": item.id,
+                    "description": item.summary,
+                    "topic": record["topic"],
+                },
+                allow_write=True,
+            )
+            if metadata.is_error:
+                raise RuntimeError(
+                    f"Could not update Agentic Company manual metadata: {metadata.text}"
+                )
+            record["action"] = "updated"
+
+        record["uuid"] = guide_uuid
+        await _verify_single_manual(session, guide_uuid, body)
+    return [record]
+
+
+def _guide_listing_payload(result) -> dict:
+    if result.is_error:
+        raise RuntimeError(f"Could not inspect Agentic Company manual guides: {result.text}")
+    try:
+        payload = json.loads(result.text)
+    except (AttributeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Could not parse Agentic Company manual guides: {result.text}") from exc
+    if not isinstance(payload, dict):
+        raise TypeError("Agentic Company manual guide listing was not an object.")
+    return payload
+
+
+def select_agentic_manual(payload: dict) -> str | None:
+    """Select the one canonical personal manual, using its topic as registry."""
+    guides = payload.get("guides")
+    if payload.get("success") is not True or not isinstance(guides, list):
+        raise RuntimeError("Agentic Company manual guide listing was unsuccessful or malformed.")
+    if not guides:
+        return None
+    expected_topic = f"{AGENTIC_COMPANY_PREFIX}/manual"
+    if len(guides) != 1:
+        uuids = [str(guide.get("uuid")) for guide in guides if isinstance(guide, dict)]
+        raise RuntimeError(
+            "Expected one personal guide under agentic-company/manual; found "
+            f"{len(guides)} ({', '.join(uuids)}). Remove duplicates before continuing."
+        )
+    guide = guides[0]
+    if (
+        not isinstance(guide, dict)
+        or guide.get("topic") != expected_topic
+        or guide.get("title") != AGENTIC_COMPANY_MANUAL_ID
+        or guide.get("access") != "user"
+        or not isinstance(guide.get("uuid"), str)
+        or not guide["uuid"]
+    ):
+        raise RuntimeError(
+            "The guide at agentic-company/manual is not the canonical personal "
+            "analyst-field-manual; refusing to read or overwrite it."
+        )
+    return guide["uuid"]
+
+
+async def _verify_single_manual(session, expected_uuid: str, body: str) -> None:
+    listing = await session.call_tool(
+        "list_guides",
+        {"topic": f"{AGENTIC_COMPANY_PREFIX}/manual"},
+    )
+    actual_uuid = select_agentic_manual(_guide_listing_payload(listing))
+    if actual_uuid != expected_uuid:
+        raise RuntimeError("The canonical manual UUID changed during publication.")
+    guide = await session.call_tool("get_guide", {"uuid": expected_uuid})
+    try:
+        remote_text = json.loads(guide.text).get("text", "")
+    except (AttributeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Could not verify the published manual: {guide.text}") from exc
+    marker = f"\n\n{AGENTIC_COMPANY_MANUAL_DESCRIPTION}\n\n"
+    remote_body = remote_text.split(marker, 1)[1] if marker in remote_text else None
+    if guide.is_error or remote_body != body.rstrip():
+        raise RuntimeError("Published manual content does not match the selected manual.md.")
 
 
 def publish_all_sync(
@@ -347,3 +553,20 @@ def publish_all_sync(
 ) -> list[dict]:
     """Synchronous wrapper over publish_all for the Click entrypoint in run.py."""
     return asyncio.run(publish_all(prefix=prefix, access=access, dry_run=dry_run))
+
+
+def publish_manual_sync(
+    manual_path: Path,
+    prefix: str | None = None,
+    access: str | None = None,
+    dry_run: bool = False,
+) -> list[dict]:
+    """Synchronous wrapper over publish_manual for the Click entrypoint."""
+    return asyncio.run(
+        publish_manual(
+            manual_path=manual_path,
+            prefix=prefix,
+            access=access,
+            dry_run=dry_run,
+        )
+    )

--- a/projects/agentic-sql-context-mcp/src/mcp_client.py
+++ b/projects/agentic-sql-context-mcp/src/mcp_client.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass
 from typing import Any, AsyncIterator
 from urllib.parse import quote
 
+import duckdb
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 
@@ -90,6 +91,14 @@ _GUIDE_TOPIC_CHARSET = re.compile(r"^[A-Za-z0-9._/-]+$")
 # identifiers we pin; anything else is a config error worth failing loudly on.
 _DB_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
+# Trusted MotherDuck share addresses accepted by the session bootstrap. Share
+# attachment is configuration, never an agent tool: the model still goes
+# through the read-only query guard below and cannot ATTACH anything itself.
+_SHARE_URL = re.compile(
+    r"^md:_share/[A-Za-z_][A-Za-z0-9_]*/"
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
 # Defense-in-depth read-only guard for the `query` tool. The real protection is a
 # read-scoped MotherDuck token; this is a belt-and-suspenders reject of any
 # statement that leads with a mutating/among keyword so a prompt-injected
@@ -104,9 +113,43 @@ _MUTATING_SQL_LEADERS = frozenset({
     "begin", "start", "commit", "rollback", "call", "pragma",
 })
 
-# Strip -- line comments and /* */ block comments before inspecting statements.
-_SQL_LINE_COMMENT = re.compile(r"--[^\n]*")
-_SQL_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+_DYNAMIC_CATALOG_ACCESS = re.compile(
+    r"^(?:query_table|query|duckdb_[A-Za-z0-9_]*|pragma_[A-Za-z0-9_]*)$",
+    re.IGNORECASE,
+)
+
+
+def _sql_tokens(sql: str) -> list[str]:
+    """Return DuckDB-tokenized keywords/identifiers/operators, omitting values.
+
+    DuckDB's tokenizer correctly handles ordinary, escaped, and dollar-quoted
+    strings and skips comments. That avoids the endless quote/comment edge
+    cases of regex-based SQL inspection while retaining quoted identifiers.
+    """
+    tokens: list[str] = []
+    for position, token_type in duckdb.tokenize(sql):
+        if token_type == duckdb.token_type.string_const:
+            continue
+        char = sql[position]
+        if char == '"':
+            index = position + 1
+            value: list[str] = []
+            while index < len(sql):
+                if sql[index] == '"':
+                    if index + 1 < len(sql) and sql[index + 1] == '"':
+                        value.append('"')
+                        index += 2
+                        continue
+                    break
+                value.append(sql[index])
+                index += 1
+            tokens.append("".join(value).casefold())
+        elif char.isalpha() or char == "_":
+            match = re.match(r"[A-Za-z_][A-Za-z0-9_$]*", sql[position:])
+            tokens.append((match.group(0) if match else char).casefold())
+        else:
+            tokens.append(char)
+    return tokens
 
 
 def _read_only_violation(sql: str) -> str | None:
@@ -119,23 +162,27 @@ def _read_only_violation(sql: str) -> str | None:
     """
     if not isinstance(sql, str) or not sql.strip():
         return None
-    cleaned = _SQL_BLOCK_COMMENT.sub(" ", sql)
-    cleaned = _SQL_LINE_COMMENT.sub(" ", cleaned)
-    for statement in cleaned.split(";"):
-        statement = statement.strip()
-        if not statement:
-            continue
-        # First bare word (strip a leading '(' from "(SELECT …)").
-        first = statement.lstrip("(").split(None, 1)
-        if not first:
-            continue
-        leader = first[0].lower()
-        if leader in _MUTATING_SQL_LEADERS:
+    try:
+        statements = duckdb.extract_statements(sql)
+    except duckdb.Error:
+        return None  # Let the server return the actionable SQL syntax error.
+    allowed_types = {duckdb.StatementType.SELECT, duckdb.StatementType.EXPLAIN}
+    for statement in statements:
+        if statement.type not in allowed_types:
             return (
                 f"Refused: this path is read-only, but the SQL leads with "
-                f"'{first[0]}'. Only read queries (SELECT / WITH / DESCRIBE / …) "
+                f"'{statement.type.name}'. Only read queries "
+                f"(SELECT / WITH / DESCRIBE / …) "
                 f"are permitted."
             )
+        if statement.type == duckdb.StatementType.EXPLAIN:
+            statement_tokens = _sql_tokens(statement.query)
+            if {"analyze", "analyse"}.intersection(statement_tokens):
+                return (
+                    "Refused: EXPLAIN ANALYZE/ANALYSE executes its child statement "
+                    "and is not permitted on this read-only path. Use plain EXPLAIN "
+                    "for query planning."
+                )
     return None
 
 
@@ -272,6 +319,8 @@ class MCPSession:
         session: ClientSession,
         database: str | None = None,
         no_guides: bool = False,
+        excluded_schemas: tuple[str, ...] = (),
+        guide_topic: str | None = None,
     ) -> None:
         self._session = session
         # Ablation baseline: when set, every guide-read tool short-circuits to
@@ -290,6 +339,9 @@ class MCPSession:
                 f"[A-Za-z_][A-Za-z0-9_]* slug."
             )
         self._database = db
+        self._excluded_schemas = frozenset(schema.casefold() for schema in excluded_schemas)
+        self._guide_topic = guide_topic
+        self._listed_guide_uuids: set[str] = set()
 
     async def call_tool(
         self,
@@ -337,11 +389,40 @@ class MCPSession:
         #    instead.)
         call_args = dict(args)
         if name in ("query", "list_tables", "list_columns"):
-            call_args.setdefault("database", self._database)
+            # The database is a session boundary, not a model-controlled arg.
+            call_args["database"] = self._database
         elif name in ("get_query_guide", "list_guides", "get_guide"):
             # get_query_guide takes no args; list_guides takes an optional topic;
             # get_guide takes a uuid. All tolerate the empty-padding strip.
             call_args = _sanitize_guide_args(call_args)
+
+        if (
+            self._guide_topic
+            and name == "list_guides"
+            and call_args.get("topic") != self._guide_topic
+        ):
+            return MCPResult(
+                text=f"Refused: this benchmark exposes only topic {self._guide_topic!r}.",
+                is_error=True,
+                rows=None,
+            )
+        if self._guide_topic and name == "get_guide":
+            requested_uuid = call_args.get("uuid")
+            if requested_uuid not in self._listed_guide_uuids:
+                return MCPResult(
+                    text=(
+                        "Refused: get_guide may read only a uuid returned by this "
+                        "session's configured topic listing."
+                    ),
+                    is_error=True,
+                    rows=None,
+                )
+
+        if name == "list_columns":
+            normalized = await self._normalize_list_columns_args(call_args)
+            if isinstance(normalized, MCPResult):
+                return normalized
+            call_args = normalized
 
         # 4a. Read-only guard for `query` (defense-in-depth over a read-scoped
         #     token). submit_answer runs its SQL through this same tool, so this
@@ -350,6 +431,13 @@ class MCPSession:
             violation = _read_only_violation(call_args.get("sql", ""))
             if violation is not None:
                 return MCPResult(text=violation, is_error=True, rows=None)
+
+        # 4a.1 Dataset information boundary. The Agentic Company share contains
+        # private simulation/answer schemas that are not benchmark context. Hide
+        # them from discovery and reject explicit references before dispatch.
+        restricted = self._restricted_schema_violation(name, call_args)
+        if restricted is not None:
+            return MCPResult(text=restricted, is_error=True, rows=None)
 
         # 4b. Guide-write guard (topic + required fields).
         if name in GUIDE_WRITE_TOOLS:
@@ -363,12 +451,34 @@ class MCPSession:
         is_error = getattr(result, "isError", False) is True
 
         structured = getattr(result, "structuredContent", None)
+        if name == "list_tables" and isinstance(structured, dict) and self._excluded_schemas:
+            structured = self._filter_table_listing(structured)
         if structured is not None:
             text = json.dumps(structured)
-            rows = structured.get("rows") if isinstance(structured, dict) else None
+            if isinstance(structured, dict) and name == "list_columns":
+                rows = structured.get("columns")
+            elif isinstance(structured, dict) and name == "list_tables":
+                rows = [
+                    *structured.get("tables", []),
+                    *structured.get("views", []),
+                ]
+            else:
+                rows = structured.get("rows") if isinstance(structured, dict) else None
         else:
             text = _join_content_text(getattr(result, "content", None))
             rows = None
+
+        if (
+            name == "list_guides"
+            and self._guide_topic
+            and isinstance(structured, dict)
+            and isinstance(structured.get("guides"), list)
+        ):
+            self._listed_guide_uuids = {
+                str(guide["uuid"])
+                for guide in structured["guides"]
+                if isinstance(guide, dict) and guide.get("uuid")
+            }
 
         # 6. detectPayloadFailure: promote a payload-level success:false to a
         #    real error and prepend its message.
@@ -378,6 +488,176 @@ class MCPSession:
             text = f"Tool reported failure: {message}\n\n{text}"
 
         return MCPResult(text=text, is_error=is_error, rows=rows)
+
+    async def _normalize_list_columns_args(self, args: dict) -> dict | MCPResult:
+        """Translate user-friendly qualified names to the MCP's split fields.
+
+        MotherDuck's list_columns tool takes separate database/schema/table
+        arguments and otherwise defaults schema to ``main``. The agent API
+        intentionally exposes one ``table`` string, so normalize
+        ``schema.table`` and ``database.schema.table`` here. Resolve an
+        unqualified name only when it is unique among visible schemas.
+        """
+        raw_table = args.get("table")
+        if not isinstance(raw_table, str) or not raw_table.strip():
+            return MCPResult(
+                text="list_columns requires a non-empty table name.",
+                is_error=True,
+                rows=None,
+            )
+        raw_parts = [part.strip().strip('"') for part in raw_table.split(".")]
+        if not 1 <= len(raw_parts) <= 3 or any(
+            not _DB_IDENTIFIER.fullmatch(part) for part in raw_parts
+        ):
+            return MCPResult(
+                text=(
+                    "Invalid table name. Use table, schema.table, or "
+                    "database.schema.table with plain identifiers."
+                ),
+                is_error=True,
+                rows=None,
+            )
+
+        normalized = dict(args)
+        normalized["database"] = self._database
+        if len(raw_parts) == 3:
+            requested_database, schema, table = raw_parts
+            if requested_database.casefold() != self._database.casefold():
+                return MCPResult(
+                    text=(
+                        f"Refused: this session exposes only database {self._database!r}."
+                    ),
+                    is_error=True,
+                    rows=None,
+                )
+            normalized["schema"] = schema
+            normalized["table"] = table
+            return normalized
+        if len(raw_parts) == 2:
+            normalized["schema"], normalized["table"] = raw_parts
+            return normalized
+
+        table = raw_parts[0]
+        explicit_schema = normalized.get("schema")
+        if explicit_schema is not None:
+            if not isinstance(explicit_schema, str) or not _DB_IDENTIFIER.fullmatch(
+                explicit_schema
+            ):
+                return MCPResult(
+                    text="Invalid schema name for list_columns.",
+                    is_error=True,
+                    rows=None,
+                )
+            normalized["table"] = table
+            return normalized
+
+        listing = await self._session.call_tool(
+            "list_tables",
+            {"database": self._database, "keywords": table, "limit": 500},
+        )
+        payload = getattr(listing, "structuredContent", None)
+        if getattr(listing, "isError", False) is True or not isinstance(payload, dict):
+            return MCPResult(
+                text=f"Could not resolve unqualified table {table!r}; use schema.table.",
+                is_error=True,
+                rows=None,
+            )
+        matches = [
+            item
+            for key in ("tables", "views")
+            for item in payload.get(key, [])
+            if isinstance(item, dict)
+            and str(item.get("name") or "").casefold() == table.casefold()
+            and str(item.get("schema") or "").casefold() not in self._excluded_schemas
+        ]
+        if len(matches) != 1:
+            candidates = ", ".join(
+                f"{item.get('schema')}.{item.get('name')}" for item in matches
+            )
+            detail = f" Candidates: {candidates}." if candidates else ""
+            return MCPResult(
+                text=(
+                    f"Unqualified table {table!r} is not uniquely resolvable.{detail} "
+                    "Use schema.table from list_tables."
+                ),
+                is_error=True,
+                rows=None,
+            )
+        normalized["schema"] = str(matches[0]["schema"])
+        normalized["table"] = str(matches[0]["name"])
+        return normalized
+
+    def _restricted_schema_violation(self, name: str, args: dict) -> str | None:
+        if not self._excluded_schemas:
+            return None
+        candidate = ""
+        if name == "query":
+            candidate = str(args.get("sql") or "")
+        elif name == "list_columns":
+            candidate = ".".join(
+                str(value)
+                for value in (args.get("schema"), args.get("table"))
+                if value
+            )
+        else:
+            return None
+        tokens = _sql_tokens(candidate)
+        if name == "query":
+            if tokens and tokens[0] in {"show", "summarize", "describe", "desc"}:
+                return (
+                    "Refused: catalog-wide SQL discovery is outside this benchmark's "
+                    "public-schema interface. Use list_tables/list_columns."
+                )
+            for index, token in enumerate(tokens[:-1]):
+                if (_DYNAMIC_CATALOG_ACCESS.fullmatch(token) and tokens[index + 1] == "("):
+                    return (
+                        "Refused: dynamic table/catalog access is outside this benchmark's "
+                        "public-schema interface. Use list_tables/list_columns and explicit "
+                        "public schema.table names."
+                    )
+                if token in {"information_schema", "pg_catalog"} and tokens[index + 1] == ".":
+                    return (
+                        "Refused: metadata catalogs are outside this benchmark's "
+                        "public-schema interface. Use list_tables/list_columns."
+                    )
+            if "sqlite_master" in tokens:
+                return (
+                    "Refused: metadata catalogs are outside this benchmark's "
+                    "public-schema interface. Use list_tables/list_columns."
+                )
+        for schema in self._excluded_schemas:
+            if any(
+                token == schema and tokens[index + 1] == "."
+                for index, token in enumerate(tokens[:-1])
+            ):
+                return f"Refused: schema '{schema}' is outside this benchmark's data boundary."
+        return None
+
+    def _filter_table_listing(self, payload: dict) -> dict:
+        filtered = dict(payload)
+        for key in ("tables", "views"):
+            values = filtered.get(key)
+            if isinstance(values, list):
+                filtered[key] = [
+                    item
+                    for item in values
+                    if not (
+                        isinstance(item, dict)
+                        and str(item.get("schema") or "").casefold()
+                        in self._excluded_schemas
+                    )
+                ]
+        if isinstance(filtered.get("tables"), list):
+            filtered["tableCount"] = len(filtered["tables"])
+        if isinstance(filtered.get("views"), list):
+            filtered["viewCount"] = len(filtered["views"])
+        visible_count = int(filtered.get("tableCount") or 0) + int(
+            filtered.get("viewCount") or 0
+        )
+        for key in ("count", "totalCount"):
+            if key in filtered:
+                filtered[key] = visible_count
+        return filtered
 
 
 def _join_content_text(content: Any) -> str:
@@ -407,6 +687,10 @@ async def create_mcp_session(
     session_hint: str | None = None,
     database: str | None = None,
     no_guides: bool = False,
+    attach_share: str | None = None,
+    attach_database: str = "sample_data",
+    excluded_schemas: tuple[str, ...] = (),
+    guide_topic: str | None = None,
 ) -> AsyncIterator[MCPSession]:
     """Open an authenticated MCP session as an async context manager.
 
@@ -436,7 +720,86 @@ async def create_mcp_session(
     async with streamablehttp_client(url, headers=headers) as (read_stream, write_stream, _):
         async with ClientSession(read_stream, write_stream) as session:
             await session.initialize()
-            yield MCPSession(session, database=database, no_guides=no_guides)
+            if attach_share is not None:
+                await _attach_trusted_share(
+                    session,
+                    share_url=attach_share,
+                    alias=database or "",
+                    bootstrap_database=attach_database,
+                )
+            yield MCPSession(
+                session,
+                database=database,
+                no_guides=no_guides,
+                excluded_schemas=excluded_schemas,
+                guide_topic=guide_topic,
+            )
+
+
+async def _attach_trusted_share(
+    session: ClientSession,
+    *,
+    share_url: str,
+    alias: str,
+    bootstrap_database: str,
+) -> None:
+    """Attach a configured share before exposing the read-only agent session."""
+    if not _SHARE_URL.fullmatch(share_url):
+        raise ValueError(f"Invalid MotherDuck share URL: {share_url!r}")
+    for label, value in (("share alias", alias), ("bootstrap database", bootstrap_database)):
+        if not _DB_IDENTIFIER.fullmatch(value):
+            raise ValueError(f"Invalid {label} {value!r}: expected a plain database identifier.")
+
+    sql = f"ATTACH '{share_url}' AS {alias} (READ_ONLY)"
+    result = await session.call_tool(
+        "query",
+        {"database": bootstrap_database, "sql": sql},
+    )
+    structured = getattr(result, "structuredContent", None)
+    text = json.dumps(structured) if structured is not None else _join_content_text(
+        getattr(result, "content", None)
+    )
+    # MotherDuck attachments can persist for the authenticated session. Treat
+    # the idempotent already-attached response as success; all other failures
+    # are configuration errors and must happen before the model runs.
+    payload_failed = isinstance(structured, dict) and structured.get("success") is False
+    attach_failed = getattr(result, "isError", False) is True or payload_failed
+    attach_error_is_idempotent = any(
+        marker in text.casefold()
+        for marker in ("already attached", "already exists")
+    )
+    if attach_failed and not attach_error_is_idempotent:
+        raise RuntimeError(f"Could not attach MotherDuck share as {alias!r}: {text}")
+
+    expected_path = share_url.removeprefix("md:")
+    quote_char = "'"
+    verify_sql = (
+        "SELECT database_name, path, type, readonly FROM duckdb_databases() "
+        f"WHERE database_name = {quote_char}{alias}{quote_char}"
+    )
+    verified = await session.call_tool(
+        "query",
+        {"database": alias, "sql": verify_sql},
+    )
+    verified_structured = getattr(verified, "structuredContent", None)
+    verified_rows = (
+        verified_structured.get("rows") if isinstance(verified_structured, dict) else None
+    )
+    expected_rows = [[alias, expected_path, "motherduck", True]]
+    if (
+        getattr(verified, "isError", False) is True
+        or not isinstance(verified_structured, dict)
+        or verified_structured.get("success") is False
+        or verified_rows != expected_rows
+    ):
+        verify_text = (
+            json.dumps(verified_structured)
+            if verified_structured is not None
+            else _join_content_text(getattr(verified, "content", None))
+        )
+        raise RuntimeError(
+            f"Database alias {alias!r} is not the configured read-only share: {verify_text}"
+        )
 
 
 async def call_tool_write(session: MCPSession, name: str, args: dict) -> MCPResult:

--- a/projects/agentic-sql-context-mcp/src/run.py
+++ b/projects/agentic-sql-context-mcp/src/run.py
@@ -1,19 +1,21 @@
-"""CLI: build the MotherDuck DB, run the agent over the 26 templates, summarize.
+"""CLI for the shared DABstep and Agentic Company evaluation harness.
 
-Single setup (one DB, one skill; the semantic layer lives in MotherDuck MCP
-guides, reached per task through a read-only MCP session). The eval set is the
-26 template-representative questions (`train_ids` in data/split.json); gold
-answers come from data/dabstep/tasks/all.jsonl.
+DABstep remains the default profile. Agentic Company supplies an external
+question set, a single manual guide, a shared multi-schema snapshot, an
+isolated prompt/skill, and criteria-driven scoring while reusing the same agent
+loop, MCP tools, concurrency, retries, logging, results, and summary behavior.
 """
 
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import subprocess
 import time
 from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 
 import click
@@ -26,16 +28,62 @@ from rich.text import Text
 
 from src import guides_load
 from src.agent import OpenRouterProvider, run_agent
+from src.agentic_company_score import score as score_agentic_company
 from src.load import DEFAULT_DATABASE, build_db
 from src.mcp_client import create_mcp_session
-from src.score import ExecutionError, score
+from src.score import ExecutionError
+from src.score import score as score_dabstep
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DATA_DIR = REPO_ROOT / "data"
 RESULTS_DIR = REPO_ROOT / "results"
 SKILL_PATH = REPO_ROOT / "skill" / "SKILL.md"
+AGENTIC_COMPANY_SKILL_PATH = REPO_ROOT / "skill" / "AGENTIC_COMPANY.md"
 TASKS_PATH = DATA_DIR / "dabstep" / "tasks" / "all.jsonl"
 SPLIT_PATH = DATA_DIR / "split.json"
+
+AGENTIC_COMPANY_BENCHMARK = "agentic-company"
+AGENTIC_COMPANY_DATABASE = "agentic_company_snapshot"
+AGENTIC_COMPANY_GUIDE_TOPIC = "agentic-company/manual"
+AGENTIC_COMPANY_MANIFEST_VERSION = "0.3.0"
+AGENTIC_COMPANY_SNAPSHOT_CUTOFF = "2026-07-31"
+AGENTIC_COMPANY_TASK_COUNT = 40
+AGENTIC_COMPANY_TOPIC_COUNT = 10
+AGENTIC_COMPANY_DIFFICULTY_DISTRIBUTION = {"easy": 10, "hard": 30}
+AGENTIC_COMPANY_DATABASE_BYTES = 705_441_792
+AGENTIC_COMPANY_DATABASE_SHA256 = (
+    "0a3c0bd92591093ad936d4eeb3cecf60958916dbbfd75ea4210b88619f0d9aa2"
+)
+AGENTIC_COMPANY_QUESTIONS_SHA256 = (
+    "ed3dc9836d8401cfdf614270adad262e0f22ae68df67e6c08741c0871170abd1"
+)
+AGENTIC_COMPANY_MANUAL_SHA256 = (
+    "fb68e02d6263e4d5d260769bf2b716be2d0c4139743ae67f7a87c1b45c14013f"
+)
+AGENTIC_COMPANY_SHARE = (
+    "md:_share/agentic_company_snapshot_share/"
+    "6b172abb-d377-4f0f-9a8a-d0ac199e074d"
+)
+AGENTIC_COMPANY_EXCLUDED_SCHEMAS = ("ground_truth", "sim")
+_AGENTIC_REQUIRED_FIELDS = (
+    "task_id",
+    "question",
+    "guidelines",
+    "answer",
+    "answer_criteria",
+    "level",
+    "topic_id",
+    "topic",
+    "snapshot_cutoff",
+    "source_tables",
+)
+_AGENTIC_CRITERIA_TYPES = {
+    "number",
+    "string",
+    "label:number",
+    "label:label:number",
+    "list[string]",
+}
 
 console = Console()
 
@@ -66,6 +114,7 @@ def _git_output(*args: str) -> str | None:
 
 def _build_run_provenance(
     *,
+    benchmark: str,
     split: str,
     database: str,
     model: str,
@@ -74,10 +123,12 @@ def _build_run_provenance(
     concurrency: int,
     out: Path,
     question_count: int,
+    artifacts: dict | None = None,
 ) -> dict:
     commit_sha = _git_output("rev-parse", "HEAD")
     dirty_status = _git_output("status", "--porcelain")
     resolved_config = {
+        "benchmark": benchmark,
         "split": split,
         "database": database,
         "model": model,
@@ -87,7 +138,13 @@ def _build_run_provenance(
         "question_count": question_count,
         "run_label": out.stem,
     }
-    return {
+    if artifacts:
+        # controllog.run_metadata has a fixed keyword schema. Keep benchmark
+        # provenance nested inside its supported resolved_config payload so
+        # artifact hashes participate in the config hash without becoming an
+        # unexpected top-level keyword.
+        resolved_config["benchmark_artifacts"] = artifacts
+    provenance = {
         "commit_sha": commit_sha,
         "repo": _git_output("config", "--get", "remote.origin.url"),
         "dirty": bool(dirty_status) if dirty_status is not None else None,
@@ -95,12 +152,192 @@ def _build_run_provenance(
         "resolved_config": resolved_config,
         "agent_name": AGENT_ID,
         "dataset_name": database,
-        "dataset_version": split,
+        "dataset_version": (artifacts or {}).get("version", split),
     }
+    return provenance
 
 
 def _md_database() -> str:
     return os.environ.get("MD_DATABASE", DEFAULT_DATABASE)
+
+
+def _agentic_company_benchmark_dir() -> Path:
+    configured = os.environ.get("AGENTIC_COMPANY_REPO")
+    root = Path(configured).expanduser() if configured else REPO_ROOT.parents[2] / "the-agentic-company"
+    return root / "benchmarks" / "dabstep_agentic_company"
+
+
+def _resolve_agentic_paths(
+    questions_jsonl: Path | None = None,
+    manual: Path | None = None,
+) -> tuple[Path, Path, Path]:
+    benchmark_dir = _agentic_company_benchmark_dir()
+    return (
+        questions_jsonl or benchmark_dir / "questions.jsonl",
+        manual or benchmark_dir / "manual.md",
+        benchmark_dir / "manifest.json",
+    )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_agentic_manifest(questions: list[dict], manifest: dict) -> None:
+    """Reject incomplete/drifted benchmark artifacts before model spend."""
+    if manifest.get("version") != AGENTIC_COMPANY_MANIFEST_VERSION:
+        raise ValueError(
+            "Agentic Company manifest version does not match this harness: "
+            f"expected {AGENTIC_COMPANY_MANIFEST_VERSION!r}, "
+            f"received {manifest.get('version')!r}."
+        )
+    cutoff = manifest.get("snapshot_cutoff")
+    if cutoff != AGENTIC_COMPANY_SNAPSHOT_CUTOFF:
+        raise ValueError(
+            "Agentic Company manifest snapshot_cutoff does not match this harness: "
+            f"expected {AGENTIC_COMPANY_SNAPSHOT_CUTOFF!r}, received {cutoff!r}."
+        )
+    excluded_schemas = manifest.get("excluded_schemas")
+    if excluded_schemas != list(AGENTIC_COMPANY_EXCLUDED_SCHEMAS):
+        raise ValueError(
+            "Agentic Company manifest excluded_schemas does not match the enforced "
+            f"boundary: expected {list(AGENTIC_COMPANY_EXCLUDED_SCHEMAS)!r}, "
+            f"received {excluded_schemas!r}."
+        )
+    source_database = manifest.get("source_database")
+    if not isinstance(source_database, dict):
+        raise TypeError("Agentic Company manifest source_database must be an object.")
+    if source_database.get("path") != "data/company_for_analysis.duckdb":
+        raise ValueError("Agentic Company manifest source_database.path is not canonical.")
+    source_bytes = source_database.get("bytes")
+    if source_bytes != AGENTIC_COMPANY_DATABASE_BYTES:
+        raise ValueError(
+            "Agentic Company manifest database byte size does not match the pinned snapshot."
+        )
+    if source_database.get("sha256") != AGENTIC_COMPANY_DATABASE_SHA256:
+        raise ValueError(
+            "Agentic Company manifest database SHA does not match the pinned snapshot."
+        )
+    expected_count = manifest.get("task_count")
+    if isinstance(expected_count, bool) or not isinstance(expected_count, int):
+        raise TypeError("Agentic Company manifest task_count must be an integer.")
+    if expected_count != AGENTIC_COMPANY_TASK_COUNT:
+        raise ValueError(
+            f"Agentic Company manifest task_count must be {AGENTIC_COMPANY_TASK_COUNT}."
+        )
+    if len(questions) != expected_count:
+        raise ValueError(
+            "Agentic Company questions.jsonl does not match manifest task_count: "
+            f"expected {expected_count}, loaded {len(questions)}."
+        )
+    expected_distribution = manifest.get("difficulty_distribution")
+    if not isinstance(expected_distribution, dict):
+        raise TypeError("Agentic Company manifest difficulty_distribution must be an object.")
+    if expected_distribution != AGENTIC_COMPANY_DIFFICULTY_DISTRIBUTION:
+        raise ValueError(
+            "Agentic Company manifest difficulty_distribution does not match the "
+            f"pinned benchmark: {AGENTIC_COMPANY_DIFFICULTY_DISTRIBUTION}."
+        )
+    actual_distribution: dict[str, int] = {}
+    for question in questions:
+        level = str(question.get("level") or "")
+        actual_distribution[level] = actual_distribution.get(level, 0) + 1
+    if actual_distribution != expected_distribution:
+        raise ValueError(
+            "Agentic Company question difficulty distribution does not match manifest: "
+            f"expected {expected_distribution}, loaded {actual_distribution}."
+        )
+    expected_topics = manifest.get("topic_count")
+    actual_topics = len({str(question.get("topic_id")) for question in questions})
+    if isinstance(expected_topics, bool) or not isinstance(expected_topics, int):
+        raise TypeError("Agentic Company manifest topic_count must be an integer.")
+    if expected_topics != AGENTIC_COMPANY_TOPIC_COUNT:
+        raise ValueError(
+            f"Agentic Company manifest topic_count must be {AGENTIC_COMPANY_TOPIC_COUNT}."
+        )
+    if actual_topics != expected_topics:
+        raise ValueError(
+            "Agentic Company question topic count does not match manifest: "
+            f"expected {expected_topics}, loaded {actual_topics}."
+        )
+    topics = manifest.get("topics")
+    if not isinstance(topics, list) or len(topics) != expected_topics:
+        raise ValueError("Agentic Company manifest topics must list every topic exactly once.")
+    expected_by_id: dict[str, dict] = {}
+    for topic in topics:
+        if not isinstance(topic, dict) or not isinstance(topic.get("topic_id"), str):
+            raise TypeError("Every Agentic Company manifest topic must be an object with topic_id.")
+        topic_id = topic["topic_id"]
+        if topic_id in expected_by_id:
+            raise ValueError(f"Duplicate Agentic Company manifest topic_id {topic_id!r}.")
+        expected_by_id[topic_id] = topic
+    canonical_topic_ids = {f"T{index:02d}" for index in range(1, 11)}
+    if set(expected_by_id) != canonical_topic_ids:
+        raise ValueError("Agentic Company manifest must contain topic IDs T01 through T10.")
+    actual_by_id: dict[str, dict[str, object]] = {}
+    for question in questions:
+        topic_id = question["topic_id"]
+        topic_name = question["topic"]
+        if question["snapshot_cutoff"] != cutoff:
+            raise ValueError(
+                f"{question['task_id']}: snapshot_cutoff does not match manifest."
+            )
+        source_tables = question["source_tables"]
+        if not isinstance(source_tables, list) or not source_tables or not all(
+            isinstance(table, str) and table for table in source_tables
+        ):
+            raise TypeError(f"{question['task_id']}: source_tables must be non-empty strings.")
+        actual = actual_by_id.setdefault(
+            topic_id,
+            {"topic": topic_name, "task_count": 0, "easy_count": 0, "hard_count": 0},
+        )
+        if actual["topic"] != topic_name:
+            raise ValueError(f"{topic_id}: question topic labels are inconsistent.")
+        actual["task_count"] = int(actual["task_count"]) + 1
+        level_key = f"{question['level']}_count"
+        actual[level_key] = int(actual[level_key]) + 1
+    if set(actual_by_id) != set(expected_by_id):
+        raise ValueError("Agentic Company manifest topic IDs do not match questions.jsonl.")
+    for topic_id, expected in expected_by_id.items():
+        actual = actual_by_id[topic_id]
+        for field in ("topic", "task_count", "easy_count", "hard_count"):
+            if expected.get(field) != actual[field]:
+                raise ValueError(
+                    f"Agentic Company topic {topic_id} {field} does not match manifest: "
+                    f"expected {expected.get(field)!r}, loaded {actual[field]!r}."
+                )
+
+
+def _validate_agentic_criteria(criteria: object, location: str) -> None:
+    if not isinstance(criteria, dict):
+        raise TypeError(f"{location}: answer_criteria must be an object")
+    answer_type = criteria.get("type")
+    if answer_type not in _AGENTIC_CRITERIA_TYPES:
+        raise ValueError(f"{location}: unsupported answer criteria type {answer_type!r}")
+    if answer_type in {"number", "label:number", "label:label:number"}:
+        decimals = criteria.get("decimals")
+        if isinstance(decimals, bool) or not isinstance(decimals, int) or decimals < 0:
+            raise ValueError(f"{location}: decimals must be a non-negative integer")
+        tolerance = criteria.get("tolerance")
+        try:
+            parsed_tolerance = Decimal(str(tolerance))
+        except (InvalidOperation, ValueError, TypeError) as exc:
+            raise ValueError(f"{location}: tolerance must be a finite non-negative number") from exc
+        if not parsed_tolerance.is_finite() or parsed_tolerance < 0:
+            raise ValueError(f"{location}: tolerance must be a finite non-negative number")
+    if answer_type in {"label:number", "label:label:number", "list[string]"}:
+        delimiter = criteria.get("delimiter")
+        if not isinstance(delimiter, str) or not delimiter:
+            raise ValueError(f"{location}: delimiter must be a non-empty string")
+    if answer_type == "list[string]":
+        if not isinstance(criteria.get("order_sensitive"), bool):
+            raise ValueError(f"{location}: order_sensitive must be a boolean")
+        if not isinstance(criteria.get("empty_answer", ""), str):
+            raise ValueError(f"{location}: empty_answer must be a string")
 
 
 def _bad_golds() -> set[str]:
@@ -111,12 +348,68 @@ def _bad_golds() -> set[str]:
     return {str(t) for t in json.loads(p.read_text()).get("task_ids", [])}
 
 
-def _load_questions(split: str) -> list[dict]:
+def _load_questions(
+    split: str,
+    *,
+    benchmark: str = "dabstep",
+    questions_path: Path | None = None,
+) -> list[dict]:
     """Load questions, excluding known-bad golds from the test/all sets.
     split='templates' -> the 26 train_ids (one per template; bad golds aren't among them);
     split='test'      -> the 419 held-out questions (all minus the 26 train minus 5 bad golds);
     split='all'       -> 445 (450 minus 5 bad golds).
     """
+    if benchmark == AGENTIC_COMPANY_BENCHMARK:
+        if split != "all":
+            raise ValueError("Agentic Company supports only split='all'.")
+        if questions_path is None:
+            questions_path = _resolve_agentic_paths()[0]
+        if not questions_path.is_file():
+            raise FileNotFoundError(f"Agentic Company questions not found: {questions_path}")
+        questions: list[dict] = []
+        seen: set[str] = set()
+        for line_number, line in enumerate(questions_path.read_text().splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                question = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{questions_path}:{line_number}: invalid JSON: {exc}") from exc
+            missing = [field for field in _AGENTIC_REQUIRED_FIELDS if field not in question]
+            if missing:
+                raise ValueError(f"{questions_path}:{line_number}: missing fields {missing}")
+            task_id = question["task_id"]
+            if not isinstance(task_id, str) or not task_id:
+                raise ValueError(f"{questions_path}:{line_number}: task_id must be a string")
+            if task_id in seen:
+                raise ValueError(f"{questions_path}:{line_number}: duplicate task_id {task_id!r}")
+            location = f"{questions_path}:{line_number}"
+            _validate_agentic_criteria(question["answer_criteria"], location)
+            if not all(
+                isinstance(question[field], str)
+                for field in (
+                    "question",
+                    "guidelines",
+                    "answer",
+                    "level",
+                    "topic_id",
+                    "topic",
+                    "snapshot_cutoff",
+                )
+            ):
+                raise ValueError(
+                    f"{location}: question, guidelines, answer, level, topic_id, topic, "
+                    "and snapshot_cutoff must be strings"
+                )
+            if question["level"] not in {"easy", "hard"}:
+                raise ValueError(f"{location}: level must be 'easy' or 'hard'")
+            seen.add(task_id)
+            question["question_index"] = len(questions)
+            questions.append(question)
+        return questions
+    if benchmark != "dabstep":
+        raise ValueError(f"Unknown benchmark: {benchmark!r}")
+
     all_qs = [json.loads(line) for line in TASKS_PATH.read_text().splitlines() if line.strip()]
     bad = _bad_golds()
     if split == "all":
@@ -174,17 +467,34 @@ def context_cmd() -> None:
 
 
 @cli.command("guides-load")
+@click.option(
+    "--benchmark",
+    type=click.Choice(["dabstep", AGENTIC_COMPANY_BENCHMARK]),
+    default="dabstep",
+    show_default=True,
+    help="Guide bundle to publish.",
+)
 @click.option("--dry-run", is_flag=True, default=False,
               help="Preview the planned guide topics without making any MCP calls.")
 @click.option("--prefix", default=None,
-              help="Guide topic prefix (default $DABSTEP_GUIDES_PREFIX or 'dabstep').")
-def guides_load_cmd(dry_run: bool, prefix: str | None) -> None:
-    """Publish the local context items to the MotherDuck MCP as guides.
+              help="Override the DABstep topic prefix (Agentic Company is fixed).")
+@click.option(
+    "--manual",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Agentic Company manual.md (defaults to the canonical external benchmark path).",
+)
+def guides_load_cmd(
+    benchmark: str,
+    dry_run: bool,
+    prefix: str | None,
+    manual: Path | None,
+) -> None:
+    """Publish the selected benchmark's context to MotherDuck MCP guides.
 
-    The write half of the "context layer IS guides" swap: each context item is
-    created (or, idempotently, updated via the committed guides.lock.json) as a
-    guide via the guide-write tools. Requires MOTHERDUCK_TOKEN; org-level guides
-    need an admin token (see guides_load for the access/prefix config).
+    DABstep publishes its context-item bundle. Agentic Company discovers or
+    creates exactly one personal manual at its fixed topic, without a local UUID
+    lock. Live publication requires MOTHERDUCK_TOKEN.
     """
     if not dry_run and not os.environ.get("MOTHERDUCK_TOKEN"):
         raise click.ClickException("MOTHERDUCK_TOKEN is not set.")
@@ -192,8 +502,18 @@ def guides_load_cmd(dry_run: bool, prefix: str | None) -> None:
     label = "planning" if dry_run else "publishing"
     console.print(f"[bold]{label}[/bold] context items → MotherDuck guides …")
     try:
-        results = guides_load.publish_all_sync(prefix=prefix, dry_run=dry_run)
-    except RuntimeError as exc:
+        if benchmark == AGENTIC_COMPANY_BENCHMARK:
+            manual_path = _resolve_agentic_paths(manual=manual)[1]
+            results = guides_load.publish_manual_sync(
+                manual_path=manual_path,
+                prefix=prefix,
+                dry_run=dry_run,
+            )
+        else:
+            if manual is not None:
+                raise click.ClickException("--manual is only valid for agentic-company.")
+            results = guides_load.publish_all_sync(prefix=prefix, dry_run=dry_run)
+    except (RuntimeError, TypeError, ValueError, OSError) as exc:
         raise click.ClickException(str(exc)) from exc
 
     table = Table(show_header=True, box=None, padding=(0, 2))
@@ -242,11 +562,34 @@ def _correctness_mark(c: str) -> str:
 
 
 @cli.command()
-@click.option("--split", type=click.Choice(["templates", "test", "all"]), default="templates",
-              help="'templates' = 26 reps (default); 'test' = 424 held-out; 'all' = full 450.")
+@click.option(
+    "--benchmark",
+    type=click.Choice(["dabstep", AGENTIC_COMPANY_BENCHMARK]),
+    default="dabstep",
+    show_default=True,
+)
+@click.option("--split", type=click.Choice(["templates", "test", "all"]), default=None,
+              help="DABstep: templates/test/all. Agentic Company: all (default).")
 @click.option("--model", default="gemini", help="OpenRouter model id or alias: gemini, opus, sonnet, haiku, gpt")
 @click.option("--database", default=None, help="MotherDuck database to query (read-only).")
-@click.option("--limit", type=int, default=None, help="Cap number of questions.")
+@click.option(
+    "--questions-jsonl",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Path to the pinned Agentic Company questions.jsonl artifact.",
+)
+@click.option(
+    "--manual",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Path to the pinned Agentic Company manual.md artifact.",
+)
+@click.option(
+    "--limit",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Cap number of selected questions (must be at least 1).",
+)
 @click.option("--task-id", "task_id", type=str, default=None, help="Run only this task_id.")
 @click.option("--task-ids", "task_ids", type=str, default=None,
               help="Comma-separated task_ids to run as one batch (overrides --split).")
@@ -263,9 +606,12 @@ def _correctness_mark(c: str) -> str:
                    "exist.' — measures the agent without the semantic layer.")
 @click.option("--out", type=click.Path(path_type=Path), default=None)
 def evaluate(
-    split: str,
+    benchmark: str,
+    split: str | None,
     model: str,
     database: str | None,
+    questions_jsonl: Path | None,
+    manual: Path | None,
     limit: int | None,
     task_id: str | None,
     task_ids: str | None,
@@ -281,27 +627,122 @@ def evaluate(
     if luna_max:
         model, reasoning = "luna", "max"
     model = MODEL_ALIASES.get(model, model)
-    database = database or _md_database()
+    is_agentic_company = benchmark == AGENTIC_COMPANY_BENCHMARK
+    split = split or ("all" if is_agentic_company else "templates")
+    if is_agentic_company and split != "all":
+        raise click.ClickException("agentic-company supports only --split all.")
+    if not is_agentic_company and (questions_jsonl is not None or manual is not None):
+        raise click.ClickException(
+            "--questions-jsonl and --manual are only valid with --benchmark agentic-company."
+        )
 
+    artifacts: dict = {}
+    manifest: dict | None = None
+    resolved_questions_path: Path | None = None
+    if is_agentic_company:
+        resolved_questions_path, resolved_manual_path, manifest_path = _resolve_agentic_paths(
+            questions_jsonl=questions_jsonl,
+            manual=manual,
+        )
+        for label, path in (
+            ("questions", resolved_questions_path),
+            ("manual", resolved_manual_path),
+            ("manifest", manifest_path),
+        ):
+            if not path.is_file():
+                raise click.ClickException(f"Agentic Company {label} not found: {path}")
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except json.JSONDecodeError as exc:
+            raise click.ClickException(
+                f"Agentic Company manifest is not valid JSON: {manifest_path}: {exc}"
+            ) from exc
+        if not isinstance(manifest, dict):
+            raise click.ClickException(
+                f"Agentic Company manifest must be a JSON object: {manifest_path}"
+            )
+        database = (
+            database
+            or os.environ.get("AGENTIC_COMPANY_MD_DATABASE")
+            or AGENTIC_COMPANY_DATABASE
+        )
+    else:
+        database = database or _md_database()
+
+    try:
+        all_questions = _load_questions(
+            "all" if (task_ids is not None or task_id is not None) else split,
+            benchmark=benchmark,
+            questions_path=resolved_questions_path,
+        )
+    except (TypeError, ValueError, OSError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    if is_agentic_company:
+        try:
+            _validate_agentic_manifest(all_questions, manifest or {})
+        except (TypeError, ValueError) as exc:
+            raise click.ClickException(str(exc)) from exc
+        questions_sha256 = _sha256(resolved_questions_path)
+        manual_sha256 = _sha256(resolved_manual_path)
+        if questions_sha256 != AGENTIC_COMPANY_QUESTIONS_SHA256:
+            raise click.ClickException(
+                "Agentic Company questions.jsonl does not match the pinned v0.3.0 artifact."
+            )
+        if manual_sha256 != AGENTIC_COMPANY_MANUAL_SHA256:
+            raise click.ClickException(
+                "Agentic Company manual.md does not match the pinned v0.3.0 artifact."
+            )
+        artifacts = {
+            "version": manifest["version"],
+            "snapshot_cutoff": manifest["snapshot_cutoff"],
+            "questions_path": str(resolved_questions_path.resolve()),
+            "questions_sha256": questions_sha256,
+            "manual_path": str(resolved_manual_path.resolve()),
+            "manual_sha256": manual_sha256,
+            "database_sha256": manifest["source_database"]["sha256"],
+            "share": AGENTIC_COMPANY_SHARE,
+        }
+
+    task_key = (
+        (lambda value: str(value).casefold())
+        if is_agentic_company
+        else (lambda value: str(value))
+    )
     if task_ids is not None:
         wanted = [t.strip() for t in task_ids.split(",") if t.strip()]
-        by_id = {str(q["task_id"]): q for q in _load_questions("all")}
-        missing = [t for t in wanted if t not in by_id]
+        if not wanted:
+            raise click.ClickException("--task-ids must contain at least one task ID.")
+        if len(wanted) != len({task_key(task) for task in wanted}):
+            raise click.ClickException("--task-ids must not contain duplicate task IDs.")
+        by_id = {task_key(q["task_id"]): q for q in all_questions}
+        missing = [task for task in wanted if task_key(task) not in by_id]
         if missing:
-            raise click.ClickException(f"task_ids not found in all.jsonl: {missing}")
-        questions = [by_id[t] for t in wanted]
+            raise click.ClickException(f"task_ids not found in the selected question set: {missing}")
+        questions = [by_id[task_key(task)] for task in wanted]
     elif task_id is not None:
-        all_qs = _load_questions("all")
-        questions = [q for q in all_qs if str(q["task_id"]) == task_id]
+        questions = [
+            question
+            for question in all_questions
+            if task_key(question["task_id"]) == task_key(task_id)
+        ]
         if not questions:
-            raise click.ClickException(f"task_id {task_id!r} not found in all.jsonl")
+            raise click.ClickException(
+                f"task_id {task_id!r} not found in the selected question set"
+            )
     else:
-        questions = _load_questions(split)
-        if limit:
-            questions = questions[:limit]
+        questions = all_questions
+    if limit is not None:
+        questions = questions[:limit]
+    if not questions:
+        raise click.ClickException("No questions were selected for evaluation.")
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    out = out or RESULTS_DIR / f"{split}_{ts}.jsonl"
+    default_name = (
+        f"agentic-company_{split}_{ts}.jsonl"
+        if is_agentic_company
+        else f"{split}_{ts}.jsonl"
+    )
+    out = out or RESULTS_DIR / default_name
     out.parent.mkdir(parents=True, exist_ok=True)
 
     if concurrency < 1:
@@ -314,9 +755,15 @@ def evaluate(
     )
 
     asyncio.run(_evaluate_loop(
-        split=split, database=database, model=model, questions=questions,
+        benchmark=benchmark, split=split, database=database, model=model, questions=questions,
         max_turns=max_turns, reasoning=reasoning, watch=watch,
         concurrency=concurrency, no_guides=no_guides, out=out,
+        skill_path=AGENTIC_COMPANY_SKILL_PATH if is_agentic_company else SKILL_PATH,
+        guide_topic=AGENTIC_COMPANY_GUIDE_TOPIC if is_agentic_company else None,
+        attach_share=AGENTIC_COMPANY_SHARE if is_agentic_company else None,
+        excluded_schemas=AGENTIC_COMPANY_EXCLUDED_SCHEMAS if is_agentic_company else (),
+        artifacts=artifacts,
+        project_id=("agentic-company-dabstep" if is_agentic_company else PROJECT_ID),
     ))
 
 
@@ -340,6 +787,46 @@ def _describe_exception(e: BaseException) -> str:
 
 def _tid_prefix(task_id: str | None) -> str:
     return f"[dim][{task_id}][/dim] " if task_id else ""
+
+
+def _score_question(
+    *,
+    benchmark: str,
+    execution_result,
+    question: dict,
+    predicted_sql: str | None,
+    hit_limit: bool = False,
+):
+    if benchmark == AGENTIC_COMPANY_BENCHMARK:
+        return score_agentic_company(
+            execution_result=execution_result,
+            gold_answer=question.get("answer", ""),
+            criteria=question.get("answer_criteria") or {},
+            predicted_sql=predicted_sql,
+            hit_limit=hit_limit,
+        )
+    return score_dabstep(
+        execution_result=execution_result,
+        gold_answer=question.get("answer", ""),
+        guidelines=question.get("guidelines"),
+        predicted_sql=predicted_sql,
+        hit_limit=hit_limit,
+    )
+
+
+def _agentic_result_metadata(question: dict, artifacts: dict | None) -> dict:
+    return {
+        "benchmark": AGENTIC_COMPANY_BENCHMARK,
+        "question_index": question.get("question_index"),
+        "topic_id": question.get("topic_id"),
+        "topic": question.get("topic"),
+        "answer_criteria": question.get("answer_criteria"),
+        "snapshot_cutoff": question.get("snapshot_cutoff"),
+        "source_tables": question.get("source_tables"),
+        "questions_sha256": (artifacts or {}).get("questions_sha256"),
+        "manual_sha256": (artifacts or {}).get("manual_sha256"),
+        "database_sha256": (artifacts or {}).get("database_sha256"),
+    }
 
 
 def _render_thinking(text: str, task_id: str | None = None) -> None:
@@ -440,10 +927,73 @@ def _render_tool_call(call: dict, task_id: str | None = None) -> None:
     console.print(Padding(Text(f"→ {tool} (unknown)"), (0, 0, 0, 6)))
 
 
+async def _preflight_agentic_company(
+    *,
+    database: str,
+    attach_share: str,
+    excluded_schemas: tuple[str, ...],
+    artifacts: dict,
+    verify_guide: bool,
+) -> None:
+    """Fail before model spend if the pinned share or single guide is wrong."""
+    async with create_mcp_session(
+        session_hint="agentic-company-preflight",
+        database=database,
+        attach_share=attach_share,
+        excluded_schemas=excluded_schemas,
+        guide_topic=AGENTIC_COMPANY_GUIDE_TOPIC,
+    ) as mcp:
+        cutoff = await mcp.call_tool(
+            "query",
+            {"sql": "SELECT max(sim_date)::VARCHAR FROM finance.pnl_daily"},
+        )
+        expected_cutoff = artifacts.get("snapshot_cutoff")
+        if cutoff.is_error or cutoff.rows != [[expected_cutoff]]:
+            raise click.ClickException(
+                "Agentic Company share preflight failed: expected finance.pnl_daily "
+                f"through {expected_cutoff}, received {cutoff.text}"
+            )
+        if not verify_guide:
+            return
+        listing = await mcp.call_tool(
+            "list_guides",
+            {"topic": AGENTIC_COMPANY_GUIDE_TOPIC},
+        )
+        try:
+            guide_uuid = guides_load.select_agentic_manual(
+                guides_load._guide_listing_payload(listing)
+            )
+        except (RuntimeError, TypeError) as exc:
+            raise click.ClickException(
+                f"Agentic Company manual guide preflight failed: {exc}"
+            ) from exc
+        if guide_uuid is None:
+            raise click.ClickException(
+                "Expected exactly one guide under agentic-company/manual; run "
+                "`asm guides-load --benchmark agentic-company` before evaluation."
+            )
+        guide = await mcp.call_tool("get_guide", {"uuid": guide_uuid})
+        try:
+            remote_text = json.loads(guide.text).get("text", "")
+            local_text = Path(artifacts["manual_path"]).read_text().rstrip()
+        except (KeyError, OSError, AttributeError, json.JSONDecodeError) as exc:
+            raise click.ClickException("Could not verify the Agentic Company manual guide.") from exc
+        marker = f"\n\n{guides_load.AGENTIC_COMPANY_MANUAL_DESCRIPTION}\n\n"
+        remote_body = remote_text.split(marker, 1)[1] if marker in remote_text else None
+        if guide.is_error or remote_body != local_text:
+            raise click.ClickException(
+                "The published Agentic Company manual does not match the selected manual.md. "
+                "Run `asm guides-load --benchmark agentic-company` to update it."
+            )
+
+
 async def _evaluate_loop(
-    *, split: str, database: str, model: str, questions: list[dict],
+    *, benchmark: str, split: str, database: str, model: str, questions: list[dict],
     max_turns: int, reasoning: str, watch: bool, concurrency: int,
-    no_guides: bool = False, out: Path,
+    no_guides: bool = False, out: Path, skill_path: Path = SKILL_PATH,
+    guide_topic: str | None = None, attach_share: str | None = None,
+    excluded_schemas: tuple[str, ...] = (), artifacts: dict | None = None,
+    project_id: str = PROJECT_ID,
 ) -> None:
     correct = 0
     by_cat: dict[str, int] = {}
@@ -459,15 +1009,26 @@ async def _evaluate_loop(
     # OpenRouter's documented "disable reasoning" is effort="none"; omitting the
     # reasoning param would instead fall back to the model's endpoint default.
     provider = OpenRouterProvider(reasoning_effort="none" if reasoning == "off" else reasoning)
-    skill_text = SKILL_PATH.read_text() if SKILL_PATH.exists() else None
+    skill_text = skill_path.read_text() if skill_path.exists() else None
     md_token = os.environ.get("MOTHERDUCK_TOKEN")
     if not md_token:
         raise click.ClickException("MOTHERDUCK_TOKEN is not set.")
+    if benchmark == AGENTIC_COMPANY_BENCHMARK:
+        if attach_share is None:
+            raise click.ClickException("Agentic Company profile requires its configured share.")
+        await _preflight_agentic_company(
+            database=database,
+            attach_share=attach_share,
+            excluded_schemas=excluded_schemas,
+            artifacts=artifacts or {},
+            verify_guide=not no_guides,
+        )
     f = out.open("w")
     wall_t0 = time.time()
 
     run_id = controllog.new_id()
     run_provenance = _build_run_provenance(
+        benchmark=benchmark,
         split=split,
         database=database,
         model=model,
@@ -476,13 +1037,14 @@ async def _evaluate_loop(
         concurrency=concurrency,
         out=out,
         question_count=len(questions),
+        artifacts=artifacts,
     )
     run_provenance["resolved_config"]["no_guides"] = no_guides
     controllog.init(
-        project_id=PROJECT_ID,
+        project_id=project_id,
         log_dir=RESULTS_DIR,
         default_dims={
-            "split": split, "model": model, "database": database,
+            "benchmark": benchmark, "split": split, "model": model, "database": database,
             "run_id": run_id, "run_label": out.stem,
         },
     )
@@ -519,11 +1081,16 @@ async def _evaluate_loop(
                 try:
                     async with create_mcp_session(
                         session_hint=tid, database=database, no_guides=no_guides,
+                        attach_share=attach_share,
+                        excluded_schemas=excluded_schemas,
+                        guide_topic=guide_topic,
                     ) as mcp:
                         run = await run_agent(
                             mcp=mcp, database=database,
                             question=q["question"], guidelines=q.get("guidelines"),
                             model=model, provider=provider, skill_text=skill_text,
+                            prompt_profile=benchmark,
+                            guide_topic=guide_topic,
                             max_turns=max_turns,
                             on_tool_call=(lambda call, _tid=tid: _render_tool_call(call, _tid)) if watch else None,
                             on_thinking=(lambda text, _tid=tid: _render_thinking(text, _tid)) if watch else None,
@@ -543,18 +1110,22 @@ async def _evaluate_loop(
             elapsed = time.time() - t0
 
             if run is None:
-                result = score(
-                    execution_result=ExecutionError("RunFailure", err or ""),
-                    gold_answer=q.get("answer", ""), guidelines=q.get("guidelines"),
+                execution_result = ExecutionError("RunFailure", err or "")
+                result = _score_question(
+                    benchmark=benchmark,
+                    execution_result=execution_result,
+                    question=q,
                     predicted_sql=None,
                 )
             else:
                 exec_result = run.final_rows if run.final_rows is not None else ExecutionError(
                     "NoSubmission", "agent did not submit"
                 )
-                result = score(
-                    execution_result=exec_result, gold_answer=q.get("answer", ""),
-                    guidelines=q.get("guidelines"), predicted_sql=run.final_sql,
+                result = _score_question(
+                    benchmark=benchmark,
+                    execution_result=exec_result,
+                    question=q,
+                    predicted_sql=run.final_sql,
                     hit_limit=run.hit_limit,
                 )
 
@@ -578,6 +1149,8 @@ async def _evaluate_loop(
                 "cached_tokens": run.cached_tokens if run else 0,
                 "error": err, "ts": datetime.now(timezone.utc).isoformat(),
             }
+            if benchmark == AGENTIC_COMPANY_BENCHMARK:
+                row.update(_agentic_result_metadata(q, artifacts))
 
             total_tokens = (run.prompt_tokens + run.completion_tokens) if run else 0
             wall_ms = int(elapsed * 1000)
@@ -585,15 +1158,15 @@ async def _evaluate_loop(
             terminal_state = "DONE" if run is not None else "FAILED"
             postings = [
                 controllog.post("resource.tokens", "provider:openrouter", "+tokens", -total_tokens, {"model": model}),
-                controllog.post("resource.tokens", f"project:{PROJECT_ID}", "+tokens", +total_tokens, {"model": model}),
+                controllog.post("resource.tokens", f"project:{project_id}", "+tokens", +total_tokens, {"model": model}),
                 controllog.post("truth.time", f"agent:{AGENT_ID}", "ms", -wall_ms, {"kind": "wall"}),
-                controllog.post("truth.time", f"project:{PROJECT_ID}", "ms", +wall_ms, {"kind": "wall"}),
+                controllog.post("truth.time", f"project:{project_id}", "ms", +wall_ms, {"kind": "wall"}),
                 controllog.post("truth.money", "vendor:openrouter", "$", -float(cost), {"model": model}),
-                controllog.post("truth.money", f"project:{PROJECT_ID}", "$", +float(cost), {"model": model}),
+                controllog.post("truth.money", f"project:{project_id}", "$", +float(cost), {"model": model}),
                 controllog.post("truth.state", f"task:{tid}", "tasks", -1, {"from": "WIP"}),
                 controllog.post("truth.state", f"task:{tid}", "tasks", +1, {"to": terminal_state}),
                 controllog.post("truth.utility", f"task:{tid}", "points", +reward, {"metric": "reward"}),
-                controllog.post("truth.utility", f"project:{PROJECT_ID}", "points", -reward, {"metric": "reward"}),
+                controllog.post("truth.utility", f"project:{project_id}", "points", -reward, {"metric": "reward"}),
             ]
             controllog.event(
                 kind="task_complete",

--- a/projects/agentic-sql-context-mcp/src/run.py
+++ b/projects/agentic-sql-context-mcp/src/run.py
@@ -9,13 +9,11 @@ loop, MCP tools, concurrency, retries, logging, results, and summary behavior.
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 import os
 import subprocess
 import time
 from datetime import datetime, timezone
-from decimal import Decimal, InvalidOperation
 from pathlib import Path
 
 import click
@@ -28,7 +26,11 @@ from rich.text import Text
 
 from src import guides_load
 from src.agent import OpenRouterProvider, run_agent
-from src.agentic_company_score import score as score_agentic_company
+from src.agentic_company_profile import (
+    AGENTIC_COMPANY_PROFILE,
+    AgenticCompanyArtifacts,
+    AgenticCompanyProfile,
+)
 from src.load import DEFAULT_DATABASE, build_db
 from src.mcp_client import create_mcp_session
 from src.score import ExecutionError
@@ -38,58 +40,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DATA_DIR = REPO_ROOT / "data"
 RESULTS_DIR = REPO_ROOT / "results"
 SKILL_PATH = REPO_ROOT / "skill" / "SKILL.md"
-AGENTIC_COMPANY_SKILL_PATH = REPO_ROOT / "skill" / "AGENTIC_COMPANY.md"
 TASKS_PATH = DATA_DIR / "dabstep" / "tasks" / "all.jsonl"
 SPLIT_PATH = DATA_DIR / "split.json"
 
-AGENTIC_COMPANY_BENCHMARK = "agentic-company"
-AGENTIC_COMPANY_DATABASE = "agentic_company_snapshot"
-AGENTIC_COMPANY_GUIDE_TOPIC = "agentic-company/manual"
-AGENTIC_COMPANY_MANIFEST_VERSION = "0.3.0"
-AGENTIC_COMPANY_SNAPSHOT_CUTOFF = "2026-07-31"
-AGENTIC_COMPANY_TASK_COUNT = 40
-AGENTIC_COMPANY_TOPIC_COUNT = 10
-AGENTIC_COMPANY_DIFFICULTY_DISTRIBUTION = {"easy": 10, "hard": 30}
-AGENTIC_COMPANY_DATABASE_BYTES = 705_441_792
-AGENTIC_COMPANY_DATABASE_SHA256 = (
-    "0a3c0bd92591093ad936d4eeb3cecf60958916dbbfd75ea4210b88619f0d9aa2"
-)
-AGENTIC_COMPANY_QUESTIONS_SHA256 = (
-    "ed3dc9836d8401cfdf614270adad262e0f22ae68df67e6c08741c0871170abd1"
-)
-AGENTIC_COMPANY_MANUAL_SHA256 = (
-    "fb68e02d6263e4d5d260769bf2b716be2d0c4139743ae67f7a87c1b45c14013f"
-)
-AGENTIC_COMPANY_SHARE = (
-    "md:_share/agentic_company_snapshot_share/"
-    "6b172abb-d377-4f0f-9a8a-d0ac199e074d"
-)
-AGENTIC_COMPANY_EXCLUDED_SCHEMAS = ("ground_truth", "sim")
-_AGENTIC_REQUIRED_FIELDS = (
-    "task_id",
-    "question",
-    "guidelines",
-    "answer",
-    "answer_criteria",
-    "level",
-    "topic_id",
-    "topic",
-    "snapshot_cutoff",
-    "source_tables",
-)
-_AGENTIC_CRITERIA_TYPES = {
-    "number",
-    "string",
-    "label:number",
-    "label:label:number",
-    "list[string]",
-}
-
 console = Console()
-
 PROJECT_ID = "agentic-sql-claude-edition"
 AGENT_ID = "asc-sql"
-
 MODEL_ALIASES = {
     "opus": "anthropic/claude-opus-4.7",
     "sonnet": "anthropic/claude-sonnet-4.6",
@@ -161,185 +117,6 @@ def _md_database() -> str:
     return os.environ.get("MD_DATABASE", DEFAULT_DATABASE)
 
 
-def _agentic_company_benchmark_dir() -> Path:
-    configured = os.environ.get("AGENTIC_COMPANY_REPO")
-    root = Path(configured).expanduser() if configured else REPO_ROOT.parents[2] / "the-agentic-company"
-    return root / "benchmarks" / "dabstep_agentic_company"
-
-
-def _resolve_agentic_paths(
-    questions_jsonl: Path | None = None,
-    manual: Path | None = None,
-) -> tuple[Path, Path, Path]:
-    benchmark_dir = _agentic_company_benchmark_dir()
-    return (
-        questions_jsonl or benchmark_dir / "questions.jsonl",
-        manual or benchmark_dir / "manual.md",
-        benchmark_dir / "manifest.json",
-    )
-
-
-def _sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _validate_agentic_manifest(questions: list[dict], manifest: dict) -> None:
-    """Reject incomplete/drifted benchmark artifacts before model spend."""
-    if manifest.get("version") != AGENTIC_COMPANY_MANIFEST_VERSION:
-        raise ValueError(
-            "Agentic Company manifest version does not match this harness: "
-            f"expected {AGENTIC_COMPANY_MANIFEST_VERSION!r}, "
-            f"received {manifest.get('version')!r}."
-        )
-    cutoff = manifest.get("snapshot_cutoff")
-    if cutoff != AGENTIC_COMPANY_SNAPSHOT_CUTOFF:
-        raise ValueError(
-            "Agentic Company manifest snapshot_cutoff does not match this harness: "
-            f"expected {AGENTIC_COMPANY_SNAPSHOT_CUTOFF!r}, received {cutoff!r}."
-        )
-    excluded_schemas = manifest.get("excluded_schemas")
-    if excluded_schemas != list(AGENTIC_COMPANY_EXCLUDED_SCHEMAS):
-        raise ValueError(
-            "Agentic Company manifest excluded_schemas does not match the enforced "
-            f"boundary: expected {list(AGENTIC_COMPANY_EXCLUDED_SCHEMAS)!r}, "
-            f"received {excluded_schemas!r}."
-        )
-    source_database = manifest.get("source_database")
-    if not isinstance(source_database, dict):
-        raise TypeError("Agentic Company manifest source_database must be an object.")
-    if source_database.get("path") != "data/company_for_analysis.duckdb":
-        raise ValueError("Agentic Company manifest source_database.path is not canonical.")
-    source_bytes = source_database.get("bytes")
-    if source_bytes != AGENTIC_COMPANY_DATABASE_BYTES:
-        raise ValueError(
-            "Agentic Company manifest database byte size does not match the pinned snapshot."
-        )
-    if source_database.get("sha256") != AGENTIC_COMPANY_DATABASE_SHA256:
-        raise ValueError(
-            "Agentic Company manifest database SHA does not match the pinned snapshot."
-        )
-    expected_count = manifest.get("task_count")
-    if isinstance(expected_count, bool) or not isinstance(expected_count, int):
-        raise TypeError("Agentic Company manifest task_count must be an integer.")
-    if expected_count != AGENTIC_COMPANY_TASK_COUNT:
-        raise ValueError(
-            f"Agentic Company manifest task_count must be {AGENTIC_COMPANY_TASK_COUNT}."
-        )
-    if len(questions) != expected_count:
-        raise ValueError(
-            "Agentic Company questions.jsonl does not match manifest task_count: "
-            f"expected {expected_count}, loaded {len(questions)}."
-        )
-    expected_distribution = manifest.get("difficulty_distribution")
-    if not isinstance(expected_distribution, dict):
-        raise TypeError("Agentic Company manifest difficulty_distribution must be an object.")
-    if expected_distribution != AGENTIC_COMPANY_DIFFICULTY_DISTRIBUTION:
-        raise ValueError(
-            "Agentic Company manifest difficulty_distribution does not match the "
-            f"pinned benchmark: {AGENTIC_COMPANY_DIFFICULTY_DISTRIBUTION}."
-        )
-    actual_distribution: dict[str, int] = {}
-    for question in questions:
-        level = str(question.get("level") or "")
-        actual_distribution[level] = actual_distribution.get(level, 0) + 1
-    if actual_distribution != expected_distribution:
-        raise ValueError(
-            "Agentic Company question difficulty distribution does not match manifest: "
-            f"expected {expected_distribution}, loaded {actual_distribution}."
-        )
-    expected_topics = manifest.get("topic_count")
-    actual_topics = len({str(question.get("topic_id")) for question in questions})
-    if isinstance(expected_topics, bool) or not isinstance(expected_topics, int):
-        raise TypeError("Agentic Company manifest topic_count must be an integer.")
-    if expected_topics != AGENTIC_COMPANY_TOPIC_COUNT:
-        raise ValueError(
-            f"Agentic Company manifest topic_count must be {AGENTIC_COMPANY_TOPIC_COUNT}."
-        )
-    if actual_topics != expected_topics:
-        raise ValueError(
-            "Agentic Company question topic count does not match manifest: "
-            f"expected {expected_topics}, loaded {actual_topics}."
-        )
-    topics = manifest.get("topics")
-    if not isinstance(topics, list) or len(topics) != expected_topics:
-        raise ValueError("Agentic Company manifest topics must list every topic exactly once.")
-    expected_by_id: dict[str, dict] = {}
-    for topic in topics:
-        if not isinstance(topic, dict) or not isinstance(topic.get("topic_id"), str):
-            raise TypeError("Every Agentic Company manifest topic must be an object with topic_id.")
-        topic_id = topic["topic_id"]
-        if topic_id in expected_by_id:
-            raise ValueError(f"Duplicate Agentic Company manifest topic_id {topic_id!r}.")
-        expected_by_id[topic_id] = topic
-    canonical_topic_ids = {f"T{index:02d}" for index in range(1, 11)}
-    if set(expected_by_id) != canonical_topic_ids:
-        raise ValueError("Agentic Company manifest must contain topic IDs T01 through T10.")
-    actual_by_id: dict[str, dict[str, object]] = {}
-    for question in questions:
-        topic_id = question["topic_id"]
-        topic_name = question["topic"]
-        if question["snapshot_cutoff"] != cutoff:
-            raise ValueError(
-                f"{question['task_id']}: snapshot_cutoff does not match manifest."
-            )
-        source_tables = question["source_tables"]
-        if not isinstance(source_tables, list) or not source_tables or not all(
-            isinstance(table, str) and table for table in source_tables
-        ):
-            raise TypeError(f"{question['task_id']}: source_tables must be non-empty strings.")
-        actual = actual_by_id.setdefault(
-            topic_id,
-            {"topic": topic_name, "task_count": 0, "easy_count": 0, "hard_count": 0},
-        )
-        if actual["topic"] != topic_name:
-            raise ValueError(f"{topic_id}: question topic labels are inconsistent.")
-        actual["task_count"] = int(actual["task_count"]) + 1
-        level_key = f"{question['level']}_count"
-        actual[level_key] = int(actual[level_key]) + 1
-    if set(actual_by_id) != set(expected_by_id):
-        raise ValueError("Agentic Company manifest topic IDs do not match questions.jsonl.")
-    for topic_id, expected in expected_by_id.items():
-        actual = actual_by_id[topic_id]
-        for field in ("topic", "task_count", "easy_count", "hard_count"):
-            if expected.get(field) != actual[field]:
-                raise ValueError(
-                    f"Agentic Company topic {topic_id} {field} does not match manifest: "
-                    f"expected {expected.get(field)!r}, loaded {actual[field]!r}."
-                )
-
-
-def _validate_agentic_criteria(criteria: object, location: str) -> None:
-    if not isinstance(criteria, dict):
-        raise TypeError(f"{location}: answer_criteria must be an object")
-    answer_type = criteria.get("type")
-    if answer_type not in _AGENTIC_CRITERIA_TYPES:
-        raise ValueError(f"{location}: unsupported answer criteria type {answer_type!r}")
-    if answer_type in {"number", "label:number", "label:label:number"}:
-        decimals = criteria.get("decimals")
-        if isinstance(decimals, bool) or not isinstance(decimals, int) or decimals < 0:
-            raise ValueError(f"{location}: decimals must be a non-negative integer")
-        tolerance = criteria.get("tolerance")
-        try:
-            parsed_tolerance = Decimal(str(tolerance))
-        except (InvalidOperation, ValueError, TypeError) as exc:
-            raise ValueError(f"{location}: tolerance must be a finite non-negative number") from exc
-        if not parsed_tolerance.is_finite() or parsed_tolerance < 0:
-            raise ValueError(f"{location}: tolerance must be a finite non-negative number")
-    if answer_type in {"label:number", "label:label:number", "list[string]"}:
-        delimiter = criteria.get("delimiter")
-        if not isinstance(delimiter, str) or not delimiter:
-            raise ValueError(f"{location}: delimiter must be a non-empty string")
-    if answer_type == "list[string]":
-        if not isinstance(criteria.get("order_sensitive"), bool):
-            raise ValueError(f"{location}: order_sensitive must be a boolean")
-        if not isinstance(criteria.get("empty_answer", ""), str):
-            raise ValueError(f"{location}: empty_answer must be a string")
-
-
 def _bad_golds() -> set[str]:
     """Task ids with provably-wrong hf_consensus golds, set aside (see bad_golds.json)."""
     p = DATA_DIR / "bad_golds.json"
@@ -359,54 +136,9 @@ def _load_questions(
     split='test'      -> the 419 held-out questions (all minus the 26 train minus 5 bad golds);
     split='all'       -> 445 (450 minus 5 bad golds).
     """
-    if benchmark == AGENTIC_COMPANY_BENCHMARK:
-        if split != "all":
-            raise ValueError("Agentic Company supports only split='all'.")
-        if questions_path is None:
-            questions_path = _resolve_agentic_paths()[0]
-        if not questions_path.is_file():
-            raise FileNotFoundError(f"Agentic Company questions not found: {questions_path}")
-        questions: list[dict] = []
-        seen: set[str] = set()
-        for line_number, line in enumerate(questions_path.read_text().splitlines(), start=1):
-            if not line.strip():
-                continue
-            try:
-                question = json.loads(line)
-            except json.JSONDecodeError as exc:
-                raise ValueError(f"{questions_path}:{line_number}: invalid JSON: {exc}") from exc
-            missing = [field for field in _AGENTIC_REQUIRED_FIELDS if field not in question]
-            if missing:
-                raise ValueError(f"{questions_path}:{line_number}: missing fields {missing}")
-            task_id = question["task_id"]
-            if not isinstance(task_id, str) or not task_id:
-                raise ValueError(f"{questions_path}:{line_number}: task_id must be a string")
-            if task_id in seen:
-                raise ValueError(f"{questions_path}:{line_number}: duplicate task_id {task_id!r}")
-            location = f"{questions_path}:{line_number}"
-            _validate_agentic_criteria(question["answer_criteria"], location)
-            if not all(
-                isinstance(question[field], str)
-                for field in (
-                    "question",
-                    "guidelines",
-                    "answer",
-                    "level",
-                    "topic_id",
-                    "topic",
-                    "snapshot_cutoff",
-                )
-            ):
-                raise ValueError(
-                    f"{location}: question, guidelines, answer, level, topic_id, topic, "
-                    "and snapshot_cutoff must be strings"
-                )
-            if question["level"] not in {"easy", "hard"}:
-                raise ValueError(f"{location}: level must be 'easy' or 'hard'")
-            seen.add(task_id)
-            question["question_index"] = len(questions)
-            questions.append(question)
-        return questions
+    if benchmark == AGENTIC_COMPANY_PROFILE.name:
+        path = questions_path or AGENTIC_COMPANY_PROFILE.resolve_paths()[0]
+        return AGENTIC_COMPANY_PROFILE.load_questions(path, split=split)
     if benchmark != "dabstep":
         raise ValueError(f"Unknown benchmark: {benchmark!r}")
 
@@ -469,7 +201,7 @@ def context_cmd() -> None:
 @cli.command("guides-load")
 @click.option(
     "--benchmark",
-    type=click.Choice(["dabstep", AGENTIC_COMPANY_BENCHMARK]),
+    type=click.Choice(["dabstep", AGENTIC_COMPANY_PROFILE.name]),
     default="dabstep",
     show_default=True,
     help="Guide bundle to publish.",
@@ -502,8 +234,15 @@ def guides_load_cmd(
     label = "planning" if dry_run else "publishing"
     console.print(f"[bold]{label}[/bold] context items → MotherDuck guides …")
     try:
-        if benchmark == AGENTIC_COMPANY_BENCHMARK:
-            manual_path = _resolve_agentic_paths(manual=manual)[1]
+        if benchmark == AGENTIC_COMPANY_PROFILE.name:
+            questions_path, manual_path, manifest_path = AGENTIC_COMPANY_PROFILE.resolve_paths(
+                manual=manual
+            )
+            AGENTIC_COMPANY_PROFILE.load_bundle(
+                questions_path,
+                manual_path,
+                manifest_path,
+            )
             results = guides_load.publish_manual_sync(
                 manual_path=manual_path,
                 prefix=prefix,
@@ -564,7 +303,7 @@ def _correctness_mark(c: str) -> str:
 @cli.command()
 @click.option(
     "--benchmark",
-    type=click.Choice(["dabstep", AGENTIC_COMPANY_BENCHMARK]),
+    type=click.Choice(["dabstep", AGENTIC_COMPANY_PROFILE.name]),
     default="dabstep",
     show_default=True,
 )
@@ -627,87 +366,43 @@ def evaluate(
     if luna_max:
         model, reasoning = "luna", "max"
     model = MODEL_ALIASES.get(model, model)
-    is_agentic_company = benchmark == AGENTIC_COMPANY_BENCHMARK
-    split = split or ("all" if is_agentic_company else "templates")
-    if is_agentic_company and split != "all":
-        raise click.ClickException("agentic-company supports only --split all.")
-    if not is_agentic_company and (questions_jsonl is not None or manual is not None):
+    profile = AGENTIC_COMPANY_PROFILE if benchmark == AGENTIC_COMPANY_PROFILE.name else None
+    split = split or (profile.default_split if profile else "templates")
+    if profile and split != profile.default_split:
+        raise click.ClickException(
+            f"{profile.name} supports only --split {profile.default_split}."
+        )
+    if profile is None and (questions_jsonl is not None or manual is not None):
         raise click.ClickException(
             "--questions-jsonl and --manual are only valid with --benchmark agentic-company."
         )
 
-    artifacts: dict = {}
-    manifest: dict | None = None
-    resolved_questions_path: Path | None = None
-    if is_agentic_company:
-        resolved_questions_path, resolved_manual_path, manifest_path = _resolve_agentic_paths(
+    artifacts: AgenticCompanyArtifacts | None = None
+    if profile:
+        resolved_questions_path, resolved_manual_path, manifest_path = profile.resolve_paths(
             questions_jsonl=questions_jsonl,
             manual=manual,
         )
-        for label, path in (
-            ("questions", resolved_questions_path),
-            ("manual", resolved_manual_path),
-            ("manifest", manifest_path),
-        ):
-            if not path.is_file():
-                raise click.ClickException(f"Agentic Company {label} not found: {path}")
         try:
-            manifest = json.loads(manifest_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise click.ClickException(
-                f"Agentic Company manifest is not valid JSON: {manifest_path}: {exc}"
-            ) from exc
-        if not isinstance(manifest, dict):
-            raise click.ClickException(
-                f"Agentic Company manifest must be a JSON object: {manifest_path}"
+            all_questions, artifacts = profile.load_bundle(
+                resolved_questions_path,
+                resolved_manual_path,
+                manifest_path,
             )
-        database = (
-            database
-            or os.environ.get("AGENTIC_COMPANY_MD_DATABASE")
-            or AGENTIC_COMPANY_DATABASE
-        )
+        except (TypeError, ValueError, OSError) as exc:
+            raise click.ClickException(str(exc)) from exc
+        database = profile.database_name(database)
     else:
         database = database or _md_database()
-
-    try:
-        all_questions = _load_questions(
-            "all" if (task_ids is not None or task_id is not None) else split,
-            benchmark=benchmark,
-            questions_path=resolved_questions_path,
-        )
-    except (TypeError, ValueError, OSError) as exc:
-        raise click.ClickException(str(exc)) from exc
-    if is_agentic_company:
         try:
-            _validate_agentic_manifest(all_questions, manifest or {})
-        except (TypeError, ValueError) as exc:
+            all_questions = _load_questions(
+                "all" if (task_ids is not None or task_id is not None) else split,
+                benchmark=benchmark,
+            )
+        except (TypeError, ValueError, OSError) as exc:
             raise click.ClickException(str(exc)) from exc
-        questions_sha256 = _sha256(resolved_questions_path)
-        manual_sha256 = _sha256(resolved_manual_path)
-        if questions_sha256 != AGENTIC_COMPANY_QUESTIONS_SHA256:
-            raise click.ClickException(
-                "Agentic Company questions.jsonl does not match the pinned v0.3.0 artifact."
-            )
-        if manual_sha256 != AGENTIC_COMPANY_MANUAL_SHA256:
-            raise click.ClickException(
-                "Agentic Company manual.md does not match the pinned v0.3.0 artifact."
-            )
-        artifacts = {
-            "version": manifest["version"],
-            "snapshot_cutoff": manifest["snapshot_cutoff"],
-            "questions_path": str(resolved_questions_path.resolve()),
-            "questions_sha256": questions_sha256,
-            "manual_path": str(resolved_manual_path.resolve()),
-            "manual_sha256": manual_sha256,
-            "database_sha256": manifest["source_database"]["sha256"],
-            "share": AGENTIC_COMPANY_SHARE,
-        }
 
-    task_key = (
-        (lambda value: str(value).casefold())
-        if is_agentic_company
-        else (lambda value: str(value))
-    )
+    task_key = profile.task_key if profile else (lambda value: str(value))
     if task_ids is not None:
         wanted = [t.strip() for t in task_ids.split(",") if t.strip()]
         if not wanted:
@@ -738,8 +433,8 @@ def evaluate(
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     default_name = (
-        f"agentic-company_{split}_{ts}.jsonl"
-        if is_agentic_company
+        f"{profile.name}_{split}_{ts}.jsonl"
+        if profile
         else f"{split}_{ts}.jsonl"
     )
     out = out or RESULTS_DIR / default_name
@@ -754,17 +449,23 @@ def evaluate(
         + (" · [bold red]NO GUIDES[/bold red]" if no_guides else "")
     )
 
-    asyncio.run(_evaluate_loop(
-        benchmark=benchmark, split=split, database=database, model=model, questions=questions,
-        max_turns=max_turns, reasoning=reasoning, watch=watch,
-        concurrency=concurrency, no_guides=no_guides, out=out,
-        skill_path=AGENTIC_COMPANY_SKILL_PATH if is_agentic_company else SKILL_PATH,
-        guide_topic=AGENTIC_COMPANY_GUIDE_TOPIC if is_agentic_company else None,
-        attach_share=AGENTIC_COMPANY_SHARE if is_agentic_company else None,
-        excluded_schemas=AGENTIC_COMPANY_EXCLUDED_SCHEMAS if is_agentic_company else (),
-        artifacts=artifacts,
-        project_id=("agentic-company-dabstep" if is_agentic_company else PROJECT_ID),
-    ))
+    asyncio.run(
+        _evaluate_loop(
+            benchmark=benchmark,
+            split=split,
+            database=database,
+            model=model,
+            questions=questions,
+            max_turns=max_turns,
+            reasoning=reasoning,
+            watch=watch,
+            concurrency=concurrency,
+            no_guides=no_guides,
+            out=out,
+            profile=profile,
+            artifacts=artifacts,
+        )
+    )
 
 
 def _describe_exception(e: BaseException) -> str:
@@ -787,46 +488,6 @@ def _describe_exception(e: BaseException) -> str:
 
 def _tid_prefix(task_id: str | None) -> str:
     return f"[dim][{task_id}][/dim] " if task_id else ""
-
-
-def _score_question(
-    *,
-    benchmark: str,
-    execution_result,
-    question: dict,
-    predicted_sql: str | None,
-    hit_limit: bool = False,
-):
-    if benchmark == AGENTIC_COMPANY_BENCHMARK:
-        return score_agentic_company(
-            execution_result=execution_result,
-            gold_answer=question.get("answer", ""),
-            criteria=question.get("answer_criteria") or {},
-            predicted_sql=predicted_sql,
-            hit_limit=hit_limit,
-        )
-    return score_dabstep(
-        execution_result=execution_result,
-        gold_answer=question.get("answer", ""),
-        guidelines=question.get("guidelines"),
-        predicted_sql=predicted_sql,
-        hit_limit=hit_limit,
-    )
-
-
-def _agentic_result_metadata(question: dict, artifacts: dict | None) -> dict:
-    return {
-        "benchmark": AGENTIC_COMPANY_BENCHMARK,
-        "question_index": question.get("question_index"),
-        "topic_id": question.get("topic_id"),
-        "topic": question.get("topic"),
-        "answer_criteria": question.get("answer_criteria"),
-        "snapshot_cutoff": question.get("snapshot_cutoff"),
-        "source_tables": question.get("source_tables"),
-        "questions_sha256": (artifacts or {}).get("questions_sha256"),
-        "manual_sha256": (artifacts or {}).get("manual_sha256"),
-        "database_sha256": (artifacts or {}).get("database_sha256"),
-    }
 
 
 def _render_thinking(text: str, task_id: str | None = None) -> None:
@@ -927,73 +588,12 @@ def _render_tool_call(call: dict, task_id: str | None = None) -> None:
     console.print(Padding(Text(f"→ {tool} (unknown)"), (0, 0, 0, 6)))
 
 
-async def _preflight_agentic_company(
-    *,
-    database: str,
-    attach_share: str,
-    excluded_schemas: tuple[str, ...],
-    artifacts: dict,
-    verify_guide: bool,
-) -> None:
-    """Fail before model spend if the pinned share or single guide is wrong."""
-    async with create_mcp_session(
-        session_hint="agentic-company-preflight",
-        database=database,
-        attach_share=attach_share,
-        excluded_schemas=excluded_schemas,
-        guide_topic=AGENTIC_COMPANY_GUIDE_TOPIC,
-    ) as mcp:
-        cutoff = await mcp.call_tool(
-            "query",
-            {"sql": "SELECT max(sim_date)::VARCHAR FROM finance.pnl_daily"},
-        )
-        expected_cutoff = artifacts.get("snapshot_cutoff")
-        if cutoff.is_error or cutoff.rows != [[expected_cutoff]]:
-            raise click.ClickException(
-                "Agentic Company share preflight failed: expected finance.pnl_daily "
-                f"through {expected_cutoff}, received {cutoff.text}"
-            )
-        if not verify_guide:
-            return
-        listing = await mcp.call_tool(
-            "list_guides",
-            {"topic": AGENTIC_COMPANY_GUIDE_TOPIC},
-        )
-        try:
-            guide_uuid = guides_load.select_agentic_manual(
-                guides_load._guide_listing_payload(listing)
-            )
-        except (RuntimeError, TypeError) as exc:
-            raise click.ClickException(
-                f"Agentic Company manual guide preflight failed: {exc}"
-            ) from exc
-        if guide_uuid is None:
-            raise click.ClickException(
-                "Expected exactly one guide under agentic-company/manual; run "
-                "`asm guides-load --benchmark agentic-company` before evaluation."
-            )
-        guide = await mcp.call_tool("get_guide", {"uuid": guide_uuid})
-        try:
-            remote_text = json.loads(guide.text).get("text", "")
-            local_text = Path(artifacts["manual_path"]).read_text().rstrip()
-        except (KeyError, OSError, AttributeError, json.JSONDecodeError) as exc:
-            raise click.ClickException("Could not verify the Agentic Company manual guide.") from exc
-        marker = f"\n\n{guides_load.AGENTIC_COMPANY_MANUAL_DESCRIPTION}\n\n"
-        remote_body = remote_text.split(marker, 1)[1] if marker in remote_text else None
-        if guide.is_error or remote_body != local_text:
-            raise click.ClickException(
-                "The published Agentic Company manual does not match the selected manual.md. "
-                "Run `asm guides-load --benchmark agentic-company` to update it."
-            )
-
-
 async def _evaluate_loop(
     *, benchmark: str, split: str, database: str, model: str, questions: list[dict],
     max_turns: int, reasoning: str, watch: bool, concurrency: int,
-    no_guides: bool = False, out: Path, skill_path: Path = SKILL_PATH,
-    guide_topic: str | None = None, attach_share: str | None = None,
-    excluded_schemas: tuple[str, ...] = (), artifacts: dict | None = None,
-    project_id: str = PROJECT_ID,
+    no_guides: bool = False, out: Path,
+    profile: AgenticCompanyProfile | None = None,
+    artifacts: AgenticCompanyArtifacts | None = None,
 ) -> None:
     correct = 0
     by_cat: dict[str, int] = {}
@@ -1009,19 +609,42 @@ async def _evaluate_loop(
     # OpenRouter's documented "disable reasoning" is effort="none"; omitting the
     # reasoning param would instead fall back to the model's endpoint default.
     provider = OpenRouterProvider(reasoning_effort="none" if reasoning == "off" else reasoning)
+    skill_path = profile.skill_path if profile else SKILL_PATH
     skill_text = skill_path.read_text() if skill_path.exists() else None
+    guide_topic = profile.guide_topic if profile else None
+    attach_share = profile.share if profile else None
+    excluded_schemas = profile.excluded_schemas if profile else ()
+    project_id = profile.project_id if profile else PROJECT_ID
+    artifact_provenance = artifacts.provenance() if artifacts else None
     md_token = os.environ.get("MOTHERDUCK_TOKEN")
     if not md_token:
         raise click.ClickException("MOTHERDUCK_TOKEN is not set.")
-    if benchmark == AGENTIC_COMPANY_BENCHMARK:
-        if attach_share is None:
-            raise click.ClickException("Agentic Company profile requires its configured share.")
-        await _preflight_agentic_company(
-            database=database,
-            attach_share=attach_share,
-            excluded_schemas=excluded_schemas,
-            artifacts=artifacts or {},
-            verify_guide=not no_guides,
+    if profile:
+        if artifacts is None:
+            raise click.ClickException("Agentic Company profile requires validated artifacts.")
+        try:
+            await profile.preflight(
+                database=database,
+                artifacts=artifacts,
+                verify_guide=not no_guides,
+            )
+        except (RuntimeError, TypeError, ValueError, OSError) as exc:
+            raise click.ClickException(str(exc)) from exc
+
+    def score_question(execution_result, question: dict, predicted_sql, hit_limit=False):
+        if profile:
+            return profile.score(
+                execution_result=execution_result,
+                question=question,
+                predicted_sql=predicted_sql,
+                hit_limit=hit_limit,
+            )
+        return score_dabstep(
+            execution_result=execution_result,
+            gold_answer=question.get("answer", ""),
+            guidelines=question.get("guidelines"),
+            predicted_sql=predicted_sql,
+            hit_limit=hit_limit,
         )
     f = out.open("w")
     wall_t0 = time.time()
@@ -1037,7 +660,7 @@ async def _evaluate_loop(
         concurrency=concurrency,
         out=out,
         question_count=len(questions),
-        artifacts=artifacts,
+        artifacts=artifact_provenance,
     )
     run_provenance["resolved_config"]["no_guides"] = no_guides
     controllog.init(
@@ -1111,8 +734,7 @@ async def _evaluate_loop(
 
             if run is None:
                 execution_result = ExecutionError("RunFailure", err or "")
-                result = _score_question(
-                    benchmark=benchmark,
+                result = score_question(
                     execution_result=execution_result,
                     question=q,
                     predicted_sql=None,
@@ -1121,8 +743,7 @@ async def _evaluate_loop(
                 exec_result = run.final_rows if run.final_rows is not None else ExecutionError(
                     "NoSubmission", "agent did not submit"
                 )
-                result = _score_question(
-                    benchmark=benchmark,
+                result = score_question(
                     execution_result=exec_result,
                     question=q,
                     predicted_sql=run.final_sql,
@@ -1149,8 +770,8 @@ async def _evaluate_loop(
                 "cached_tokens": run.cached_tokens if run else 0,
                 "error": err, "ts": datetime.now(timezone.utc).isoformat(),
             }
-            if benchmark == AGENTIC_COMPANY_BENCHMARK:
-                row.update(_agentic_result_metadata(q, artifacts))
+            if profile and artifacts:
+                row.update(profile.result_metadata(q, artifacts))
 
             total_tokens = (run.prompt_tokens + run.completion_tokens) if run else 0
             wall_ms = int(elapsed * 1000)

--- a/projects/agentic-sql-context-mcp/tests/test_agentic_company_profile.py
+++ b/projects/agentic-sql-context-mcp/tests/test_agentic_company_profile.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import ClassVar
@@ -22,24 +23,25 @@ from src.agent import (
     build_agentic_company_system_prompt,
     build_system_prompt,
 )
+from src.agentic_company_profile import AGENTIC_COMPANY_PROFILE
 from src.agentic_company_score import answers_match, format_answer, score
 from src.mcp_client import MCPSession, _attach_trusted_share, _read_only_violation
 from src.run import (
-    AGENTIC_COMPANY_BENCHMARK,
-    AGENTIC_COMPANY_DATABASE_BYTES,
-    AGENTIC_COMPANY_DATABASE_SHA256,
-    AGENTIC_COMPANY_GUIDE_TOPIC,
-    AGENTIC_COMPANY_SHARE,
-    AGENTIC_COMPANY_SKILL_PATH,
-    AGENTIC_COMPANY_SNAPSHOT_CUTOFF,
     _build_run_provenance,
     _load_questions,
-    _resolve_agentic_paths,
-    _validate_agentic_manifest,
     cli,
 )
 from src.score import Correctness, ExecutionError
 
+AGENTIC_COMPANY_BENCHMARK = AGENTIC_COMPANY_PROFILE.name
+AGENTIC_COMPANY_DATABASE_BYTES = AGENTIC_COMPANY_PROFILE.database_bytes
+AGENTIC_COMPANY_DATABASE_SHA256 = AGENTIC_COMPANY_PROFILE.database_sha256
+AGENTIC_COMPANY_GUIDE_TOPIC = AGENTIC_COMPANY_PROFILE.guide_topic
+AGENTIC_COMPANY_SHARE = AGENTIC_COMPANY_PROFILE.share
+AGENTIC_COMPANY_SKILL_PATH = AGENTIC_COMPANY_PROFILE.skill_path
+AGENTIC_COMPANY_SNAPSHOT_CUTOFF = AGENTIC_COMPANY_PROFILE.snapshot_cutoff
+_resolve_agentic_paths = AGENTIC_COMPANY_PROFILE.resolve_paths
+_validate_agentic_manifest = AGENTIC_COMPANY_PROFILE.validate_manifest
 CANONICAL_QUESTIONS = _resolve_agentic_paths()[0]
 
 
@@ -89,12 +91,13 @@ def _write_benchmark_fixture(directory: Path, questions: list[dict]) -> tuple[Pa
     (directory / "manifest.json").write_text(
         json.dumps(
             {
-                "version": "0.3.0",
+                "version": AGENTIC_COMPANY_PROFILE.manifest_version,
                 "snapshot_cutoff": AGENTIC_COMPANY_SNAPSHOT_CUTOFF,
                 "task_count": len(questions),
                 "topic_count": len({question["topic_id"] for question in questions}),
                 "difficulty_distribution": distribution,
                 "excluded_schemas": ["ground_truth", "sim"],
+                "context_files": ["benchmarks/dabstep_agentic_company/manual.md"],
                 "source_database": {
                     "path": "data/company_for_analysis.duckdb",
                     "bytes": AGENTIC_COMPANY_DATABASE_BYTES,
@@ -131,6 +134,14 @@ def _write_benchmark_fixture(directory: Path, questions: list[dict]) -> tuple[Pa
 def _ids_hash(questions: list[dict]) -> str:
     ids = "\n".join(str(question["task_id"]) for question in questions)
     return hashlib.sha256(ids.encode()).hexdigest()
+
+
+def _profile_for_fixture(directory: Path):
+    return replace(
+        AGENTIC_COMPANY_PROFILE,
+        questions_sha256=hashlib.sha256((directory / "questions.jsonl").read_bytes()).hexdigest(),
+        manual_sha256=hashlib.sha256((directory / "manual.md").read_bytes()).hexdigest(),
+    )
 
 
 class QuestionLoaderTests(unittest.TestCase):
@@ -243,6 +254,9 @@ class AgenticScoringTests(unittest.TestCase):
             "type": "list[string]",
             "delimiter": ",",
             "order_sensitive": True,
+            "element_type": "label:number",
+            "decimals": 2,
+            "tolerance": 0.005,
         }
         gold = "Cedarpoint Outfitters:406.67, ParcelPeak Marketplace:45.69"
         reversed_answer = "ParcelPeak Marketplace:45.69, Cedarpoint Outfitters:406.67"
@@ -250,6 +264,13 @@ class AgenticScoringTests(unittest.TestCase):
         self.assertTrue(
             answers_match(
                 "Cedarpoint Outfitters:406.666, ParcelPeak Marketplace:45.694",
+                gold,
+                criteria,
+            )
+        )
+        self.assertFalse(
+            answers_match(
+                "Cedarpoint Outfitters:406.676, ParcelPeak Marketplace:45.69",
                 gold,
                 criteria,
             )
@@ -267,7 +288,14 @@ class AgenticScoringTests(unittest.TestCase):
             format_answer([("2026-02", "cash_out_ap", -2952349.09)], triple),
             "2026-02:cash_out_ap:-2952349.09",
         )
-        ordered_list = {"type": "list[string]", "delimiter": ",", "order_sensitive": True}
+        ordered_list = {
+            "type": "list[string]",
+            "delimiter": ",",
+            "order_sensitive": True,
+            "element_type": "label:number",
+            "decimals": 2,
+            "tolerance": 0.005,
+        }
         self.assertEqual(
             format_answer([("A", "1.00"), ("B", "2.00")], ordered_list),
             "A:1.00, B:2.00",
@@ -656,7 +684,7 @@ class SubmissionTests(unittest.TestCase):
 class CLIProfileTests(unittest.TestCase):
     def test_agentic_provenance_matches_installed_controllog_schema(self) -> None:
         artifacts = {
-            "version": "0.3.0",
+            "version": AGENTIC_COMPANY_PROFILE.manifest_version,
             "questions_sha256": "q-sha",
             "manual_sha256": "m-sha",
             "database_sha256": "db-sha",
@@ -691,16 +719,10 @@ class CLIProfileTests(unittest.TestCase):
             )
             out = fixture_dir / "result.jsonl"
             loop = AsyncMock()
+            fixture_profile = _profile_for_fixture(fixture_dir)
             with (
                 patch("src.run._evaluate_loop", loop),
-                patch(
-                    "src.run.AGENTIC_COMPANY_QUESTIONS_SHA256",
-                    hashlib.sha256((fixture_dir / "questions.jsonl").read_bytes()).hexdigest(),
-                ),
-                patch(
-                    "src.run.AGENTIC_COMPANY_MANUAL_SHA256",
-                    hashlib.sha256((fixture_dir / "manual.md").read_bytes()).hexdigest(),
-                ),
+                patch("src.run.AGENTIC_COMPANY_PROFILE", fixture_profile),
             ):
                 result = runner.invoke(
                     cli,
@@ -720,7 +742,34 @@ class CLIProfileTests(unittest.TestCase):
         self.assertEqual(kwargs["benchmark"], AGENTIC_COMPANY_BENCHMARK)
         self.assertEqual(kwargs["split"], "all")
         self.assertEqual([question["task_id"] for question in kwargs["questions"]], ["AC-030"])
-        self.assertEqual(kwargs["guide_topic"], AGENTIC_COMPANY_GUIDE_TOPIC)
+        self.assertEqual(kwargs["profile"].guide_topic, AGENTIC_COMPANY_GUIDE_TOPIC)
+        self.assertEqual(kwargs["artifacts"].version, AGENTIC_COMPANY_PROFILE.manifest_version)
+
+    @unittest.skipUnless(CANONICAL_QUESTIONS.is_file(), "external benchmark checkout not present")
+    def test_default_canonical_bundle_reaches_shared_loop(self) -> None:
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            loop = AsyncMock()
+            with patch("src.run._evaluate_loop", loop):
+                result = runner.invoke(
+                    cli,
+                    [
+                        "evaluate",
+                        "--benchmark",
+                        AGENTIC_COMPANY_BENCHMARK,
+                        "--task-id",
+                        "AC-030",
+                        "--out",
+                        str(Path(tmpdir) / "result.jsonl"),
+                    ],
+                )
+        self.assertEqual(result.exit_code, 0, result.output)
+        kwargs = loop.await_args.kwargs
+        self.assertEqual(kwargs["artifacts"].version, "0.3.1")
+        self.assertEqual(
+            kwargs["artifacts"].questions_sha256,
+            AGENTIC_COMPANY_PROFILE.questions_sha256,
+        )
 
     def test_invalid_limit_and_duplicate_ids_fail_before_loop(self) -> None:
         runner = CliRunner()
@@ -737,16 +786,7 @@ class CLIProfileTests(unittest.TestCase):
                 AGENTIC_COMPANY_BENCHMARK,
             ]
             env = {"AGENTIC_COMPANY_REPO": str(repo_root)}
-            with (
-                patch(
-                    "src.run.AGENTIC_COMPANY_QUESTIONS_SHA256",
-                    hashlib.sha256((fixture_dir / "questions.jsonl").read_bytes()).hexdigest(),
-                ),
-                patch(
-                    "src.run.AGENTIC_COMPANY_MANUAL_SHA256",
-                    hashlib.sha256((fixture_dir / "manual.md").read_bytes()).hexdigest(),
-                ),
-            ):
+            with patch("src.run.AGENTIC_COMPANY_PROFILE", _profile_for_fixture(fixture_dir)):
                 invalid_limit = runner.invoke(cli, [*common, "--limit", "0"], env=env)
                 duplicate_ids = runner.invoke(
                     cli,
@@ -816,6 +856,49 @@ class CLIProfileTests(unittest.TestCase):
 
 
 class MCPBoundaryTests(unittest.TestCase):
+    def test_public_snapshot_fingerprint_is_checked_before_model_spend(self) -> None:
+        fingerprint_rows = [
+            ["catalog.products", 8, "111"],
+            ["catalog.skus", 19, "222"],
+        ]
+        profile = replace(
+            AGENTIC_COMPANY_PROFILE,
+            public_schemas=("catalog",),
+            public_relation_count=2,
+            public_snapshot_fingerprint=AGENTIC_COMPANY_PROFILE.snapshot_fingerprint(
+                fingerprint_rows
+            ),
+        )
+
+        class FakeSession:
+            def __init__(self) -> None:
+                self.queries: list[str] = []
+
+            async def call_tool(self, name: str, args: dict):
+                if name == "list_tables":
+                    return SimpleNamespace(
+                        is_error=False,
+                        rows=[
+                            {"schema": "catalog", "name": "products"},
+                            {"schema": "catalog", "name": "skus"},
+                        ],
+                        text="ok",
+                    )
+                if name == "query":
+                    self.queries.append(args["sql"])
+                    return SimpleNamespace(is_error=False, rows=fingerprint_rows, text="ok")
+                raise AssertionError(name)
+
+        async def exercise() -> None:
+            session = FakeSession()
+            await profile._verify_public_snapshot(session)
+            self.assertIn("md5_number(to_json(t))", session.queries[0])
+            drifted = replace(profile, public_snapshot_fingerprint="0" * 64)
+            with self.assertRaisesRegex(RuntimeError, "does not match"):
+                await drifted._verify_public_snapshot(session)
+
+        asyncio.run(exercise())
+
     def test_list_columns_splits_qualified_names_and_reports_column_rows(self) -> None:
         class FakeSession:
             def __init__(self) -> None:

--- a/projects/agentic-sql-context-mcp/tests/test_agentic_company_profile.py
+++ b/projects/agentic-sql-context-mcp/tests/test_agentic_company_profile.py
@@ -1,0 +1,1065 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import inspect
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import ClassVar
+from unittest.mock import AsyncMock, patch
+
+import controllog
+from click.testing import CliRunner
+
+from src import guides_load
+from src.agent import (
+    RunState,
+    _make_tools,
+    _resolve_hit_limit,
+    build_agentic_company_system_prompt,
+    build_system_prompt,
+)
+from src.agentic_company_score import answers_match, format_answer, score
+from src.mcp_client import MCPSession, _attach_trusted_share, _read_only_violation
+from src.run import (
+    AGENTIC_COMPANY_BENCHMARK,
+    AGENTIC_COMPANY_DATABASE_BYTES,
+    AGENTIC_COMPANY_DATABASE_SHA256,
+    AGENTIC_COMPANY_GUIDE_TOPIC,
+    AGENTIC_COMPANY_SHARE,
+    AGENTIC_COMPANY_SKILL_PATH,
+    AGENTIC_COMPANY_SNAPSHOT_CUTOFF,
+    _build_run_provenance,
+    _load_questions,
+    _resolve_agentic_paths,
+    _validate_agentic_manifest,
+    cli,
+)
+from src.score import Correctness, ExecutionError
+
+CANONICAL_QUESTIONS = _resolve_agentic_paths()[0]
+
+
+def _fixture_question(
+    task_id: str = "AC-001",
+    *,
+    criteria: dict | None = None,
+    answer: str = "13",
+) -> dict:
+    return {
+        "task_id": task_id,
+        "topic_id": "T01",
+        "topic": "Fixture topic",
+        "level": "easy",
+        "question": "How many fixture rows exist?",
+        "guidelines": "Answer with a whole number.",
+        "answer_criteria": criteria
+        or {"type": "number", "decimals": 0, "tolerance": 0, "shape": "integer"},
+        "answer": answer,
+        "snapshot_cutoff": "2026-07-31",
+        "source_tables": ["catalog.skus"],
+    }
+
+
+def _fixture_questions() -> list[dict]:
+    questions: list[dict] = []
+    for index in range(1, 41):
+        topic_number = (index - 1) // 4 + 1
+        question = _fixture_question(f"AC-{index:03d}")
+        question["topic_id"] = f"T{topic_number:02d}"
+        question["topic"] = f"Fixture topic {topic_number:02d}"
+        question["level"] = "easy" if (index - 1) % 4 == 0 else "hard"
+        questions.append(question)
+    return questions
+
+
+def _write_benchmark_fixture(directory: Path, questions: list[dict]) -> tuple[Path, Path]:
+    directory.mkdir(parents=True, exist_ok=True)
+    questions_path = directory / "questions.jsonl"
+    manual_path = directory / "manual.md"
+    questions_path.write_text("\n".join(json.dumps(question) for question in questions) + "\n")
+    manual_path.write_text("# Agentic Company analyst field manual\n\nFixture manual.\n")
+    distribution: dict[str, int] = {}
+    for question in questions:
+        level = question["level"]
+        distribution[level] = distribution.get(level, 0) + 1
+    (directory / "manifest.json").write_text(
+        json.dumps(
+            {
+                "version": "0.3.0",
+                "snapshot_cutoff": AGENTIC_COMPANY_SNAPSHOT_CUTOFF,
+                "task_count": len(questions),
+                "topic_count": len({question["topic_id"] for question in questions}),
+                "difficulty_distribution": distribution,
+                "excluded_schemas": ["ground_truth", "sim"],
+                "source_database": {
+                    "path": "data/company_for_analysis.duckdb",
+                    "bytes": AGENTIC_COMPANY_DATABASE_BYTES,
+                    "sha256": AGENTIC_COMPANY_DATABASE_SHA256,
+                },
+                "topics": [
+                    {
+                        "topic_id": topic_id,
+                        "topic": next(
+                            question["topic"]
+                            for question in questions
+                            if question["topic_id"] == topic_id
+                        ),
+                        "task_count": sum(
+                            question["topic_id"] == topic_id for question in questions
+                        ),
+                        "easy_count": sum(
+                            question["topic_id"] == topic_id and question["level"] == "easy"
+                            for question in questions
+                        ),
+                        "hard_count": sum(
+                            question["topic_id"] == topic_id and question["level"] == "hard"
+                            for question in questions
+                        ),
+                    }
+                    for topic_id in sorted({question["topic_id"] for question in questions})
+                ],
+            }
+        )
+    )
+    return questions_path, manual_path
+
+
+def _ids_hash(questions: list[dict]) -> str:
+    ids = "\n".join(str(question["task_id"]) for question in questions)
+    return hashlib.sha256(ids.encode()).hexdigest()
+
+
+class QuestionLoaderTests(unittest.TestCase):
+    def test_dabstep_splits_are_unchanged(self) -> None:
+        expected = {
+            "templates": (26, "e92b2dc5f55f9cdec2c3374c2de5b57904aa3f93832868ce4966f4c1073ced96"),
+            "test": (419, "8fa71c50ed2bdc89859366f22187e501e2bd08bbd132f95aa66125a891c2d280"),
+            "all": (445, "31c3e4836b98098c085069947cc957a738999538a85adb7d5f1d435cb0816d04"),
+        }
+        for split, (count, digest) in expected.items():
+            questions = _load_questions(split)
+            self.assertEqual(len(questions), count)
+            self.assertEqual(_ids_hash(questions), digest)
+
+    @unittest.skipUnless(CANONICAL_QUESTIONS.is_file(), "external benchmark checkout not present")
+    def test_agentic_company_loads_canonical_40_in_order(self) -> None:
+        questions = _load_questions(
+            "all",
+            benchmark=AGENTIC_COMPANY_BENCHMARK,
+            questions_path=CANONICAL_QUESTIONS,
+        )
+        self.assertEqual([question["task_id"] for question in questions], [
+            f"AC-{index:03d}" for index in range(1, 41)
+        ])
+        self.assertEqual(sum(question["level"] == "easy" for question in questions), 10)
+        self.assertEqual(sum(question["level"] == "hard" for question in questions), 30)
+        self.assertEqual(len({question["topic_id"] for question in questions}), 10)
+
+    def test_duplicate_external_ids_fail_with_line_number(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fixture = Path(tmpdir) / "questions.jsonl"
+            record = json.dumps(_fixture_question())
+            fixture.write_text(record + "\n" + record + "\n")
+            with self.assertRaisesRegex(ValueError, r":2: duplicate task_id"):
+                _load_questions(
+                    "all",
+                    benchmark=AGENTIC_COMPANY_BENCHMARK,
+                    questions_path=fixture,
+                )
+
+    def test_malformed_numeric_criteria_fails_before_evaluation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fixture = Path(tmpdir) / "questions.jsonl"
+            question = _fixture_question()
+            question["answer_criteria"]["decimals"] = "bad"
+            fixture.write_text(json.dumps(question) + "\n")
+            with self.assertRaisesRegex(ValueError, "decimals must be"):
+                _load_questions(
+                    "all",
+                    benchmark=AGENTIC_COMPANY_BENCHMARK,
+                    questions_path=fixture,
+                )
+
+    def test_manifest_pins_snapshot_and_per_topic_contract(self) -> None:
+        questions = _fixture_questions()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_benchmark_fixture(Path(tmpdir), questions)
+            manifest = json.loads((Path(tmpdir) / "manifest.json").read_text())
+            _validate_agentic_manifest(questions, manifest)
+            for path, value, message in (
+                (("snapshot_cutoff",), "2026-07-30", "snapshot_cutoff"),
+                (("source_database", "sha256"), "0" * 64, "database SHA"),
+                (("topics", 0, "task_count"), 2, "task_count"),
+            ):
+                with self.subTest(path=path):
+                    mutated = json.loads(json.dumps(manifest))
+                    target = mutated
+                    for key in path[:-1]:
+                        target = target[key]
+                    target[path[-1]] = value
+                    with self.assertRaisesRegex(ValueError, message):
+                        _validate_agentic_manifest(questions, mutated)
+
+
+class AgenticScoringTests(unittest.TestCase):
+    NUMBER: ClassVar[dict] = {"type": "number", "decimals": 0, "tolerance": 0}
+    PAIR: ClassVar[dict] = {
+        "type": "label:number",
+        "delimiter": ":",
+        "decimals": 2,
+        "tolerance": 0.01,
+    }
+
+    def test_wrong_sign_and_missing_component_fail(self) -> None:
+        self.assertFalse(answers_match("-13", "13", self.NUMBER))
+        self.assertFalse(
+            answers_match(
+                "Foldflat Camp Kitchen",
+                "Foldflat Camp Kitchen:2922657.73",
+                self.PAIR,
+            )
+        )
+
+    def test_tolerance_is_absolute_and_sign_sensitive(self) -> None:
+        self.assertTrue(answers_match("x:1.009", "x:1.00", self.PAIR))
+        self.assertFalse(answers_match("x:1.011", "x:1.00", self.PAIR))
+        self.assertFalse(answers_match("x:1.00", "x:-1.00", self.PAIR))
+
+    def test_string_normalization_ignores_punctuation(self) -> None:
+        self.assertTrue(
+            answers_match(
+                "organic search",
+                "organic_search",
+                {"type": "string"},
+            )
+        )
+
+    def test_ordered_list_reversal_fails(self) -> None:
+        criteria = {
+            "type": "list[string]",
+            "delimiter": ",",
+            "order_sensitive": True,
+        }
+        gold = "Cedarpoint Outfitters:406.67, ParcelPeak Marketplace:45.69"
+        reversed_answer = "ParcelPeak Marketplace:45.69, Cedarpoint Outfitters:406.67"
+        self.assertTrue(answers_match(gold, gold, criteria))
+        self.assertTrue(
+            answers_match(
+                "Cedarpoint Outfitters:406.666, ParcelPeak Marketplace:45.694",
+                gold,
+                criteria,
+            )
+        )
+        self.assertFalse(answers_match(reversed_answer, gold, criteria))
+
+    def test_compound_row_formatting(self) -> None:
+        triple = {
+            "type": "label:label:number",
+            "delimiter": ":",
+            "decimals": 2,
+            "tolerance": 0.01,
+        }
+        self.assertEqual(
+            format_answer([("2026-02", "cash_out_ap", -2952349.09)], triple),
+            "2026-02:cash_out_ap:-2952349.09",
+        )
+        ordered_list = {"type": "list[string]", "delimiter": ",", "order_sensitive": True}
+        self.assertEqual(
+            format_answer([("A", "1.00"), ("B", "2.00")], ordered_list),
+            "A:1.00, B:2.00",
+        )
+
+    def test_execution_error_is_never_correct(self) -> None:
+        result = score(
+            ExecutionError("Failure", "boom"),
+            "Not Applicable",
+            {"type": "string"},
+            predicted_sql=None,
+        )
+        self.assertFalse(result.is_correct)
+        self.assertEqual(result.correctness, Correctness.ERROR)
+
+    def test_fractional_count_does_not_round_into_correct_integer(self) -> None:
+        result = score(
+            [(13.49,)],
+            "13",
+            self.NUMBER,
+            predicted_sql="SELECT 13.49",
+        )
+        self.assertFalse(result.is_correct)
+        self.assertEqual(result.predicted_answer, "13.49")
+
+    def test_latched_rows_are_scored_even_if_hit_limit_was_reported(self) -> None:
+        result = score(
+            [(13,)],
+            "13",
+            self.NUMBER,
+            predicted_sql="SELECT 13",
+            hit_limit=True,
+        )
+        self.assertTrue(result.is_correct)
+
+    @unittest.skipUnless(CANONICAL_QUESTIONS.is_file(), "external benchmark checkout not present")
+    def test_every_canonical_gold_self_scores_with_realistic_rows(self) -> None:
+        questions = _load_questions(
+            "all",
+            benchmark=AGENTIC_COMPANY_BENCHMARK,
+            questions_path=CANONICAL_QUESTIONS,
+        )
+        for question in questions:
+            answer_type = question["answer_criteria"]["type"]
+            answer = question["answer"]
+            if answer_type == "number":
+                rows = [(float(answer),)]
+            elif answer_type == "string":
+                rows = [(answer,)]
+            elif answer_type == "label:number":
+                label, number = answer.rsplit(":", 1)
+                rows = [(label, float(number))]
+            elif answer_type == "label:label:number":
+                first, second, number = answer.split(":")
+                rows = [(first, second, float(number))]
+            else:
+                rows = [tuple(item.strip().rsplit(":", 1)) for item in answer.split(",")]
+            result = score(
+                rows,
+                answer,
+                question["answer_criteria"],
+                predicted_sql="SELECT answer",
+            )
+            self.assertTrue(result.is_correct, question["task_id"])
+
+
+class PromptAndGuideTests(unittest.TestCase):
+    class FakeManualSession:
+        def __init__(
+            self,
+            *,
+            body: str,
+            guides: list[dict] | None = None,
+            create_mode: str = "normal",
+            returned_body: str | None = None,
+        ) -> None:
+            self.body = body
+            self.guides = list(guides or [])
+            self.create_mode = create_mode
+            self.returned_body = body if returned_body is None else returned_body
+            self.calls: list[tuple[str, dict, bool]] = []
+
+        async def call_tool(self, name: str, args: dict, allow_write: bool = False):
+            self.calls.append((name, args, allow_write))
+            if name == "list_guides":
+                payload = {"success": True, "guides": list(self.guides)}
+                return SimpleNamespace(is_error=False, text=json.dumps(payload))
+            if name == "create_guide":
+                if self.create_mode != "empty_after_error":
+                    self.guides = [self._canonical_guide("created-uuid")]
+                if self.create_mode == "raise":
+                    raise ConnectionError("ambiguous transport failure")
+                if self.create_mode == "empty_after_error":
+                    return SimpleNamespace(is_error=True, text="permission denied")
+                payload = (
+                    {"success": True}
+                    if self.create_mode == "missing_uuid"
+                    else {"guide": {"id": "created-uuid"}}
+                )
+                return SimpleNamespace(is_error=False, text=json.dumps(payload))
+            if name in {"update_guide", "update_guide_metadata"}:
+                return SimpleNamespace(is_error=False, text=json.dumps({"success": True}))
+            if name == "get_guide":
+                text = (
+                    f"fixture\n\n{guides_load.AGENTIC_COMPANY_MANUAL_DESCRIPTION}\n\n"
+                    f"{self.returned_body.rstrip()}"
+                )
+                return SimpleNamespace(
+                    is_error=False,
+                    text=json.dumps({"success": True, "text": text}),
+                )
+            raise AssertionError(name)
+
+        @staticmethod
+        def _canonical_guide(uuid: str) -> dict:
+            return {
+                "uuid": uuid,
+                "topic": AGENTIC_COMPANY_GUIDE_TOPIC,
+                "title": "analyst-field-manual",
+                "access": "user",
+            }
+
+    class FakeManualContext:
+        def __init__(self, session) -> None:
+            self.session = session
+
+        async def __aenter__(self):
+            return self.session
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+    def test_agentic_prompt_is_isolated_and_uses_one_manual_topic(self) -> None:
+        skill = AGENTIC_COMPANY_SKILL_PATH.read_text()
+        prompt = build_agentic_company_system_prompt("agentic_company_snapshot", skill)
+        lowered = prompt.casefold()
+        self.assertIn(AGENTIC_COMPANY_GUIDE_TOPIC, prompt)
+        self.assertNotIn("payments database", lowered)
+        self.assertNotIn("dabstep/", lowered)
+        self.assertNotIn("aci", lowered)
+        self.assertNotIn("mcc", lowered)
+        tools = _make_tools(
+            RunState(mcp=SimpleNamespace(), database="agentic_company_snapshot"),
+            guide_topic=AGENTIC_COMPANY_GUIDE_TOPIC,
+        )
+        self.assertEqual([tool.name for tool in tools], [
+            "list_guides", "get_guide", "list_tables", "list_columns", "query", "submit_answer"
+        ])
+
+    def test_dabstep_default_prompt_still_uses_existing_template(self) -> None:
+        prompt = build_system_prompt("example", "skill")
+        self.assertIn("payments database", prompt)
+        self.assertIn("dabstep/fees", prompt)
+
+    def test_manual_dry_run_publishes_exactly_one_guide(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manual = Path(tmpdir) / "manual.md"
+            manual.write_text("# Fixture manual\n")
+            results = guides_load.publish_manual_sync(manual, dry_run=True)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["id"], "analyst-field-manual")
+        self.assertEqual(results[0]["topic"], AGENTIC_COMPANY_GUIDE_TOPIC)
+
+    def test_manual_prefix_and_access_cannot_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            directory = Path(tmpdir)
+            manual = directory / "manual.md"
+            manual.write_text("# Fixture manual\n")
+            with self.assertRaisesRegex(ValueError, "prefix is fixed"):
+                guides_load.publish_manual_sync(manual, prefix="other", dry_run=True)
+            with self.assertRaisesRegex(ValueError, "access is fixed"):
+                guides_load.publish_manual_sync(manual, access="organization", dry_run=True)
+
+    def test_manual_selector_is_principal_portable_and_fails_closed(self) -> None:
+        canonical = {
+            "success": True,
+            "guides": [{
+                "uuid": "principal-specific-uuid",
+                "topic": AGENTIC_COMPANY_GUIDE_TOPIC,
+                "title": "analyst-field-manual",
+                "access": "user",
+            }],
+        }
+        self.assertEqual(
+            guides_load.select_agentic_manual(canonical),
+            "principal-specific-uuid",
+        )
+        self.assertIsNone(
+            guides_load.select_agentic_manual({"success": True, "guides": []})
+        )
+        for mutation in (
+            {"title": "unrelated"},
+            {"access": "organization"},
+            {"topic": "other/manual"},
+        ):
+            payload = json.loads(json.dumps(canonical))
+            payload["guides"][0].update(mutation)
+            with self.assertRaisesRegex(RuntimeError, "canonical personal"):
+                guides_load.select_agentic_manual(payload)
+        duplicate = json.loads(json.dumps(canonical))
+        duplicate["guides"].append(dict(duplicate["guides"][0], uuid="second"))
+        with self.assertRaisesRegex(RuntimeError, "Remove duplicates"):
+            guides_load.select_agentic_manual(duplicate)
+
+    def test_failed_first_dabstep_create_does_not_write_empty_lock(self) -> None:
+        class FakeSession:
+            async def call_tool(self, name: str, args: dict, allow_write: bool = False):
+                return SimpleNamespace(is_error=True, text="transient failure")
+
+        class FakeContext:
+            async def __aenter__(self):
+                return FakeSession()
+
+            async def __aexit__(self, exc_type, exc, traceback):
+                return False
+
+        async def exercise(lock: Path) -> None:
+            item = guides_load.ContextItem(
+                id="fixture",
+                domain="manual",
+                summary="fixture",
+                body="fixture",
+            )
+            with patch.object(guides_load, "create_mcp_session", return_value=FakeContext()):
+                results = await guides_load._publish_items(
+                    [item],
+                    prefix="fixture",
+                    access="user",
+                    dry_run=False,
+                    lockfile_path=lock,
+                )
+            self.assertEqual(results[0]["action"], "failed")
+            self.assertFalse(lock.exists())
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            asyncio.run(exercise(Path(tmpdir) / "guides.lock.json"))
+
+    def test_manual_live_create_and_update_are_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manual = Path(tmpdir) / "manual.md"
+            manual.write_text("# Fixture manual\n")
+            for existing, expected_action in ((False, "created"), (True, "updated")):
+                with self.subTest(existing=existing):
+                    guides = (
+                        [self.FakeManualSession._canonical_guide("existing-uuid")]
+                        if existing
+                        else []
+                    )
+                    session = self.FakeManualSession(body=manual.read_text(), guides=guides)
+                    context = self.FakeManualContext(session)
+                    with patch.object(
+                        guides_load,
+                        "create_mcp_session",
+                        return_value=context,
+                    ):
+                        results = guides_load.publish_manual_sync(manual)
+                    names = [name for name, _, _ in session.calls]
+                    self.assertEqual(results[0]["action"], expected_action)
+                    self.assertEqual(names.count("create_guide"), 0 if existing else 1)
+                    self.assertEqual(names.count("update_guide"), 1 if existing else 0)
+                    self.assertEqual(
+                        names.count("update_guide_metadata"), 1 if existing else 0
+                    )
+                    self.assertEqual(names.count("list_guides"), 2)
+                    self.assertEqual(names.count("get_guide"), 1)
+
+    def test_manual_ambiguous_create_is_adopted_without_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manual = Path(tmpdir) / "manual.md"
+            manual.write_text("# Fixture manual\n")
+            for create_mode in ("missing_uuid", "raise"):
+                with self.subTest(create_mode=create_mode):
+                    session = self.FakeManualSession(
+                        body=manual.read_text(),
+                        create_mode=create_mode,
+                    )
+                    with patch.object(
+                        guides_load,
+                        "create_mcp_session",
+                        return_value=self.FakeManualContext(session),
+                    ):
+                        results = guides_load.publish_manual_sync(manual)
+                    names = [name for name, _, _ in session.calls]
+                    self.assertEqual(results[0]["action"], "created")
+                    self.assertEqual(names.count("create_guide"), 1)
+                    self.assertEqual(names.count("list_guides"), 3)
+
+    def test_manual_publish_fails_closed_without_a_second_create(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manual = Path(tmpdir) / "manual.md"
+            manual.write_text("# Fixture manual\n")
+            cases = (
+                self.FakeManualSession(
+                    body=manual.read_text(),
+                    create_mode="empty_after_error",
+                ),
+                self.FakeManualSession(
+                    body=manual.read_text(),
+                    guides=[
+                        self.FakeManualSession._canonical_guide("first"),
+                        self.FakeManualSession._canonical_guide("second"),
+                    ],
+                ),
+                self.FakeManualSession(
+                    body=manual.read_text(),
+                    guides=[self.FakeManualSession._canonical_guide("existing")],
+                    returned_body="wrong body",
+                ),
+            )
+            for session in cases:
+                with self.subTest(mode=session.create_mode, guides=len(session.guides)):
+                    with (
+                        patch.object(
+                            guides_load,
+                            "create_mcp_session",
+                            return_value=self.FakeManualContext(session),
+                        ),
+                        self.assertRaises(RuntimeError),
+                    ):
+                        guides_load.publish_manual_sync(manual)
+                    names = [name for name, _, _ in session.calls]
+                    self.assertLessEqual(names.count("create_guide"), 1)
+                    if len(session.guides) > 1:
+                        self.assertFalse(
+                            {"create_guide", "update_guide", "update_guide_metadata"}
+                            .intersection(names)
+                        )
+
+
+class SubmissionTests(unittest.TestCase):
+    def test_hit_limit_fix_is_scoped_to_agentic_company(self) -> None:
+        self.assertTrue(
+            _resolve_hit_limit(
+                prompt_profile="dabstep",
+                submitted=True,
+                hit_limit=True,
+            )
+        )
+        self.assertFalse(
+            _resolve_hit_limit(
+                prompt_profile=AGENTIC_COMPANY_BENCHMARK,
+                submitted=True,
+                hit_limit=True,
+            )
+        )
+
+    def test_parallel_submissions_latch_first_success_exactly_once(self) -> None:
+        class BlockingMCP:
+            def __init__(self) -> None:
+                self.started = asyncio.Event()
+                self.release = asyncio.Event()
+                self.calls: list[str] = []
+
+            async def call_tool(self, name: str, args: dict):
+                self.calls.append(args["sql"])
+                self.started.set()
+                await self.release.wait()
+                return SimpleNamespace(is_error=False, rows=[[1]], text="ok")
+
+        async def exercise() -> None:
+            mcp = BlockingMCP()
+            state = RunState(mcp=mcp, database="fixture")
+            submit = _make_tools(state)[-1]
+            invoke = submit.on_invoke_tool._invoke_tool_impl
+            context = SimpleNamespace(tool_name="submit_answer")
+            first = asyncio.create_task(
+                invoke(context, json.dumps({"sql": "SELECT 1"}))
+            )
+            await mcp.started.wait()
+            second = asyncio.create_task(
+                invoke(context, json.dumps({"sql": "SELECT 2"}))
+            )
+            await asyncio.sleep(0)
+            self.assertEqual(mcp.calls, ["SELECT 1"])
+            mcp.release.set()
+            first_result, second_result = await asyncio.gather(first, second)
+            self.assertIn("Submitted", first_result)
+            self.assertEqual(second_result, "ERROR: answer already submitted")
+            self.assertEqual(mcp.calls, ["SELECT 1"])
+            self.assertEqual(state.final_sql, "SELECT 1")
+            self.assertEqual(state.final_rows, [(1,)])
+
+        asyncio.run(exercise())
+
+
+class CLIProfileTests(unittest.TestCase):
+    def test_agentic_provenance_matches_installed_controllog_schema(self) -> None:
+        artifacts = {
+            "version": "0.3.0",
+            "questions_sha256": "q-sha",
+            "manual_sha256": "m-sha",
+            "database_sha256": "db-sha",
+        }
+        provenance = _build_run_provenance(
+            benchmark=AGENTIC_COMPANY_BENCHMARK,
+            split="all",
+            database="agentic_company_snapshot",
+            model="fixture-model",
+            reasoning="low",
+            max_turns=40,
+            concurrency=1,
+            out=Path("fixture.jsonl"),
+            question_count=40,
+            artifacts=artifacts,
+        )
+        inspect.signature(controllog.run_metadata).bind(run_id="fixture-run", **provenance)
+        self.assertNotIn("benchmark_artifacts", provenance)
+        self.assertEqual(
+            provenance["resolved_config"]["benchmark_artifacts"],
+            artifacts,
+        )
+
+    def test_agentic_task_selection_reaches_shared_loop(self) -> None:
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            fixture_dir = repo_root / "benchmarks" / "dabstep_agentic_company"
+            _write_benchmark_fixture(
+                fixture_dir,
+                _fixture_questions(),
+            )
+            out = fixture_dir / "result.jsonl"
+            loop = AsyncMock()
+            with (
+                patch("src.run._evaluate_loop", loop),
+                patch(
+                    "src.run.AGENTIC_COMPANY_QUESTIONS_SHA256",
+                    hashlib.sha256((fixture_dir / "questions.jsonl").read_bytes()).hexdigest(),
+                ),
+                patch(
+                    "src.run.AGENTIC_COMPANY_MANUAL_SHA256",
+                    hashlib.sha256((fixture_dir / "manual.md").read_bytes()).hexdigest(),
+                ),
+            ):
+                result = runner.invoke(
+                    cli,
+                    [
+                        "evaluate",
+                        "--benchmark",
+                        AGENTIC_COMPANY_BENCHMARK,
+                        "--task-id",
+                        "ac-030",
+                        "--out",
+                        str(out),
+                    ],
+                    env={"AGENTIC_COMPANY_REPO": str(repo_root)},
+                )
+        self.assertEqual(result.exit_code, 0, result.output)
+        kwargs = loop.await_args.kwargs
+        self.assertEqual(kwargs["benchmark"], AGENTIC_COMPANY_BENCHMARK)
+        self.assertEqual(kwargs["split"], "all")
+        self.assertEqual([question["task_id"] for question in kwargs["questions"]], ["AC-030"])
+        self.assertEqual(kwargs["guide_topic"], AGENTIC_COMPANY_GUIDE_TOPIC)
+
+    def test_invalid_limit_and_duplicate_ids_fail_before_loop(self) -> None:
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            fixture_dir = repo_root / "benchmarks" / "dabstep_agentic_company"
+            _write_benchmark_fixture(
+                fixture_dir,
+                _fixture_questions(),
+            )
+            common = [
+                "evaluate",
+                "--benchmark",
+                AGENTIC_COMPANY_BENCHMARK,
+            ]
+            env = {"AGENTIC_COMPANY_REPO": str(repo_root)}
+            with (
+                patch(
+                    "src.run.AGENTIC_COMPANY_QUESTIONS_SHA256",
+                    hashlib.sha256((fixture_dir / "questions.jsonl").read_bytes()).hexdigest(),
+                ),
+                patch(
+                    "src.run.AGENTIC_COMPANY_MANUAL_SHA256",
+                    hashlib.sha256((fixture_dir / "manual.md").read_bytes()).hexdigest(),
+                ),
+            ):
+                invalid_limit = runner.invoke(cli, [*common, "--limit", "0"], env=env)
+                duplicate_ids = runner.invoke(
+                    cli,
+                    [*common, "--task-ids", "AC-001,AC-001"],
+                    env=env,
+                )
+        self.assertNotEqual(invalid_limit.exit_code, 0)
+        self.assertIn("range x>=1", invalid_limit.output)
+        self.assertNotEqual(duplicate_ids.exit_code, 0)
+        self.assertIn("must not contain duplicate", duplicate_ids.output)
+
+    def test_file_overrides_do_not_relocate_other_benchmark_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir) / "repo"
+            canonical = repo_root / "benchmarks" / "dabstep_agentic_company"
+            canonical.mkdir(parents=True)
+            questions_override = Path(tmpdir) / "questions.jsonl"
+            manual_override = Path(tmpdir) / "manual.md"
+            with patch.dict("os.environ", {"AGENTIC_COMPANY_REPO": str(repo_root)}):
+                questions, manual, manifest = _resolve_agentic_paths(manual=manual_override)
+                self.assertEqual(questions, canonical / "questions.jsonl")
+                self.assertEqual(manual, manual_override)
+                self.assertEqual(manifest, canonical / "manifest.json")
+                questions, manual, manifest = _resolve_agentic_paths(
+                    questions_jsonl=questions_override
+                )
+                self.assertEqual(questions, questions_override)
+                self.assertEqual(manual, canonical / "manual.md")
+                self.assertEqual(manifest, canonical / "manifest.json")
+
+    def test_manifest_rejects_truncated_question_set_before_loop(self) -> None:
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            fixture_dir = repo_root / "benchmarks" / "dabstep_agentic_company"
+            questions_path, _ = _write_benchmark_fixture(
+                fixture_dir,
+                _fixture_questions(),
+            )
+            lines = questions_path.read_text().splitlines()
+            questions_path.write_text("\n".join(lines[:-1]) + "\n")
+            loop = AsyncMock()
+            with patch("src.run._evaluate_loop", loop):
+                result = runner.invoke(
+                    cli,
+                    ["evaluate", "--benchmark", AGENTIC_COMPANY_BENCHMARK],
+                    env={"AGENTIC_COMPANY_REPO": str(repo_root)},
+                )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("expected 40, loaded 39", result.output)
+        loop.assert_not_awaited()
+
+    def test_default_cli_profile_remains_dabstep_templates(self) -> None:
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            loop = AsyncMock()
+            with patch("src.run._evaluate_loop", loop):
+                result = runner.invoke(
+                    cli,
+                    ["evaluate", "--out", str(Path(tmpdir) / "result.jsonl")],
+                )
+        self.assertEqual(result.exit_code, 0, result.output)
+        kwargs = loop.await_args.kwargs
+        self.assertEqual(kwargs["benchmark"], "dabstep")
+        self.assertEqual(kwargs["split"], "templates")
+        self.assertEqual(len(kwargs["questions"]), 26)
+
+
+class MCPBoundaryTests(unittest.TestCase):
+    def test_list_columns_splits_qualified_names_and_reports_column_rows(self) -> None:
+        class FakeSession:
+            def __init__(self) -> None:
+                self.calls: list[tuple[str, dict]] = []
+
+            async def call_tool(self, name: str, args: dict):
+                self.calls.append((name, args))
+                if name == "list_tables":
+                    payload = {
+                        "success": True,
+                        "tables": [{"schema": "catalog", "name": "products"}],
+                        "views": [],
+                    }
+                elif name == "list_columns":
+                    payload = {
+                        "success": True,
+                        "database": args["database"],
+                        "schema": args.get("schema", "main"),
+                        "table": args["table"],
+                        "columns": [
+                            {"name": "product_id", "type": "VARCHAR"},
+                            {"name": "name", "type": "VARCHAR"},
+                        ],
+                        "columnCount": 2,
+                    }
+                else:
+                    raise AssertionError(name)
+                return SimpleNamespace(
+                    isError=False,
+                    structuredContent=payload,
+                    content=[],
+                )
+
+        async def exercise() -> None:
+            raw = FakeSession()
+            session = MCPSession(raw, database="agentic_company_snapshot")
+            qualified = await session.call_tool(
+                "list_columns",
+                {"table": "catalog.products"},
+            )
+            self.assertFalse(qualified.is_error)
+            self.assertEqual(len(qualified.rows or []), 2)
+            self.assertEqual(
+                raw.calls[-1],
+                (
+                    "list_columns",
+                    {
+                        "table": "products",
+                        "database": "agentic_company_snapshot",
+                        "schema": "catalog",
+                    },
+                ),
+            )
+
+            unqualified = await session.call_tool("list_columns", {"table": "products"})
+            self.assertFalse(unqualified.is_error)
+            self.assertEqual(len(unqualified.rows or []), 2)
+            self.assertEqual(raw.calls[-2][0], "list_tables")
+            self.assertEqual(raw.calls[-1][1]["schema"], "catalog")
+
+            fully_qualified = await session.call_tool(
+                "list_columns",
+                {"table": "agentic_company_snapshot.catalog.products"},
+            )
+            self.assertFalse(fully_qualified.is_error)
+            self.assertEqual(raw.calls[-1][1]["table"], "products")
+
+        asyncio.run(exercise())
+
+    def test_share_attach_is_read_only_and_alias_verified(self) -> None:
+        class FakeAttachSession:
+            def __init__(self) -> None:
+                self.calls: list[tuple[str, dict]] = []
+
+            async def call_tool(self, name: str, args: dict):
+                self.calls.append((name, args))
+                if len(self.calls) == 1:
+                    payload = {"success": False, "error": "alias already attached"}
+                    return SimpleNamespace(
+                        isError=True,
+                        structuredContent=payload,
+                        content=[],
+                    )
+                payload = {
+                    "success": True,
+                    "rows": [[
+                        "agentic_company_snapshot",
+                        (
+                            "_share/agentic_company_snapshot_share/"
+                            "6b172abb-d377-4f0f-9a8a-d0ac199e074d"
+                        ),
+                        "motherduck",
+                        True,
+                    ]],
+                }
+                return SimpleNamespace(
+                    isError=False,
+                    structuredContent=payload,
+                    content=[],
+                )
+
+        async def exercise() -> None:
+            session = FakeAttachSession()
+            await _attach_trusted_share(
+                session,
+                share_url=AGENTIC_COMPANY_SHARE,
+                alias="agentic_company_snapshot",
+                bootstrap_database="sample_data",
+            )
+            self.assertIn("(READ_ONLY)", session.calls[0][1]["sql"])
+            self.assertIn("duckdb_databases()", session.calls[1][1]["sql"])
+
+        asyncio.run(exercise())
+
+    def test_restricted_schema_is_hidden_and_rejected(self) -> None:
+        payload = {
+            "success": True,
+            "tableCount": 2,
+            "viewCount": 0,
+            "count": 2,
+            "totalCount": 2,
+            "tables": [
+                {"schema": "catalog", "name": "skus"},
+                {"schema": "sim", "name": "private"},
+            ],
+        }
+
+        class FakeSession:
+            async def call_tool(self, name: str, args: dict):
+                return SimpleNamespace(
+                    isError=False,
+                    structuredContent=payload,
+                    content=[],
+                )
+
+        async def exercise() -> None:
+            session = MCPSession(
+                FakeSession(),
+                database="agentic_company_snapshot",
+                excluded_schemas=("ground_truth", "sim"),
+            )
+            listing = await session.call_tool("list_tables", {})
+            parsed = json.loads(listing.text)
+            self.assertEqual(parsed["tableCount"], 1)
+            self.assertEqual(parsed["count"], 1)
+            self.assertEqual(parsed["totalCount"], 1)
+            self.assertEqual(parsed["tables"][0]["schema"], "catalog")
+            blocked = await session.call_tool("query", {"sql": "SELECT * FROM sim.private"})
+            self.assertTrue(blocked.is_error)
+            self.assertIn("outside this benchmark", blocked.text)
+            dynamic = await session.call_tool(
+                "query",
+                {"sql": "SELECT * FROM query_table('s' || 'im.private')"},
+            )
+            self.assertTrue(dynamic.is_error)
+            metadata = await session.call_tool(
+                "query",
+                {"sql": "SELECT * FROM duckdb_tables()"},
+            )
+            self.assertTrue(metadata.is_error)
+            for sql in (
+                "SELECT * FROM pg_catalog.pg_tables",
+                "SELECT * FROM \"query_table\"('s' || 'im.private')",
+                "SELECT * FROM \"query\"('FROM ' || 's' || 'im.private')",
+                "SHOW ALL TABLES",
+            ):
+                quoted_bypass = await session.call_tool("query", {"sql": sql})
+                self.assertTrue(quoted_bypass.is_error, sql)
+            for sql in (
+                "SELECT '--' AS marker, * FROM sim.private",
+                "SELECT '/*' AS marker FROM ground_truth.answers WHERE '*/'='*/'",
+                "SELECT $$--$$ AS marker, * FROM sim.private",
+                "SELECT $tag$/*$tag$ AS marker FROM ground_truth.answers",
+                r"SELECT E'foo\'--bar' AS marker, * FROM sim.private",
+            ):
+                hidden_after_literal = await session.call_tool("query", {"sql": sql})
+                self.assertTrue(hidden_after_literal.is_error, sql)
+            for sql in (
+                "SELECT 'sim' AS label",
+                "SELECT $$sim.private$$ AS label",
+                "SELECT 1 AS sim",
+                "SELECT 1 -- do not use sim",
+            ):
+                allowed = await session.call_tool("query", {"sql": sql})
+                self.assertFalse(allowed.is_error, sql)
+
+        asyncio.run(exercise())
+
+    def test_comment_markers_in_strings_cannot_hide_mutation(self) -> None:
+        violation = _read_only_violation("SELECT '--'; DROP TABLE public_data")
+        self.assertIsNotNone(violation)
+        self.assertIn("DROP", violation or "")
+        dollar_violation = _read_only_violation("SELECT $$--$$; DROP TABLE public_data")
+        self.assertIsNotNone(dollar_violation)
+        self.assertIn("DROP", dollar_violation or "")
+
+    def test_explain_analyze_cannot_execute_a_mutation(self) -> None:
+        for sql in (
+            "EXPLAIN ANALYZE DELETE FROM public_data",
+            "EXPLAIN (ANALYZE) DELETE FROM public_data",
+            "EXPLAIN (ANALYZE TRUE) DELETE FROM public_data",
+            "EXPLAIN ANALYSE DELETE FROM public_data",
+            "EXPLAIN ANALYZE INSERT INTO public_data VALUES (1)",
+            "EXPLAIN ANALYZE CREATE TABLE leaked AS SELECT 1",
+            "SELECT 1; EXPLAIN ANALYZE DROP TABLE public_data",
+        ):
+            violation = _read_only_violation(sql)
+            self.assertIsNotNone(violation, sql)
+            self.assertIn("EXPLAIN ANALYZE", violation or "")
+        self.assertIsNone(_read_only_violation("EXPLAIN SELECT 1"))
+
+    def test_single_guide_topic_and_discovered_uuid_are_enforced(self) -> None:
+        class FakeGuideSession:
+            async def call_tool(self, name: str, args: dict):
+                if name == "list_guides":
+                    payload = {"success": True, "guides": [{"uuid": "manual-uuid"}]}
+                else:
+                    payload = {"success": True, "text": "manual"}
+                return SimpleNamespace(
+                    isError=False,
+                    structuredContent=payload,
+                    content=[],
+                )
+
+        async def exercise() -> None:
+            session = MCPSession(
+                FakeGuideSession(),
+                database="agentic_company_snapshot",
+                guide_topic=AGENTIC_COMPANY_GUIDE_TOPIC,
+            )
+            wrong_topic = await session.call_tool("list_guides", {"topic": "dabstep/fees"})
+            self.assertTrue(wrong_topic.is_error)
+            undiscovered = await session.call_tool("get_guide", {"uuid": "manual-uuid"})
+            self.assertTrue(undiscovered.is_error)
+            listed = await session.call_tool(
+                "list_guides",
+                {"topic": AGENTIC_COMPANY_GUIDE_TOPIC},
+            )
+            self.assertFalse(listed.is_error)
+            guide = await session.call_tool("get_guide", {"uuid": "manual-uuid"})
+            self.assertFalse(guide.is_error)
+
+        asyncio.run(exercise())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an **Agentic Company** benchmark profile (40-question DABstep set) to the agentic-sql-context-mcp harness, alongside the default DABstep profile. The existing evaluate loop is reused unchanged — concurrency, retries, OpenRouter routing, tool traces, controllog events, JSONL results, and summaries.

### What's new

- **Canonical source, not copies**: reads `questions.jsonl` + `manual.md` from the adjacent `the-agentic-company` repo (default `../../../the-agentic-company`, override via `AGENTIC_COMPANY_REPO`). The v0.3.0 manifest contract and exact question/manual hashes are validated before any model spend.
- **Single personal guide**: only `manual.md` is published as model context, at `agentic-company/manual` with `access=user`. The fixed topic acts as the registry so each MotherDuck principal creates/updates exactly one manual — no principal-specific UUIDs committed. Architecture docs and private semantic contracts are never published.
- **Trusted share attachment**: the profile attaches the configured read-only share as `agentic_company_snapshot` at the start of each MCP session.
- **Benchmark-integrity defenses**: the private `ground_truth` and `sim` schemas are hidden from table discovery, and explicit schema references, metadata enumeration, and dynamic table lookup against them are rejected. (The share still physically contains them; a warehouse-enforced boundary requires publishing a sanitized share.)
- **Strict scorer** (`src/agentic_company_score.py`): driven by each task's explicit `answer_criteria`, deliberately separate from the permissive DABstep scorer whose compatibility rules (sign-insensitive deltas, order-insensitive lists) conflict with the Agentic Company contract.
- **Multi-schema skill prompt** (`skill/AGENTIC_COMPANY.md`) and README docs.

### Usage

```bash
uv run asm guides-load --benchmark agentic-company --dry-run
uv run asm guides-load --benchmark agentic-company
uv run asm evaluate --benchmark agentic-company --task-id AC-002 --watch
uv run asm evaluate --benchmark agentic-company --split all
```

DABstep remains the default profile with its existing scorer and split behavior.

## Test plan

- [x] `uv run --with pytest pytest tests/ -q` — 37 passed, 10 subtests passed
- [ ] Codex review
- [ ] `guides-load --dry-run` + a single-task evaluate run against the live share

🤖 Generated with [Claude Code](https://claude.com/claude-code)