### PR TITLE
quackbot-modal: await run_turn.spawn.aio() in the async events handler

### DIFF
--- a/projects/quackbot-modal/modal_app.py
+++ b/projects/quackbot-modal/modal_app.py
@@ -510,7 +510,11 @@ def web():
             return PlainTextResponse("ok (not a turn)")
 
         try:
-            run_turn.spawn(body)
+            # `.aio`: this handler is async, and the blocking `spawn` would
+            # otherwise stall the event loop on the one container that owes
+            # Slack a 3s ack for every event in flight (Modal warns about
+            # exactly this at runtime — AsyncUsageWarning).
+            await run_turn.spawn.aio(body)
         except Exception as err:
             # The spawn is the entire handoff. Acking a delivery whose spawn
             # failed throws the message away, so answer 500 instead and let


### PR DESCRIPTION
## What

One-line fix for the runtime warning Modal emits on every spawned turn:

```
/root/modal_app.py:513: AsyncUsageWarning: A blocking Modal interface is being used in an async context.
```

The `/slack/events` handler is `async`, but handed the event off with the blocking `run_turn.spawn(body)`. That call blocks the event loop on the single always-warm edge container (`min_containers=1`) that owes Slack a 3-second ack for every event in flight — the same reason the interactive handler already routes its psycopg work through `run_in_threadpool`. Switched to Modal's async interface, `await run_turn.spawn.aio(body)`, which is Modal's own suggested rewrite in the warning.

## Testing

- `test_modal_app.py` passes (signature verifier + spawn-filter suite).
- Behavior under the existing `try/except` is unchanged: a failed spawn still answers 500 so Slack redelivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)